### PR TITLE
fix: 🐛 Focus editor when pressing ESC in RT commands

### DIFF
--- a/packages/rich-text/src/plugins/CommandPalette/CommandPanel/index.js
+++ b/packages/rich-text/src/plugins/CommandPalette/CommandPanel/index.js
@@ -263,12 +263,12 @@ class CommandPalette extends React.PureComponent {
   };
 
   handleKeyboard = e => {
-    if (isHotKey('down', e) || isHotKey('up', e) || isHotKey('enter', e)) {
+    const isEscKey = isHotKey('esc', e); // ESC to close menu shouldn't blur editor.
+    if (isEscKey || isHotKey('down', e) || isHotKey('up', e) || isHotKey('enter', e)) {
       e.preventDefault();
       e.stopPropagation();
     }
-
-    if (isHotKey('esc', e) || isHotKey('tab', e)) {
+    if (isEscKey || isHotKey('tab', e)) {
       this.setState({
         isClosed: true
       });


### PR DESCRIPTION
When pressing ESC while the rich text commands menu is open, the menu closes, but the focus was gone from the editor which means the user had to focus it again to continue writing.