### PR TITLE
fix: correct imports of lodash/noop

### DIFF
--- a/packages/date/src/DatepickerInput.tsx
+++ b/packages/date/src/DatepickerInput.tsx
@@ -1,5 +1,5 @@
-import noop from 'lodash-es/noop';
 import React, { Component, FocusEventHandler, FocusEvent } from 'react';
+import noop from 'lodash/noop';
 // eslint-disable-next-line no-restricted-imports
 import moment from 'moment';
 import { TextInput } from '@contentful/forma-36-react-components';

--- a/packages/markdown/src/components/MarkdownToolbar.tsx
+++ b/packages/markdown/src/components/MarkdownToolbar.tsx
@@ -1,4 +1,4 @@
-import noop from 'lodash-es/noop';
+import noop from 'lodash/noop';
 import React from 'react';
 import { css, cx } from 'emotion';
 import { Button, Tooltip, Icon } from '@contentful/forma-36-react-components';


### PR DESCRIPTION
Using `lodash-es` imports is causing problems with Web app webpack bundle