### PR TITLE
fix(markdown): make behaviour consistent with rich text

### DIFF
--- a/cypress/integration/MarkdownEditorInsertLink.spec.ts
+++ b/cypress/integration/MarkdownEditorInsertLink.spec.ts
@@ -90,10 +90,6 @@ describe('Markdown Editor / Insert Link Dialog', () => {
 
     selectors.getInsertDialogButton().click();
 
-    // clear value
-    selectors.inputs.getTargetUrlInput().clear();
-    selectors.getInvalidMessage().should('be.visible');
-
     // type correct value
 
     const correctValues = ['https://contentful.com', 'http://google.com', 'ftp://somefile'];
@@ -139,7 +135,7 @@ describe('Markdown Editor / Insert Link Dialog', () => {
       selectors.inputs
         .getTargetUrlInput()
         .should('be.visible')
-        .should('have.value', 'https://')
+        .should('have.value', '')
         .should('have.focus');
       selectors.inputs
         .getLinkTitle()
@@ -208,7 +204,7 @@ describe('Markdown Editor / Insert Link Dialog', () => {
       selectors.inputs
         .getTargetUrlInput()
         .should('be.visible')
-        .should('have.value', 'https://')
+        .should('have.value', '')
         .should('have.focus');
       selectors.inputs
         .getLinkTitle()

--- a/packages/markdown/src/dialogs/InsertLinkModalDialog.tsx
+++ b/packages/markdown/src/dialogs/InsertLinkModalDialog.tsx
@@ -26,7 +26,7 @@ type InsertLinkModalProps = {
 export const InsertLinkModal = ({ selectedText, onClose }: InsertLinkModalProps) => {
   const mainInputRef = useRef<HTMLInputElement>(null);
   const [text, setText] = useState(selectedText || '');
-  const [url, setUrl] = useState('https://');
+  const [url, setUrl] = useState('');
   const [touched, setTouched] = useState(false);
   const [title, setTitle] = useState('');
   const onInsert = (values: InsertLinkModalPositiveResult) => onClose(values);
@@ -67,7 +67,7 @@ export const InsertLinkModal = ({ selectedText, onClose }: InsertLinkModalProps)
           }}
           validationMessage={touched && !urlIsValid ? 'Invalid URL' : ''}
           textInputProps={{
-            placeholder: 'https://example.com',
+            placeholder: 'https://',
             maxLength: 2100,
             testId: 'target-url-field',
             inputRef: mainInputRef


### PR DESCRIPTION
Make insert link dialog behavior consistent with insert link in rich text editor. 
Based on a customer feedback:

> A lot of time is wasted when inserting links to documents because the "https://" is pre-filled in the Target URL field when inserting links (Markdown field type). The insert link box pre-fills the URL field with `https://` and when you click inside of the box to overwrite it, does not automatically highlight the `https://` allowing you to simply copy/paste. Every time a link is added, the `https://` must be manually highlighted and deleted before pasting a URL. This isn't critical but is a huge waste of time when a URL is almost never copied without the prefix. It's a tedious bottleneck that could become a larger time sink as we ramp up content production. It's odd also because the Markdown editor and the Rich Text editor handle this same functionality differently - shouldn't they be consistent?

Brought by @brampling 