### PR TITLE
fix: 🐛 allow empty style tags in markdown editor [PEN-893] 

### DIFF
--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -30,7 +30,7 @@
     "emotion": "^10.0.17",
     "lodash": "^4.17.15",
     "lodash-es": "^4.17.15",
-    "markdown-to-jsx": "^6.11.0"
+    "markdown-to-jsx": "git://github.com/contentful/markdown-to-jsx.git#7af79aef2b581eaa0b1103e8642d639ba1fab196"
   },
   "devDependencies": {
     "@babel/core": "^7.5.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12631,10 +12631,9 @@ markdown-table@^1.1.0:
   resolved "https://registry.yarnpkg.com/markdown-table/-/markdown-table-1.1.3.tgz#9fcb69bcfdb8717bfd0398c6ec2d93036ef8de60"
   integrity sha512-1RUZVgQlpJSPWYbFSpmudq5nHY1doEIv89gBtF0s4gW1GF2XorxcA/70M5vq7rLv0a6mhOUccRsqkwhwLCIQ2Q==
 
-markdown-to-jsx@^6.11.0:
+"markdown-to-jsx@git://github.com/contentful/markdown-to-jsx.git#7af79aef2b581eaa0b1103e8642d639ba1fab196":
   version "6.11.0"
-  resolved "https://registry.yarnpkg.com/markdown-to-jsx/-/markdown-to-jsx-6.11.0.tgz#a2e3f2bc781c3402d8bb0f8e0a12a186474623b0"
-  integrity sha512-RH7LCJQ4RFmPqVeZEesKaO1biRzB/k4utoofmTCp3Eiw6D7qfvK8fzZq/2bjEJAtVkfPrM5SMt5APGf2rnaKMg==
+  resolved "git://github.com/contentful/markdown-to-jsx.git#7af79aef2b581eaa0b1103e8642d639ba1fab196"
   dependencies:
     prop-types "^15.6.2"
     unquote "^1.1.0"


### PR DESCRIPTION
## Synopsis

Pulls in a pre-compiled [local fork](https://github.com/contentful/markdown-to-jsx) of `markdown-to-jsx` including the changes from this PR:

https://github.com/probablyup/markdown-to-jsx/pull/296

which in turn fixes a bug in which empty style attributes, e.g.:

```html
<div style>Foo</div>
```

cause unrecoverable crashes in the markdown field editor. (See the PR linked above for more detail on this bug.)

## Approach

Note that the [fork commit](https://github.com/contentful/markdown-to-jsx/commit/7af79aef2b581eaa0b1103e8642d639ba1fab196) this PR pulls in actually goes one commit further than the linked PR by moving the built/compiled module into `index.js` so that it can be digested by this module without having to add JSX support to webpack. This is so that we don't have to publish the fork to npm, and if/when our changes are accepted by the author of `markdown-to-jsx` we can simply `yarn add` the module from npm again.

Although this patch is for somewhat of an edge case, I'm opting for replacement with the fork (rather than waiting for a response to our PR) because it doesn't seem like contributions to `markdown-to-jsx` are very actively responded to at the moment, and this bug was escalated from a support inquiry (hence is a bit more urgent than normal). See linked JIRA ticket for more info.

## Release plan

Needs to be pulled into the webapp, like usual. I'll make a PR after this is released.

## Dependencies & References

- https://contentful.atlassian.net/browse/PEN-893