### PR TITLE
fix: 🐛 Close action on click

### DIFF
--- a/extensions/field-extension/src/index.tsx
+++ b/extensions/field-extension/src/index.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { render } from 'react-dom';
 import { init, FieldExtensionSDK } from 'contentful-ui-extensions-sdk';
-import { AssetReferenceEditor } from '../../../packages/reference/src/index';
+import { EntryReferenceEditor } from '../../../packages/reference/src/index';
 import '@contentful/forma-36-react-components/dist/styles.css';
 import '@contentful/forma-36-fcss/dist/styles.css';
 import './index.css';
@@ -11,14 +11,14 @@ init<FieldExtensionSDK>(sdk => {
   fieldSdk.window.startAutoResizer();
   render(
     <div style={{ minHeight: 400 }}>
-      <AssetReferenceEditor
+      <EntryReferenceEditor
         viewType="card"
         field={fieldSdk.field}
         baseSdk={fieldSdk}
         isInitiallyDisabled={true}
         parameters={{
           instance: {
-            canCreateAsset: true
+            canCreateEntry: true
           }
         }}
       />

--- a/packages/reference/src/WrappedAssetCard/AssetCardActions.tsx
+++ b/packages/reference/src/WrappedAssetCard/AssetCardActions.tsx
@@ -16,80 +16,69 @@ function downloadAsset(url: string) {
   window.open(url, '_blank');
 }
 
-export class AssetCardActions extends React.PureComponent<{
+export function renderAssetInfo(props: { entityFile: File }) {
+  const { entityFile } = props;
+  const fileName = get(entityFile, 'fileName');
+  const mimeType = get(entityFile, 'contentType');
+  const fileSize = get(entityFile, 'details.size');
+  const image = get(entityFile, 'details.image');
+  return (
+    <DropdownList
+      border="top"
+      className={styles.cardDropdown}
+      // @ts-ignore
+      onClick={e => {
+        e.stopPropagation();
+      }}>
+      <DropdownListItem isTitle>File info</DropdownListItem>
+      {fileName && (
+        <DropdownListItem>
+          <div>{fileName}</div>
+        </DropdownListItem>
+      )}
+      {mimeType && (
+        <DropdownListItem>
+          <div>{mimeType}</div>
+        </DropdownListItem>
+      )}
+      {fileSize && <DropdownListItem>{shortenStorageUnit(fileSize, 'B')}</DropdownListItem>}
+      {image && <DropdownListItem>{`${image.width} × ${image.height}`}</DropdownListItem>}
+    </DropdownList>
+  );
+}
+
+export function renderActions(props: {
   onEdit: () => void;
   onRemove: () => void;
   isDisabled: boolean;
   entityFile?: File;
-}> {
-  renderActions() {
-    const { entityFile, isDisabled, onEdit, onRemove } = this.props;
-    return (
-      <DropdownList
-        className={styles.cardDropdown}
-        // @ts-ignore
-        onClick={e => {
-          e.stopPropagation();
-        }}>
-        <DropdownListItem isTitle>Actions</DropdownListItem>
-        {onEdit && (
-          <DropdownListItem onClick={onEdit} testId="card-action-edit">
-            Edit
-          </DropdownListItem>
-        )}
-        {entityFile && (
-          <DropdownListItem
-            onClick={() => downloadAsset(entityFile.url)}
-            testId="card-action-download">
-            Download
-          </DropdownListItem>
-        )}
-        {onRemove && (
-          <DropdownListItem isDisabled={isDisabled} onClick={onRemove} testId="card-action-remove">
-            Remove
-          </DropdownListItem>
-        )}
-      </DropdownList>
-    );
-  }
-
-  renderAssetInfo() {
-    const { entityFile } = this.props;
-    const fileName = get(entityFile, 'fileName');
-    const mimeType = get(entityFile, 'contentType');
-    const fileSize = get(entityFile, 'details.size');
-    const image = get(entityFile, 'details.image');
-    return (
-      <DropdownList
-        border="top"
-        className={styles.cardDropdown}
-        // @ts-ignore
-        onClick={e => {
-          e.stopPropagation();
-        }}>
-        <DropdownListItem isTitle>File info</DropdownListItem>
-        {fileName && (
-          <DropdownListItem>
-            <div>{fileName}</div>
-          </DropdownListItem>
-        )}
-        {mimeType && (
-          <DropdownListItem>
-            <div>{mimeType}</div>
-          </DropdownListItem>
-        )}
-        {fileSize && <DropdownListItem>{shortenStorageUnit(fileSize, 'B')}</DropdownListItem>}
-        {image && <DropdownListItem>{`${image.width} × ${image.height}`}</DropdownListItem>}
-      </DropdownList>
-    );
-  }
-
-  render() {
-    return (
-      <React.Fragment>
-        {this.renderActions()}
-        {this.props.entityFile ? this.renderAssetInfo() : null}
-      </React.Fragment>
-    );
-  }
+}) {
+  const { entityFile, isDisabled, onEdit, onRemove } = props;
+  return (
+    <DropdownList
+      className={styles.cardDropdown}
+      // @ts-ignore
+      onClick={e => {
+        e.stopPropagation();
+      }}>
+      <DropdownListItem isTitle>Actions</DropdownListItem>
+      {onEdit && (
+        <DropdownListItem onClick={onEdit} testId="card-action-edit">
+          Edit
+        </DropdownListItem>
+      )}
+      {entityFile && (
+        <DropdownListItem
+          onClick={() => downloadAsset(entityFile.url)}
+          testId="card-action-download">
+          Download
+        </DropdownListItem>
+      )}
+      {onRemove && (
+        <DropdownListItem isDisabled={isDisabled} onClick={onRemove} testId="card-action-remove">
+          Remove
+        </DropdownListItem>
+      )}
+    </DropdownList>
+  );
 }

--- a/packages/reference/src/WrappedAssetCard/WrappedAssetCard.tsx
+++ b/packages/reference/src/WrappedAssetCard/WrappedAssetCard.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { AssetCard } from '@contentful/forma-36-react-components';
-import { AssetCardActions } from './AssetCardActions';
+import { renderActions, renderAssetInfo } from './AssetCardActions';
 import { File, Asset } from '../types';
 import { entityHelpers } from '@contentful/field-editor-shared';
 import { MissingEntityCard } from '../MissingEntityCard/MissingEntityCard';
@@ -85,7 +85,18 @@ export const FetchedWrappedAssetCard = (
 };
 
 export const WrappedAssetCard = (props: WrappedAssetCardProps) => {
-  const { entityFile, entityTitle, className, href, entityStatus, onEdit, size, readOnly } = props;
+  const {
+    entityFile,
+    entityTitle,
+    className,
+    href,
+    entityStatus,
+    onEdit,
+    onRemove,
+    size,
+    readOnly,
+    disabled
+  } = props;
 
   return (
     <AssetCard
@@ -101,23 +112,18 @@ export const WrappedAssetCard = (props: WrappedAssetCardProps) => {
             : `${entityFile.url}?h=300`
           : ''
       }
+      // @ts-ignore
       onClick={(e: React.MouseEvent<HTMLElement>) => {
         e.preventDefault();
         onEdit();
       }}
       // cardDragHandleComponent={cardDragHandleComponent}
       // withDragHandle={!!cardDragHandleComponent}
-      // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-      // @ts-ignore
       dropdownListElements={
-        readOnly ? null : (
-          <AssetCardActions
-            entityFile={props.entityFile}
-            isDisabled={props.disabled}
-            onEdit={props.onEdit}
-            onRemove={props.onRemove}
-          />
-        )
+        <React.Fragment>
+          {!readOnly ? renderActions({ entityFile, isDisabled: disabled, onEdit, onRemove }) : null}
+          {entityFile ? renderAssetInfo({ entityFile }) : null}
+        </React.Fragment>
       }
       size={size}
     />

--- a/packages/reference/src/WrappedEntryCard/WrappedEntryCard.tsx
+++ b/packages/reference/src/WrappedEntryCard/WrappedEntryCard.tsx
@@ -36,36 +36,6 @@ interface WrappedEntryCardProps {
   entry: Entry;
 }
 
-const EntryActions = (props: { disabled: boolean; onEdit: Function; onRemove: Function }) => {
-  const { disabled, onEdit, onRemove } = props;
-  return (
-    <DropdownList>
-      {onEdit && (
-        <DropdownListItem
-          isDisabled={disabled}
-          onClick={e => {
-            e.stopPropagation();
-            onEdit();
-          }}
-          testId="edit">
-          Edit
-        </DropdownListItem>
-      )}
-      {onRemove && (
-        <DropdownListItem
-          onClick={e => {
-            e.stopPropagation();
-            onRemove();
-          }}
-          isDisabled={disabled}
-          testId="delete">
-          Remove
-        </DropdownListItem>
-      )}
-    </DropdownList>
-  );
-};
-
 export function WrappedEntryCard(props: WrappedEntryCardProps) {
   const [file, setFile] = React.useState<null | File>(null);
 
@@ -140,7 +110,35 @@ export function WrappedEntryCard(props: WrappedEntryCardProps) {
       }
       thumbnailElement={file && isValidImage(file) ? <AssetThumbnail file={file} /> : null}
       dropdownListElements={
-        <EntryActions disabled={props.disabled} onEdit={props.onEdit} onRemove={props.onRemove} />
+        <React.Fragment>
+          <DropdownList
+            // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+            // @ts-ignore
+            onClick={e => {
+              e.stopPropagation();
+            }}>
+            {props.onEdit && (
+              <DropdownListItem
+                isDisabled={props.disabled}
+                onClick={() => {
+                  props.onEdit();
+                }}
+                testId="edit">
+                Edit
+              </DropdownListItem>
+            )}
+            {props.onRemove && (
+              <DropdownListItem
+                onClick={() => {
+                  props.onRemove();
+                }}
+                isDisabled={props.disabled}
+                testId="delete">
+                Remove
+              </DropdownListItem>
+            )}
+          </DropdownList>
+        </React.Fragment>
       }
       onClick={e => {
         e.preventDefault();


### PR DESCRIPTION
Fix all menus in references editors, so they are closed on item click.