### PR TITLE
fix: 🐛 Allow to specify mimetype when selecting asset

### DIFF
--- a/extensions/field-extension/src/index.tsx
+++ b/extensions/field-extension/src/index.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { render } from 'react-dom';
 import { init, FieldExtensionSDK } from 'contentful-ui-extensions-sdk';
-import { EntryReferenceEditor } from '../../../packages/reference/src/index';
+import { AssetReferenceEditor } from '../../../packages/reference/src/index';
 import '@contentful/forma-36-react-components/dist/styles.css';
 import '@contentful/forma-36-fcss/dist/styles.css';
 import './index.css';
@@ -11,14 +11,14 @@ init<FieldExtensionSDK>(sdk => {
   fieldSdk.window.startAutoResizer();
   render(
     <div style={{ minHeight: 400 }}>
-      <EntryReferenceEditor
+      <AssetReferenceEditor
         viewType="card"
         field={fieldSdk.field}
         baseSdk={fieldSdk}
         isInitiallyDisabled={true}
         parameters={{
           instance: {
-            canCreateEntry: true
+            canCreateAsset: true
           }
         }}
       />

--- a/packages/reference/package.json
+++ b/packages/reference/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@contentful/field-editor-shared": "^0.8.0",
     "@contentful/forma-36-react-components": "^3.31.8",
+    "contentful-ui-extensions-sdk": "^3.11.1",
     "@contentful/forma-36-tokens": "^0.5.1",
     "@contentful/mimetype": "^1.1.4",
     "constate": "2.0.0",

--- a/packages/reference/src/AssetReferenceEditor.tsx
+++ b/packages/reference/src/AssetReferenceEditor.tsx
@@ -5,6 +5,7 @@ import { ViewType, AssetReferenceValue, BaseExtensionSDK, Link } from './types';
 import { LinkActions } from './LinkActions/LinkActions';
 import { MissingEntityCard } from './MissingEntityCard/MissingEntityCard';
 import { FetchedWrappedAssetCard } from './WrappedAssetCard/WrappedAssetCard';
+import { fromFieldValidations, ReferenceValidations } from './utils/fromFieldValidations';
 import { AssetsProvider, useAssetsStore } from './EntityStore/EntityStore';
 
 export interface AssetReferenceEditorProps {
@@ -32,11 +33,12 @@ type SingleAssetReferenceEditorProps = AssetReferenceEditorProps & {
   value: AssetReferenceValue | null | undefined;
   disabled: boolean;
   setValue: (value: AssetReferenceValue | null | undefined) => void;
+  validations: ReferenceValidations;
 };
 
 function LinkSingleAssetReference(props: SingleAssetReferenceEditorProps) {
   const { disabled, baseSdk, setValue } = props;
-  // todo: need to analyze validations and apply it
+
   return (
     <LinkActions
       entityType="asset"
@@ -61,7 +63,8 @@ function LinkSingleAssetReference(props: SingleAssetReferenceEditorProps) {
       }}
       onLinkExisting={async () => {
         const item = await baseSdk.dialogs.selectSingleAsset<Link>({
-          locale: props.field.locale
+          locale: props.field.locale,
+          mimetypeGroups: props.validations.mimetypeGroups
         });
         if (!item) {
           return;
@@ -154,6 +157,8 @@ function SingleAssetReferenceEditor(props: SingleAssetReferenceEditorProps) {
 export function AssetReferenceEditor(props: AssetReferenceEditorProps) {
   const { field } = props;
 
+  const validations = fromFieldValidations(field.validations);
+
   return (
     <AssetsProvider sdk={props.baseSdk}>
       <FieldConnector<AssetReferenceValue>
@@ -165,6 +170,7 @@ export function AssetReferenceEditor(props: AssetReferenceEditorProps) {
             <SingleAssetReferenceEditor
               key={`single-asset-${externalReset}`}
               {...props}
+              validations={validations}
               disabled={disabled}
               value={value}
               setValue={setValue}

--- a/packages/reference/src/WrappedAssetCard/AssetCardActions.tsx
+++ b/packages/reference/src/WrappedAssetCard/AssetCardActions.tsx
@@ -20,7 +20,7 @@ export class AssetCardActions extends React.PureComponent<{
   onEdit: () => void;
   onRemove: () => void;
   isDisabled: boolean;
-  entityFile: File;
+  entityFile?: File;
 }> {
   renderActions() {
     const { entityFile, isDisabled, onEdit, onRemove } = this.props;
@@ -88,7 +88,7 @@ export class AssetCardActions extends React.PureComponent<{
     return (
       <React.Fragment>
         {this.renderActions()}
-        {this.renderAssetInfo()}
+        {this.props.entityFile ? this.renderAssetInfo() : null}
       </React.Fragment>
     );
   }

--- a/packages/reference/src/WrappedAssetCard/WrappedAssetCard.tsx
+++ b/packages/reference/src/WrappedAssetCard/WrappedAssetCard.tsx
@@ -23,7 +23,7 @@ const groupToIconMap = {
 };
 
 export interface WrappedAssetCardProps {
-  entityFile: File;
+  entityFile?: File;
   entityTitle: string;
   entityStatus: 'archived' | 'changed' | 'draft' | 'published';
   href?: string;
@@ -70,8 +70,9 @@ export const FetchedWrappedAssetCard = (
     defaultTitle: 'Untitled'
   });
 
-  const entityFile =
-    props.asset.fields.file[props.localeCode] || props.asset.fields.file[props.defaultLocaleCode];
+  const entityFile = props.asset.fields.file
+    ? props.asset.fields.file[props.localeCode] || props.asset.fields.file[props.defaultLocaleCode]
+    : undefined;
 
   return (
     <WrappedAssetCard

--- a/packages/reference/src/utils/fromFieldValidations.ts
+++ b/packages/reference/src/utils/fromFieldValidations.ts
@@ -1,5 +1,6 @@
 export type ReferenceValidations = {
   contentTypes?: string[];
+  mimetypeGroups?: string[];
 };
 
 export function fromFieldValidations(
@@ -7,9 +8,14 @@ export function fromFieldValidations(
   validations: Record<string, any>[] = []
 ): ReferenceValidations {
   const linkContentTypeValidations = validations.find(v => 'linkContentType' in v);
+  const linkMimetypeGroupValidations = validations.find(v => 'linkMimetypeGroup' in v);
 
   const result: ReferenceValidations = {
-    contentTypes: linkContentTypeValidations?.linkContentType ?? undefined
+    contentTypes: linkContentTypeValidations?.linkContentType ?? undefined,
+    mimetypeGroups: linkMimetypeGroupValidations?.linkMimetypeGroup ?? undefined
+    // todo: there are multiple BE problems that need to be solved first, for now we don't want to apply size constraints
+    // linkedFileSize: findValidation(field, 'assetFileSize', {}),
+    // linkedImageDimensions: findValidation(field, 'assetImageDimensions', {})
   };
 
   return result;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6271,6 +6271,13 @@ contentful-ui-extensions-sdk@^3.11.0:
   dependencies:
     es6-promise "^4.2.8"
 
+contentful-ui-extensions-sdk@^3.11.1:
+  version "3.11.1"
+  resolved "https://registry.yarnpkg.com/contentful-ui-extensions-sdk/-/contentful-ui-extensions-sdk-3.11.1.tgz#4662b69f66f9cffc6f275cbe8b5213d25880b538"
+  integrity sha512-XJn8KrC4H6F3kdFDnTq9uvCcV/vRzNi7GvB76Jrowk+BbsA08JGtPFokHxo9BBrTWlYqARcKzYG9RNuDJh1DBg==
+  dependencies:
+    es6-promise "^4.2.8"
+
 conventional-changelog-angular@^1.3.3:
   version "1.6.6"
   resolved "https://registry.yarnpkg.com/conventional-changelog-angular/-/conventional-changelog-angular-1.6.6.tgz#b27f2b315c16d0a1f23eb181309d0e6a4698ea0f"


### PR DESCRIPTION
- [x] Fixes a problem with AssetReference editor without uploaded file
- [x] Uses the latest version of SDK to allow filter out assets by mimetype