### PR TITLE
chore: 🤖 switch to remote upstream markdown-to-jsx [PEN-893]

### DIFF
--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -30,7 +30,7 @@
     "emotion": "^10.0.17",
     "lodash": "^4.17.15",
     "lodash-es": "^4.17.15",
-    "markdown-to-jsx": "git://github.com/contentful/markdown-to-jsx.git#7af79aef2b581eaa0b1103e8642d639ba1fab196"
+    "markdown-to-jsx": "^6.11.1"
   },
   "devDependencies": {
     "@babel/core": "^7.5.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12631,9 +12631,10 @@ markdown-table@^1.1.0:
   resolved "https://registry.yarnpkg.com/markdown-table/-/markdown-table-1.1.3.tgz#9fcb69bcfdb8717bfd0398c6ec2d93036ef8de60"
   integrity sha512-1RUZVgQlpJSPWYbFSpmudq5nHY1doEIv89gBtF0s4gW1GF2XorxcA/70M5vq7rLv0a6mhOUccRsqkwhwLCIQ2Q==
 
-"markdown-to-jsx@git://github.com/contentful/markdown-to-jsx.git#7af79aef2b581eaa0b1103e8642d639ba1fab196":
-  version "6.11.0"
-  resolved "git://github.com/contentful/markdown-to-jsx.git#7af79aef2b581eaa0b1103e8642d639ba1fab196"
+markdown-to-jsx@^6.11.1:
+  version "6.11.1"
+  resolved "https://registry.yarnpkg.com/markdown-to-jsx/-/markdown-to-jsx-6.11.1.tgz#3931612cfffaa5fd6610ecf2a4055eccccb98fa8"
+  integrity sha512-FdtDAv8d9/tjyHxdCvWZxxOgK2icwzBkTq/dPk+XlQ2B+DYDcwE89FWGzT92erXQ0CQR/bQbpNK3loNYhYL70g==
   dependencies:
     prop-types "^15.6.2"
     unquote "^1.1.0"


### PR DESCRIPTION
Package maintainer accepted our fix, hence we no longer need to maintain our fork and should update the dependency accordingly.

Relates to https://github.com/contentful/field-editors/pull/81