### PR TITLE
Add x--directed classes to input elements

### DIFF
--- a/packages/multiple-line/component/src/MultipleLineEditor.tsx
+++ b/packages/multiple-line/component/src/MultipleLineEditor.tsx
@@ -18,6 +18,7 @@ export function MultipleLineEditor(props: MultipleLineEditorProps) {
       {({ errors, disabled, value, setValue }) => (
         <div data-test-id="multiple-line-editor">
           <Textarea
+            className="x--directed"
             aria-label={field.id}
             rows={3}
             required={field.required}

--- a/packages/single-line/component/src/SingleLineEditor.tsx
+++ b/packages/single-line/component/src/SingleLineEditor.tsx
@@ -28,6 +28,7 @@ export function SingleLineEditor(props: SingleLineEditorProps) {
       {({ value, errors, disabled, setValue }) => (
         <div data-test-id="single-line-editor">
           <TextInput
+            className="x--directed"
             aria-label={field.id}
             required={field.required}
             error={errors.length > 0}


### PR DESCRIPTION
To achieve rtl support on the web-app we need the `x--directed` class on the input elements that should support rtl.