### PR TITLE
fix: 🐛 Generate unique input ID for boolean and radio fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@types/jest": "^24.0.19",
     "@types/lodash": "4.14.144",
     "@types/lodash-es": "4.17.3",
+    "@types/nanoid": "^2.1.0",
     "@types/react": "16.9.23",
     "@types/react-dom": "16.9.5",
     "@types/testing-library__cypress": "5.0.3",

--- a/packages/boolean/package.json
+++ b/packages/boolean/package.json
@@ -26,7 +26,8 @@
     "@contentful/forma-36-tokens": "^0.4.5",
     "emotion": "^10.0.17",
     "lodash": "^4.17.15",
-    "lodash-es": "^4.17.15"
+    "lodash-es": "^4.17.15",
+    "nanoid": "^2.1.11"
   },
   "devDependencies": {
     "@contentful/field-editor-test-utils": "^0.4.0"

--- a/packages/boolean/src/BooleanEditor.tsx
+++ b/packages/boolean/src/BooleanEditor.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import get from 'lodash/get';
+import nanoid from 'nanoid';
 import { css, cx } from 'emotion';
 import tokens from '@contentful/forma-36-tokens';
 import { FieldAPI, ParametersAPI, FieldConnector } from '@contentful/field-editor-shared';
@@ -25,8 +26,8 @@ export function BooleanEditor(props: BooleanEditorProps) {
   const { field } = props;
 
   const options = [
-    { value: true, label: get(props.parameters, ['instance', 'trueLabel'], 'Yes') },
-    { value: false, label: get(props.parameters, ['instance', 'falseLabel'], 'No') }
+    { value: true, label: get(props.parameters, ['instance', 'trueLabel'], 'Yes'), id: nanoid(6) },
+    { value: false, label: get(props.parameters, ['instance', 'falseLabel'], 'No'), id: nanoid(6) }
   ];
 
   return (
@@ -46,7 +47,7 @@ export function BooleanEditor(props: BooleanEditorProps) {
         return (
           <div data-test-id="boolean-editor" className={cx(css({ marginTop: tokens.spacingS }))}>
             {options.map(item => {
-              const id = ['entity', field.id, field.locale, item.value].join('.');
+              const id = ['entity', field.id, field.locale, item.value, item.id].join('.');
               const checked = value === item.value;
               return (
                 <React.Fragment key={id}>

--- a/packages/dropdown/src/dropdownUtils.ts
+++ b/packages/dropdown/src/dropdownUtils.ts
@@ -1,6 +1,8 @@
+import nanoid from 'nanoid';
 import { FieldAPI } from '@contentful/field-editor-shared';
 
 type DropdownOption = {
+  id: string;
   value: string | number | undefined;
   label: string;
 };
@@ -27,6 +29,7 @@ export function getOptions(field: FieldAPI): DropdownOption[] {
 
   return firstPredefinedValues
     .map((value: string) => ({
+      id: nanoid(6),
       value: parseValue(value, field.type),
       label: String(value)
     }))

--- a/packages/radio/package.json
+++ b/packages/radio/package.json
@@ -27,7 +27,8 @@
     "@contentful/forma-36-tokens": "^0.4.5",
     "emotion": "^10.0.17",
     "lodash": "^4.17.15",
-    "lodash-es": "^4.17.15"
+    "lodash-es": "^4.17.15",
+    "nanoid": "^2.1.11"
   },
   "devDependencies": {
     "@contentful/field-editor-test-utils": "^0.4.0"

--- a/packages/radio/src/RadioEditor.tsx
+++ b/packages/radio/src/RadioEditor.tsx
@@ -52,7 +52,7 @@ export function RadioEditor(props: RadioEditorProps) {
             spacing="condensed"
             className={cx(styles.form, direction === 'rtl' ? styles.rightToLeft : '')}>
             {options.map((item, index) => {
-              const id = ['entity', field.id, field.locale, index].join('.');
+              const id = ['entity', field.id, field.locale, index, item.id].join('.');
               const checked = value === item.value;
               return (
                 <React.Fragment key={id}>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3477,6 +3477,13 @@
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
   integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
 
+"@types/nanoid@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@types/nanoid/-/nanoid-2.1.0.tgz#41edfda78986e9127d0dc14de982de766f994020"
+  integrity sha512-xdkn/oRTA0GSNPLIKZgHWqDTWZsVrieKomxJBOQUK9YDD+zfSgmwD5t4WJYra5S7XyhTw7tfvwznW+pFexaepQ==
+  dependencies:
+    "@types/node" "*"
+
 "@types/node@*", "@types/node@>= 8":
   version "13.7.6"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-13.7.6.tgz#cb734a7c191472ae6a2b3a502b4dfffcea974113"
@@ -13255,6 +13262,11 @@ nan@^2.12.1:
   version "2.14.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.0.tgz#7818f722027b2459a86f0295d434d1fc2336c52c"
   integrity sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==
+
+nanoid@^2.1.11:
+  version "2.1.11"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-2.1.11.tgz#ec24b8a758d591561531b4176a01e3ab4f0f0280"
+  integrity sha512-s/snB+WGm6uwi0WjsZdaVcuf3KJXlfGl2LcxgwkEwJF0D/BWzVWAZW/XY4bFaiR7s0Jk3FPvlnepg1H1b1UwlA==
 
 nanomatch@^1.2.9:
   version "1.2.13"


### PR DESCRIPTION
Use nanoid to generate short unique IDs for dropdown/boolean options to
avoid duplicated `<input />` IDs