### PR TITLE
refactor: 💡 Use native sticky positioning

### DIFF
--- a/packages/rich-text/package.json
+++ b/packages/rich-text/package.json
@@ -40,7 +40,6 @@
     "lodash": "^4.17.15",
     "lodash-es": "^4.17.15",
     "prop-types": "^15.7.2",
-    "react-sticky-el": "^1.0.20",
     "slate": "0.44.10",
     "slate-html-serializer": "0.7.34",
     "slate-plain-serializer": "0.6.34",

--- a/packages/rich-text/src/RichTextEditor.mdx
+++ b/packages/rich-text/src/RichTextEditor.mdx
@@ -14,7 +14,7 @@ import { css } from 'emotion';
 
 ## In Action
 
-<Playground className="sticky-parent">
+<Playground>
   {() => {
     const rtPreviewStyle = css({
       backgroundColor: 'whitesmoke',

--- a/packages/rich-text/src/Toolbar/StickyToolbarWrapper.js
+++ b/packages/rich-text/src/Toolbar/StickyToolbarWrapper.js
@@ -1,43 +1,23 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import Sticky from 'react-sticky-el';
-import { SUPPORTS_STICKY_TOOLBAR } from '../helpers/browserSupport';
 import { css } from 'emotion';
 
 const styles = {
-  stickyWrapper: css({
-    transform: 'none !important',
-    webkitTransform: 'none !important'
-  }),
-  nativeStickyEnabled: css({
-    position: [
-      '-webkit-sticky',
-      'sticky'
-    ],
-    top: 0,
-    zIndex: 2
-  })
+  nativeSticky: css`
+    position: -webkit-sticky;
+    position: sticky;
+    top: -1px;
+    z-index: 2;
+  `
 };
 
-const StickyToolbarWrapper = ({ children, isDisabled }) =>
-  SUPPORTS_STICKY_TOOLBAR ? (
-    <Sticky
-      className={styles.stickyWrapper}
-      boundaryElement=".rich-text"
-      scrollElement=".sticky-parent"
-      stickyStyle={{ zIndex: 2 }}
-      disabled={isDisabled}>
-      {children}
-    </Sticky>
-  ) : (
-    <div className={isDisabled ? '' : styles.nativeStickyEnabled}>
-      {children}
-    </div>
-  );
+const StickyToolbarWrapper = ({ isDisabled, children }) => (
+  <div className={!isDisabled && styles.nativeSticky}>{children}</div>
+);
 
 StickyToolbarWrapper.propTypes = {
-  isDisabled: PropTypes.bool.isRequired,
-  children: PropTypes.node.isRequired
+  isDisabled: PropTypes.bool,
+  children: PropTypes.node
 };
 
 export default StickyToolbarWrapper;

--- a/packages/rich-text/src/helpers/browserSupport.js
+++ b/packages/rich-text/src/helpers/browserSupport.js
@@ -1,8 +1,8 @@
 import { detect as detectBrowser } from 'detect-browser';
 
 const browser = detectBrowser();
-const isIE = !!browser && browser.name === 'ie';
 const isEdge = !!browser && browser.name === 'ie';
 
-export const SUPPORTS_STICKY_TOOLBAR = !isIE;
-export const SUPPORTS_NATIVE_SLATE_HYPERLINKS = !isIE && !isEdge;
+// TODO: Test whether this is still relevant with latest Edge or at least do
+//  so after upgrading Slate.js to see if still relevant at all.
+export const SUPPORTS_NATIVE_SLATE_HYPERLINKS = !isEdge;

--- a/yarn.lock
+++ b/yarn.lock
@@ -14971,7 +14971,7 @@ prop-types-exact@^1.2.0:
     object.assign "^4.1.0"
     reflect.ownkeys "^0.2.0"
 
-prop-types@15.7.2, prop-types@>=15.5.10, prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.6, prop-types@^15.5.7, prop-types@^15.5.8, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@15.7.2, prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.6, prop-types@^15.5.7, prop-types@^15.5.8, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -15428,13 +15428,6 @@ react-sortable-hoc@^1.9.0:
     "@babel/runtime" "^7.2.0"
     invariant "^2.2.4"
     prop-types "^15.5.7"
-
-react-sticky-el@^1.0.20:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/react-sticky-el/-/react-sticky-el-1.1.0.tgz#641658f1fc038902862e3ee8c262e2dcdb902032"
-  integrity sha512-aDlz85yfyPtiE+Jlok+N109dnJ6VBhP4h3wkOFxT2tzauWoE8cMdTDB7pvQam4TIOXJtWKgilZA8q03G/PANmQ==
-  dependencies:
-    prop-types ">=15.5.10"
 
 react-test-renderer@^16.0.0-0:
   version "16.12.0"


### PR DESCRIPTION
Since we no longer have to support Internet Explorer, we can get rid of
<Sticky /> directive and instead use native `position: sticky`.