### PR TITLE
fix: 🐛 Fix slug max length 74 chars to be 75 chars

### DIFF
--- a/packages/slug/src/SlugEditor.test.tsx
+++ b/packages/slug/src/SlugEditor.test.tsx
@@ -445,8 +445,24 @@ describe('SlugEditor', () => {
     await sdk.entry.fields['title-id'].setValue('a'.repeat(80));
     await wait();
 
-    const expectedSlug = 'a'.repeat(74);
+    const expectedSlug = 'a'.repeat(75);
     expect(field.setValue).toHaveBeenLastCalledWith(expectedSlug);
-    expect(expectedSlug).toHaveLength(74);
+  });
+
+  it('slug suggestion does not contain cut-off words', async () => {
+    const { field, sdk } = createMocks({
+      field: '',
+      titleField: ''
+    });
+
+    render(<SlugEditor field={field} baseSdk={sdk as any} isInitiallyDisabled={false} />);
+
+    await wait();
+
+    await sdk.entry.fields['title-id'].setValue(`one two three ${'a'.repeat(80)}`);
+    await wait();
+
+    const expectedSlug = 'one-two-three';
+    expect(field.setValue).toHaveBeenLastCalledWith(expectedSlug);
   });
 });

--- a/packages/slug/src/services/slugify.ts
+++ b/packages/slug/src/services/slugify.ts
@@ -57,7 +57,7 @@ export function slugify(text: string, locale = 'en') {
   return getSlug(text, {
     separator: '-',
     lang: supportedLanguage(locale) || 'en',
-    truncate: CF_GENERATED_SLUG_MAX_LENGTH,
+    truncate: CF_GENERATED_SLUG_MAX_LENGTH + 1,
     custom: {
       "'": '',
       '`': '',


### PR DESCRIPTION
This bug has been in the app for a while but documentation states that the max auto generated slug is 75 characters.
Also adds another test case to verify we don't cut off slug within a word.