### PR TITLE
feat: use new sdk.access to read permissions

### DIFF
--- a/cypress/integration/LocationEditor.spec.ts
+++ b/cypress/integration/LocationEditor.spec.ts
@@ -121,17 +121,6 @@ describe('Location Editor', () => {
     ]);
   });
 
-  it('should show validation error if address does not exist', () => {
-    selectors.getSearchInput().type('something that clearly does not exist');
-    cy.wait(500);
-    selectors
-      .getValidationError()
-      .should(
-        'have.text',
-        'No results found for something that clearly does not exist. Please make sure that address is spelled correctly.'
-      );
-  });
-
   it('should disable all elements if isDisabled is true', () => {
     cy.setInitialDisabled(true);
     cy.reload();

--- a/extensions/entry-extension-collapsible/package.json
+++ b/extensions/entry-extension-collapsible/package.json
@@ -1,6 +1,6 @@
 {
   "name": "entry-extension-collapsible",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "devDependencies": {
     "@babel/core": "7.3.4",
@@ -29,7 +29,7 @@
     "help": "contentful-extension-scripts help"
   },
   "dependencies": {
-    "@contentful/field-editor-shared": "^0.10.1",
+    "@contentful/field-editor-shared": "^0.10.2",
     "@contentful/forma-36-fcss": "^0.0.35",
     "@contentful/forma-36-react-components": "^3.36.1",
     "@contentful/forma-36-tokens": "^0.5.2",

--- a/extensions/entry-extension-collapsible/src/Field.tsx
+++ b/extensions/entry-extension-collapsible/src/Field.tsx
@@ -127,8 +127,6 @@ export const Field: React.FC<FieldProps> = ({ field, locales }: FieldProps) => {
         );
 
       case 'urlEditor':
-        // TODO: verify this is correct - as it appears identical to normal
-        // single line editor..
         return (
           <FieldWrapper name={fieldDetails.name} required={fieldDetails.required}>
             <UrlEditor field={extendedField} />
@@ -164,7 +162,7 @@ export const Field: React.FC<FieldProps> = ({ field, locales }: FieldProps) => {
         return (
           <FieldWrapper name={fieldDetails.name} required={fieldDetails.required}>
             <SingleEntryReferenceEditor
-              parameters={{ instance: { canCreateEntity: false } }}
+              parameters={{ instance: { canCreateEntity: true, canLinkEntity: true } }}
               viewType="link"
               sdk={fieldSdk}
             />
@@ -180,7 +178,7 @@ export const Field: React.FC<FieldProps> = ({ field, locales }: FieldProps) => {
         return (
           <FieldWrapper name={fieldDetails.name} required={fieldDetails.required}>
             <SingleEntryReferenceEditor
-              parameters={{ instance: { canCreateEntity: false } }}
+              parameters={{ instance: { canCreateEntity: true, canLinkEntity: true } }}
               viewType="card"
               sdk={fieldSdk}
             />
@@ -197,7 +195,7 @@ export const Field: React.FC<FieldProps> = ({ field, locales }: FieldProps) => {
           <FieldWrapper name={fieldDetails.name} required={fieldDetails.required}>
             <MultipleEntryReferenceEditor
               isInitiallyDisabled={false}
-              parameters={{ instance: { canCreateEntity: false } }}
+              parameters={{ instance: { canCreateEntity: true, canLinkEntity: true } }}
               viewType="link"
               sdk={fieldSdk}
             />
@@ -214,7 +212,7 @@ export const Field: React.FC<FieldProps> = ({ field, locales }: FieldProps) => {
           <FieldWrapper name={fieldDetails.name} required={fieldDetails.required}>
             <MultipleEntryReferenceEditor
               isInitiallyDisabled={false}
-              parameters={{ instance: { canCreateEntity: false } }}
+              parameters={{ instance: { canCreateEntity: true, canLinkEntity: true } }}
               viewType="card"
               sdk={fieldSdk}
             />
@@ -230,7 +228,7 @@ export const Field: React.FC<FieldProps> = ({ field, locales }: FieldProps) => {
         return (
           <FieldWrapper name={fieldDetails.name} required={fieldDetails.required}>
             <SingleMediaEditor
-              parameters={{ instance: { canCreateEntity: false } }}
+              parameters={{ instance: { canCreateEntity: true, canLinkEntity: true } }}
               viewType="link"
               sdk={fieldSdk}
             />
@@ -246,7 +244,7 @@ export const Field: React.FC<FieldProps> = ({ field, locales }: FieldProps) => {
         return (
           <FieldWrapper name={fieldDetails.name} required={fieldDetails.required}>
             <MultipleMediaEditor
-              parameters={{ instance: { canCreateEntity: false } }}
+              parameters={{ instance: { canCreateEntity: true, canLinkEntity: true } }}
               viewType="link"
               sdk={fieldSdk}
             />
@@ -262,7 +260,7 @@ export const Field: React.FC<FieldProps> = ({ field, locales }: FieldProps) => {
         return (
           <FieldWrapper name={fieldDetails.name} required={fieldDetails.required}>
             <MultipleMediaEditor
-              parameters={{ instance: { canCreateEntity: false } }}
+              parameters={{ instance: { canCreateEntity: true, canLinkEntity: true } }}
               viewType="card"
               sdk={fieldSdk}
             />
@@ -271,21 +269,8 @@ export const Field: React.FC<FieldProps> = ({ field, locales }: FieldProps) => {
       }
 
       case 'richTextEditor': {
-        let fieldSdk: any = sdk;
-
+        const fieldSdk: any = sdk;
         fieldSdk.field = extendedField;
-
-        fieldSdk = Object.assign(fieldSdk, {
-          parameters: {
-            instance: {
-              permissions: {
-                canAccessAssets: true,
-                canCreateAssets: true,
-                canCreateEntryOfContentType: () => true
-              }
-            }
-          }
-        });
 
         return (
           <FieldWrapper name={fieldDetails.name} required={fieldDetails.required}>
@@ -296,7 +281,6 @@ export const Field: React.FC<FieldProps> = ({ field, locales }: FieldProps) => {
 
       case 'markdown': {
         const fieldSdk: any = sdk;
-
         fieldSdk.field = extendedField;
 
         return (

--- a/extensions/entry-extension-collapsible/src/Field.tsx
+++ b/extensions/entry-extension-collapsible/src/Field.tsx
@@ -299,10 +299,9 @@ export const Field: React.FC<FieldProps> = ({ field, locales }: FieldProps) => {
 
         fieldSdk.field = extendedField;
 
-        const parameters = { instance: { canUploadAssets: false } };
         return (
           <FieldWrapper name={fieldDetails.name} required={fieldDetails.required}>
-            <MarkdownEditor sdk={fieldSdk} parameters={parameters} isInitiallyDisabled={false} />
+            <MarkdownEditor sdk={fieldSdk} isInitiallyDisabled={false} />
           </FieldWrapper>
         );
       }

--- a/extensions/markdown-extension/package.json
+++ b/extensions/markdown-extension/package.json
@@ -31,7 +31,6 @@
   "dependencies": {
     "@contentful/forma-36-fcss": "^0.0.35",
     "@contentful/forma-36-react-components": "^3.36.1",
-    "@contentful/forma-36-tokens": "^0.5.2",
     "contentful-ui-extensions-sdk": "^3.14.1",
     "prop-types": "^15.7.2",
     "react": "^16.8.6",

--- a/extensions/markdown-extension/package.json
+++ b/extensions/markdown-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markdown-extension",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "devDependencies": {
     "@babel/core": "7.3.4",

--- a/extensions/markdown-extension/src/index.tsx
+++ b/extensions/markdown-extension/src/index.tsx
@@ -19,17 +19,7 @@ interface AppProps {
 
 export class App extends React.Component<AppProps> {
   render = () => {
-    return (
-      <MarkdownEditor
-        isInitiallyDisabled={false}
-        parameters={{
-          instance: {
-            canUploadAssets: true
-          }
-        }}
-        sdk={this.props.sdk}
-      />
-    );
+    return <MarkdownEditor isInitiallyDisabled={false} sdk={this.props.sdk} />;
   };
 }
 

--- a/extensions/rich-text-extension/package.json
+++ b/extensions/rich-text-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rich-text-extension",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "devDependencies": {
     "@babel/core": "7.3.4",

--- a/extensions/rich-text-extension/src/index.tsx
+++ b/extensions/rich-text-extension/src/index.tsx
@@ -6,33 +6,12 @@ import '@contentful/forma-36-fcss/dist/styles.css';
 import './index.css';
 import { RichTextEditor, renderRichTextDialog } from '../../../packages/rich-text/src/index';
 
-interface AppProps {
-  sdk: FieldExtensionSDK;
-}
-
-export class App extends React.Component<AppProps> {
-  render = () => {
-    const sdk = Object.assign(this.props.sdk, {
-      parameters: {
-        instance: {
-          permissions: {
-            canAccessAssets: true,
-            canCreateAssets: true,
-            canCreateEntryOfContentType: () => true
-          }
-        }
-      }
-    });
-    return <RichTextEditor sdk={sdk} />;
-  };
-}
-
 init((sdk: FieldExtensionSDK) => {
   sdk.window.startAutoResizer();
   if (sdk.location.is(locations.LOCATION_DIALOG)) {
     render(renderRichTextDialog(sdk), document.getElementById('root'));
   } else {
-    render(<App sdk={sdk} />, document.getElementById('root'));
+    render(<RichTextEditor sdk={sdk} />, document.getElementById('root'));
   }
 });
 

--- a/extensions/singleline-extension/package.json
+++ b/extensions/singleline-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "singleline-extension",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "devDependencies": {
     "@babel/core": "7.3.4",

--- a/packages/_shared/package.json
+++ b/packages/_shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contentful/field-editor-shared",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "main": "dist/index.js",
   "module": "dist/field-editor-shared.esm.js",
   "typings": "dist/index.d.ts",

--- a/packages/_test/package.json
+++ b/packages/_test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contentful/field-editor-test-utils",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "main": "dist/index.js",
   "module": "dist/field-editor-shared.esm.js",
   "typings": "dist/index.d.ts",
@@ -21,7 +21,7 @@
     "tsc": "tsc -p ./ --noEmit"
   },
   "dependencies": {
-    "@contentful/field-editor-shared": "^0.10.1",
+    "@contentful/field-editor-shared": "^0.10.2",
     "@contentful/forma-36-tokens": "^0.5.2",
     "contentful-ui-extensions-sdk": "^3.14.1",
     "emotion": "^10.0.17",

--- a/packages/boolean/package.json
+++ b/packages/boolean/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contentful/field-editor-boolean",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "main": "dist/index.js",
   "module": "dist/field-editor-boolean.esm.js",
   "typings": "dist/index.d.ts",
@@ -21,7 +21,7 @@
     "tsc": "tsc -p ./ --noEmit"
   },
   "dependencies": {
-    "@contentful/field-editor-shared": "^0.10.1",
+    "@contentful/field-editor-shared": "^0.10.2",
     "@contentful/forma-36-react-components": "^3.36.1",
     "@contentful/forma-36-tokens": "^0.5.2",
     "emotion": "^10.0.17",
@@ -30,7 +30,7 @@
     "nanoid": "^3.1.3"
   },
   "devDependencies": {
-    "@contentful/field-editor-test-utils": "^0.6.1"
+    "@contentful/field-editor-test-utils": "^0.6.2"
   },
   "peerDependencies": {
     "react": ">=16.8.0"

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contentful/field-editor-checkbox",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "main": "dist/index.js",
   "module": "dist/field-editor-checkbox.esm.js",
   "typings": "dist/index.d.ts",
@@ -21,7 +21,7 @@
     "tsc": "tsc -p ./ --noEmit"
   },
   "dependencies": {
-    "@contentful/field-editor-shared": "^0.10.1",
+    "@contentful/field-editor-shared": "^0.10.2",
     "@contentful/forma-36-react-components": "^3.36.1",
     "@contentful/forma-36-tokens": "^0.5.2",
     "emotion": "^10.0.17",
@@ -29,7 +29,7 @@
     "lodash-es": "^4.17.15"
   },
   "devDependencies": {
-    "@contentful/field-editor-test-utils": "^0.6.1"
+    "@contentful/field-editor-test-utils": "^0.6.2"
   },
   "peerDependencies": {
     "react": ">=16.8.0"

--- a/packages/date/package.json
+++ b/packages/date/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contentful/field-editor-date",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "main": "dist/index.js",
   "module": "dist/field-editor-date.esm.js",
   "typings": "dist/index.d.ts",
@@ -23,7 +23,7 @@
     "test:ci": "tsdx test --env=jsdom --ci"
   },
   "dependencies": {
-    "@contentful/field-editor-shared": "^0.10.1",
+    "@contentful/field-editor-shared": "^0.10.2",
     "@contentful/forma-36-react-components": "^3.36.1",
     "@contentful/forma-36-tokens": "^0.5.2",
     "emotion": "^10.0.17",
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.7.4",
-    "@contentful/field-editor-test-utils": "^0.6.1",
+    "@contentful/field-editor-test-utils": "^0.6.2",
     "@types/pikaday": "^1.7.4"
   },
   "peerDependencies": {

--- a/packages/dropdown/package.json
+++ b/packages/dropdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contentful/field-editor-dropdown",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "main": "dist/index.js",
   "module": "dist/field-editor-dropdown.esm.js",
   "typings": "dist/index.d.ts",
@@ -21,7 +21,7 @@
     "tsc": "tsc -p ./ --noEmit"
   },
   "dependencies": {
-    "@contentful/field-editor-shared": "^0.10.1",
+    "@contentful/field-editor-shared": "^0.10.2",
     "@contentful/forma-36-react-components": "^3.36.1",
     "@contentful/forma-36-tokens": "^0.5.2",
     "emotion": "^10.0.0",
@@ -30,7 +30,7 @@
     "nanoid": "^3.1.3"
   },
   "devDependencies": {
-    "@contentful/field-editor-test-utils": "^0.6.1"
+    "@contentful/field-editor-test-utils": "^0.6.2"
   },
   "peerDependencies": {
     "react": ">=16.8.0"

--- a/packages/json/package.json
+++ b/packages/json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contentful/field-editor-json",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "main": "dist/index.js",
   "module": "dist/field-editor-json.esm.js",
   "typings": "dist/index.d.ts",
@@ -19,7 +19,7 @@
     "tsc": "tsc -p ./ --noEmit"
   },
   "dependencies": {
-    "@contentful/field-editor-shared": "^0.10.1",
+    "@contentful/field-editor-shared": "^0.10.2",
     "@contentful/forma-36-react-components": "^3.36.1",
     "@contentful/forma-36-tokens": "^0.5.2",
     "@types/deep-equal": "1.0.1",
@@ -32,7 +32,7 @@
     "react-codemirror2": "6.0.0"
   },
   "devDependencies": {
-    "@contentful/field-editor-test-utils": "^0.6.1"
+    "@contentful/field-editor-test-utils": "^0.6.2"
   },
   "peerDependencies": {
     "react": ">=16.8.0"

--- a/packages/list/package.json
+++ b/packages/list/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contentful/field-editor-list",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "main": "dist/index.js",
   "module": "dist/field-editor-list.esm.js",
   "typings": "dist/index.d.ts",
@@ -21,7 +21,7 @@
     "tsc": "tsc -p ./ --noEmit"
   },
   "dependencies": {
-    "@contentful/field-editor-shared": "^0.10.1",
+    "@contentful/field-editor-shared": "^0.10.2",
     "@contentful/forma-36-react-components": "^3.36.1",
     "@contentful/forma-36-tokens": "^0.5.2",
     "emotion": "^10.0.17",
@@ -29,7 +29,7 @@
     "lodash-es": "^4.17.15"
   },
   "devDependencies": {
-    "@contentful/field-editor-test-utils": "^0.6.1"
+    "@contentful/field-editor-test-utils": "^0.6.2"
   },
   "peerDependencies": {
     "react": ">=16.8.0"

--- a/packages/location/package.json
+++ b/packages/location/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contentful/field-editor-location",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "main": "dist/index.js",
   "module": "dist/field-editor-location.esm.js",
   "typings": "dist/index.d.ts",
@@ -19,7 +19,7 @@
     "tsc": "tsc -p ./ --noEmit"
   },
   "dependencies": {
-    "@contentful/field-editor-shared": "^0.10.1",
+    "@contentful/field-editor-shared": "^0.10.2",
     "@contentful/forma-36-react-components": "^3.36.1",
     "@contentful/forma-36-tokens": "^0.5.2",
     "@types/google-map-react": "1.1.0",
@@ -30,7 +30,7 @@
     "lodash-es": "^4.17.15"
   },
   "devDependencies": {
-    "@contentful/field-editor-test-utils": "^0.6.1"
+    "@contentful/field-editor-test-utils": "^0.6.2"
   },
   "peerDependencies": {
     "react": ">=16.8.0"

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contentful/field-editor-markdown",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "main": "dist/index.js",
   "module": "dist/field-editor-markdown.esm.js",
   "typings": "dist/index.d.ts",
@@ -21,7 +21,7 @@
     "tsc": "tsc -p ./ --noEmit"
   },
   "dependencies": {
-    "@contentful/field-editor-shared": "^0.10.1",
+    "@contentful/field-editor-shared": "^0.10.2",
     "@contentful/forma-36-react-components": "^3.36.1",
     "@contentful/forma-36-tokens": "^0.5.2",
     "@types/codemirror": "0.0.81",
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.5.5",
-    "@contentful/field-editor-test-utils": "^0.6.1"
+    "@contentful/field-editor-test-utils": "^0.6.2"
   },
   "peerDependencies": {
     "react": ">=16.8.0"

--- a/packages/markdown/src/MarkdownEditor.mdx
+++ b/packages/markdown/src/MarkdownEditor.mdx
@@ -56,12 +56,13 @@ import { createFakeFieldAPI, ActionsPlayground } from '@contentful/field-editor-
         updateHeight: () => {},
         startAutoResizer: () => {}
       },
-      parameters: {
-        instance: {
-          canUploadAssets: true
-        },
-        invocation: {},
-        installation: {}
+      access: {
+        can: (access, entity) => {
+          if (access === 'create' && entity === 'Asset') {
+            return Promise.resolve(true)
+          }
+          return Promise.resolve(false)
+        }
       }
     };
 

--- a/packages/markdown/src/MarkdownEditor.tsx
+++ b/packages/markdown/src/MarkdownEditor.tsx
@@ -44,7 +44,7 @@ export function MarkdownEditor(
   const [currentValue, setCurrentValue] = React.useState<string>(props.initialValue ?? '');
   const [selectedTab, setSelectedTab] = React.useState<MarkdownTab>('editor');
   const [editor, setEditor] = React.useState<InitializedEditorType | null>(null);
-  const [canUploadAssets, canUploadAssetsSet] = React.useState<boolean>(false);
+  const [canUploadAssets, setCanUploadAssets] = React.useState<boolean>(false);
 
   React.useEffect(() => {
     if (editor && props.onReady) {
@@ -58,7 +58,7 @@ export function MarkdownEditor(
 
   React.useEffect(() => {
     props.sdk.access.can('create', 'Asset').then(value => {
-      canUploadAssetsSet(value);
+      setCanUploadAssets(value);
     });
   }, []);
 

--- a/packages/markdown/src/MarkdownEditor.tsx
+++ b/packages/markdown/src/MarkdownEditor.tsx
@@ -29,14 +29,7 @@ export interface MarkdownEditorProps {
   isInitiallyDisabled: boolean;
 
   sdk: FieldExtensionSDK;
-  /**
-   * sdk.parameters
-   */
-  parameters: {
-    instance: {
-      canUploadAssets: boolean;
-    };
-  };
+
   previewComponents?: PreviewComponents;
   onReady?: Function;
 }
@@ -51,6 +44,7 @@ export function MarkdownEditor(
   const [currentValue, setCurrentValue] = React.useState<string>(props.initialValue ?? '');
   const [selectedTab, setSelectedTab] = React.useState<MarkdownTab>('editor');
   const [editor, setEditor] = React.useState<InitializedEditorType | null>(null);
+  const [canUploadAssets, canUploadAssetsSet] = React.useState<boolean>(false);
 
   React.useEffect(() => {
     if (editor && props.onReady) {
@@ -61,6 +55,12 @@ export function MarkdownEditor(
       }, 1);
     }
   }, [editor]);
+
+  React.useEffect(() => {
+    props.sdk.access.can('create', 'Asset').then(value => {
+      canUploadAssetsSet(value);
+    });
+  }, []);
 
   React.useEffect(() => {
     if (editor) {
@@ -91,7 +91,7 @@ export function MarkdownEditor(
       <MarkdownToolbar
         mode="default"
         disabled={isActionDisabled}
-        canUploadAssets={props.parameters.instance.canUploadAssets}
+        canUploadAssets={canUploadAssets}
         actions={actions}
       />
       <MarkdownTextarea

--- a/packages/multiple-line/package.json
+++ b/packages/multiple-line/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contentful/field-editor-multiple-line",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "main": "dist/index.js",
   "module": "dist/field-editor-multiple-line.esm.js",
   "typings": "dist/index.d.ts",
@@ -21,7 +21,7 @@
     "tsc": "tsc -p ./ --noEmit"
   },
   "dependencies": {
-    "@contentful/field-editor-shared": "^0.10.1",
+    "@contentful/field-editor-shared": "^0.10.2",
     "@contentful/forma-36-react-components": "^3.36.1",
     "@contentful/forma-36-tokens": "^0.5.2",
     "emotion": "^10.0.17",
@@ -29,7 +29,7 @@
     "lodash-es": "^4.17.15"
   },
   "devDependencies": {
-    "@contentful/field-editor-test-utils": "^0.6.1"
+    "@contentful/field-editor-test-utils": "^0.6.2"
   },
   "peerDependencies": {
     "react": ">=16.8.0"

--- a/packages/number/package.json
+++ b/packages/number/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contentful/field-editor-number",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "main": "dist/index.js",
   "module": "dist/field-editor-number.esm.js",
   "typings": "dist/index.d.ts",
@@ -21,7 +21,7 @@
     "tsc": "tsc -p ./ --noEmit"
   },
   "dependencies": {
-    "@contentful/field-editor-shared": "^0.10.1",
+    "@contentful/field-editor-shared": "^0.10.2",
     "@contentful/forma-36-react-components": "^3.36.1",
     "@contentful/forma-36-tokens": "^0.5.2",
     "emotion": "^10.0.17",
@@ -29,7 +29,7 @@
     "lodash-es": "^4.17.15"
   },
   "devDependencies": {
-    "@contentful/field-editor-test-utils": "^0.6.1"
+    "@contentful/field-editor-test-utils": "^0.6.2"
   },
   "peerDependencies": {
     "react": ">=16.8.0"

--- a/packages/radio/package.json
+++ b/packages/radio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contentful/field-editor-radio",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "main": "dist/index.js",
   "module": "dist/field-editor-radio.esm.js",
   "typings": "dist/index.d.ts",
@@ -21,8 +21,8 @@
     "tsc": "tsc -p ./ --noEmit"
   },
   "dependencies": {
-    "@contentful/field-editor-dropdown": "^0.8.1",
-    "@contentful/field-editor-shared": "^0.10.1",
+    "@contentful/field-editor-dropdown": "^0.8.2",
+    "@contentful/field-editor-shared": "^0.10.2",
     "@contentful/forma-36-react-components": "^3.36.1",
     "@contentful/forma-36-tokens": "^0.5.2",
     "emotion": "^10.0.17",
@@ -31,7 +31,7 @@
     "nanoid": "^3.1.3"
   },
   "devDependencies": {
-    "@contentful/field-editor-test-utils": "^0.6.1"
+    "@contentful/field-editor-test-utils": "^0.6.2"
   },
   "peerDependencies": {
     "react": ">=16.8.0"

--- a/packages/rating/package.json
+++ b/packages/rating/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contentful/field-editor-rating",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "main": "dist/index.js",
   "module": "dist/field-editor-rating.esm.js",
   "typings": "dist/index.d.ts",
@@ -21,7 +21,7 @@
     "tsc": "tsc -p ./ --noEmit"
   },
   "dependencies": {
-    "@contentful/field-editor-shared": "^0.10.1",
+    "@contentful/field-editor-shared": "^0.10.2",
     "@contentful/forma-36-react-components": "^3.36.1",
     "@contentful/forma-36-tokens": "^0.5.2",
     "emotion": "^10.0.17",
@@ -29,7 +29,7 @@
     "lodash-es": "^4.17.15"
   },
   "devDependencies": {
-    "@contentful/field-editor-test-utils": "^0.6.1"
+    "@contentful/field-editor-test-utils": "^0.6.2"
   },
   "peerDependencies": {
     "react": ">=16.8.0"

--- a/packages/reference/package.json
+++ b/packages/reference/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contentful/field-editor-reference",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "main": "dist/index.js",
   "module": "dist/field-editor-reference.esm.js",
   "typings": "dist/index.d.ts",
@@ -21,7 +21,7 @@
     "tsc": "tsc -p ./ --noEmit"
   },
   "dependencies": {
-    "@contentful/field-editor-shared": "^0.10.1",
+    "@contentful/field-editor-shared": "^0.10.2",
     "@contentful/forma-36-react-components": "^3.36.1",
     "@contentful/forma-36-tokens": "^0.5.1",
     "@contentful/mimetype": "^1.1.4",
@@ -36,7 +36,7 @@
     "react-sortable-hoc": "^1.11.0"
   },
   "devDependencies": {
-    "@contentful/field-editor-test-utils": "^0.6.1"
+    "@contentful/field-editor-test-utils": "^0.6.2"
   },
   "peerDependencies": {
     "react": ">=16.8.0"

--- a/packages/reference/src/assets/MultipleMediaEditor.mdx
+++ b/packages/reference/src/assets/MultipleMediaEditor.mdx
@@ -80,11 +80,11 @@ import changedAsset from '../__fixtures__/changed_asset.json';
         onSlideInNavigation: () => () => {}
       },
       access: {
-        can: async (access, entityType) => {
+        can: (access, entityType) => {
           if (access === 'create' && entityType === 'Asset') {
-            return true;
+            return Promise.resolve(true);
           }
-          return false;
+          return Promise.resolve(false);
         }
       }
     };

--- a/packages/reference/src/assets/MultipleMediaEditor.mdx
+++ b/packages/reference/src/assets/MultipleMediaEditor.mdx
@@ -80,11 +80,11 @@ import changedAsset from '../__fixtures__/changed_asset.json';
         onSlideInNavigation: () => () => {}
       },
       access: {
-        can: (access, entityType) => {
+        can: async (access, entityType) => {
           if (access === 'create' && entityType === 'Asset') {
-            return Promise.resolve(true);
+            return true;
           }
-          return Promise.resolve(false);
+          return false;
         }
       }
     };

--- a/packages/reference/src/assets/MultipleMediaEditor.mdx
+++ b/packages/reference/src/assets/MultipleMediaEditor.mdx
@@ -78,6 +78,14 @@ import changedAsset from '../__fixtures__/changed_asset.json';
           return Promise.resolve({});
         },
         onSlideInNavigation: () => () => {}
+      },
+      access: {
+        can: (access, entityType) => {
+          if (access === 'create' && entityType === 'Asset') {
+            return Promise.resolve(true);
+          }
+          return Promise.resolve(false);
+        }
       }
     };
     return (

--- a/packages/reference/src/assets/SingleMediaEditor.mdx
+++ b/packages/reference/src/assets/SingleMediaEditor.mdx
@@ -69,11 +69,11 @@ import publishedAsset from '../__fixtures__/published_asset.json';
         onSlideInNavigation: () => () => {}
       },
       access: {
-        can: (access, entityType) => {
+        can: async (access, entityType) => {
           if (access === 'create' && entityType === 'Asset') {
-            return Promise.resolve(true);
+            return true;
           }
-          return Promise.resolve(false);
+          return false;
         }
       }
     };

--- a/packages/reference/src/assets/SingleMediaEditor.mdx
+++ b/packages/reference/src/assets/SingleMediaEditor.mdx
@@ -67,6 +67,14 @@ import publishedAsset from '../__fixtures__/published_asset.json';
           return Promise.resolve({});
         },
         onSlideInNavigation: () => () => {}
+      },
+      access: {
+        can: (access, entityType) => {
+          if (access === 'create' && entityType === 'Asset') {
+            return Promise.resolve(true);
+          }
+          return Promise.resolve(false);
+        }
       }
     };
     return (

--- a/packages/reference/src/assets/SingleMediaEditor.mdx
+++ b/packages/reference/src/assets/SingleMediaEditor.mdx
@@ -71,9 +71,9 @@ import publishedAsset from '../__fixtures__/published_asset.json';
       access: {
         can: async (access, entityType) => {
           if (access === 'create' && entityType === 'Asset') {
-            return true;
+            return Promise.resolve(true);
           }
-          return false;
+          return Promise.resolve(false);
         }
       }
     };

--- a/packages/reference/src/common/MultipleReferenceEditor.tsx
+++ b/packages/reference/src/common/MultipleReferenceEditor.tsx
@@ -16,12 +16,45 @@ type ChildProps = {
   onSortEnd: SortEndHandler;
 };
 
-class Editor extends React.Component<
-  ReferenceEditorProps &
-    Omit<ChildProps, 'onSortStart' | 'onSortEnd'> & {
-      children: (props: ReferenceEditorProps & ChildProps) => React.ReactElement;
+type EditorProps = ReferenceEditorProps &
+  Omit<ChildProps, 'onSortStart' | 'onSortEnd'> & {
+    children: (props: ReferenceEditorProps & ChildProps) => React.ReactElement;
+  };
+
+type EditorState = {
+  canCreateEntity: boolean;
+};
+
+class Editor extends React.Component<EditorProps, EditorState> {
+  constructor(props: EditorProps) {
+    super(props);
+    this.state = {
+      canCreateEntity: true
+    };
+  }
+
+  componentDidMount() {
+    if (this.props.entityType === 'Asset') {
+      this.props.sdk.access.can('create', 'Asset').then(value => {
+        this.setState({ canCreateEntity: value });
+      });
     }
-> {
+  }
+
+  canCreateEntity = () => {
+    if (this.props.parameters.instance.canCreateEntity === false) {
+      return false;
+    }
+    return this.state.canCreateEntity;
+  };
+
+  canLinkEntity = () => {
+    if (this.props.parameters.instance.canLinkEntity !== undefined) {
+      return this.props.parameters.instance.canLinkEntity;
+    }
+    return true;
+  };
+
   onSortStart: SortStartHandler = (_, event) => event.preventDefault();
 
   onSortEnd: SortEndHandler = ({ oldIndex, newIndex }) => {
@@ -77,8 +110,8 @@ class Editor extends React.Component<
           sdk={this.props.sdk}
           isDisabled={this.props.isDisabled}
           multiple={true}
-          canCreateEntity={this.props.parameters.instance.canCreateEntity ?? true}
-          canLinkEntity={this.props.parameters.instance.canLinkEntity ?? true}
+          canCreateEntity={this.canCreateEntity()}
+          canLinkEntity={this.canLinkEntity()}
           onCreate={this.onCreate}
           onLink={this.onLink}
           onAction={this.props.onAction}

--- a/packages/reference/src/common/SingleReferenceEditor.tsx
+++ b/packages/reference/src/common/SingleReferenceEditor.tsx
@@ -12,12 +12,45 @@ type ChildProps = {
   allContentTypes: ContentType[];
 };
 
-class Editor extends React.Component<
-  ReferenceEditorProps &
-    ChildProps & {
-      children: (props: ReferenceEditorProps & ChildProps) => React.ReactElement;
+type EditorProps = ReferenceEditorProps &
+  ChildProps & {
+    children: (props: ReferenceEditorProps & ChildProps) => React.ReactElement;
+  };
+
+type EditorState = {
+  canCreateEntity: boolean;
+};
+
+class Editor extends React.Component<EditorProps, EditorState> {
+  constructor(props: EditorProps) {
+    super(props);
+    this.state = {
+      canCreateEntity: true
+    };
+  }
+
+  componentDidMount() {
+    if (this.props.entityType === 'Asset') {
+      this.props.sdk.access.can('create', 'Asset').then(value => {
+        this.setState({ canCreateEntity: value });
+      });
     }
-> {
+  }
+
+  canCreateEntity = () => {
+    if (this.props.parameters.instance.canCreateEntity === false) {
+      return false;
+    }
+    return this.state.canCreateEntity;
+  };
+
+  canLinkEntity = () => {
+    if (this.props.parameters.instance.canLinkEntity !== undefined) {
+      return this.props.parameters.instance.canLinkEntity;
+    }
+    return true;
+  };
+
   onCreate = (id: string) => {
     this.props.setValue({
       sys: {
@@ -50,8 +83,8 @@ class Editor extends React.Component<
           sdk={this.props.sdk}
           isDisabled={this.props.isDisabled}
           multiple={false}
-          canCreateEntity={this.props.parameters.instance.canCreateEntity ?? true}
-          canLinkEntity={this.props.parameters.instance.canLinkEntity ?? true}
+          canCreateEntity={this.canCreateEntity()}
+          canLinkEntity={this.canLinkEntity()}
           onCreate={this.onCreate}
           onLink={this.onLink}
           onAction={this.props.onAction}

--- a/packages/rich-text/package.json
+++ b/packages/rich-text/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contentful/field-editor-rich-text",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "source": "./src/index.tsx",
   "main": "./dist/index.js",
   "module": "dist/field-editor-rich-text.esm.js",
@@ -24,9 +24,9 @@
   },
   "dependencies": {
     "@contentful/contentful-slatejs-adapter": "^14.1.0",
-    "@contentful/field-editor-reference": "^0.7.1",
-    "@contentful/field-editor-shared": "^0.10.1",
-    "@contentful/field-editor-test-utils": "^0.6.1",
+    "@contentful/field-editor-reference": "^0.7.2",
+    "@contentful/field-editor-shared": "^0.10.2",
+    "@contentful/field-editor-test-utils": "^0.6.2",
     "@contentful/forma-36-react-components": "^3.36.1",
     "@contentful/forma-36-tokens": "^0.5.2",
     "@contentful/rich-text-plain-text-renderer": "^14.0.0",

--- a/packages/rich-text/src/RichTextEditor.jsx
+++ b/packages/rich-text/src/RichTextEditor.jsx
@@ -93,17 +93,15 @@ export class ConnectedRichTextEditor extends React.Component {
         id: PropTypes.string.isRequired,
         locale: PropTypes.string.isRequired
       }).isRequired,
+      access: PropTypes.shape({
+        can: PropTypes.func.isRequired
+      }).isRequired,
       parameters: PropTypes.shape({
         instance: PropTypes.shape({
           getEntryUrl: PropTypes.func,
-          getAssetUrl: PropTypes.func,
-          permissions: PropTypes.shape({
-            canAccessAssets: PropTypes.bool.isRequired,
-            canCreateAssets: PropTypes.bool.isRequired,
-            canCreateEntryOfContentType: PropTypes.func.isRequired
-          })
-        })
-      }).isRequired
+          getAssetUrl: PropTypes.func
+        }).isRequired
+      })
     }).isRequired,
     value: PropTypes.object,
     isDisabled: PropTypes.bool,
@@ -124,6 +122,7 @@ export class ConnectedRichTextEditor extends React.Component {
 
   state = {
     lastOperations: List(),
+    canAccessAssets: false,
     value:
       this.props.value && this.props.value.nodeType === BLOCKS.DOCUMENT
         ? createSlateValue(this.props.value)
@@ -138,6 +137,12 @@ export class ConnectedRichTextEditor extends React.Component {
   });
 
   slatePlugins = buildPlugins(this.richTextAPI);
+
+  componentDidMount() {
+    this.props.sdk.access.can('read', 'Asset').then(canReadAssets => {
+      this.setState({ canAccessAssets: canReadAssets });
+    });
+  }
 
   onChange = editor => {
     const { value, operations } = editor;
@@ -204,7 +209,7 @@ export class ConnectedRichTextEditor extends React.Component {
               editor={this.editor.current || new BasicEditor({ readOnly: true })}
               onChange={this.onChange}
               isDisabled={this.props.isDisabled}
-              permissions={this.props.sdk.parameters.instance.permissions}
+              canAccessAssets={this.state.canAccessAssets}
               richTextAPI={this.richTextAPI}
             />
           </StickyToolbarWrapper>

--- a/packages/rich-text/src/RichTextEditor.mdx
+++ b/packages/rich-text/src/RichTextEditor.mdx
@@ -69,20 +69,22 @@ import publishedAsset from '../../reference/src/__fixtures__/published_asset.jso
           return () => {};
         }
       },
-      parameters: {
-        instance: {
-          permissions: {
-            canAccessAssets: true,
-            canCreateAssets: false,
-            canCreateEntryOfContentType: contentTypeId => {
-              return contentTypeId === 'exampleCT';
-            }
-          }
-        }
-      },
       dialogs: {
         selectSingleAsset: newEntitySelectorDummyDialog('selectSingleAsset', 'Asset'),
         selectSingleEntry: newEntitySelectorDummyDialog('selectSingleEntry', 'Entry')
+      },
+      access: {
+        can: (access, entityType) => {
+          if (entityType === 'Asset') {
+            if (access === 'create') {
+              return Promise.resolve(false);
+            }
+            if (access === 'read') {
+              return Promise.resolve(true);
+            }
+          }
+          return Promise.resolve(false);
+        }
       }
     };
 

--- a/packages/rich-text/src/RichTextEditor.mdx
+++ b/packages/rich-text/src/RichTextEditor.mdx
@@ -74,16 +74,16 @@ import publishedAsset from '../../reference/src/__fixtures__/published_asset.jso
         selectSingleEntry: newEntitySelectorDummyDialog('selectSingleEntry', 'Entry')
       },
       access: {
-        can: (access, entityType) => {
+        can: async (access, entityType) => {
           if (entityType === 'Asset') {
             if (access === 'create') {
-              return Promise.resolve(false);
+              return false;
             }
             if (access === 'read') {
-              return Promise.resolve(true);
+              return true;
             }
           }
-          return Promise.resolve(false);
+          return false;
         }
       }
     };

--- a/packages/rich-text/src/RichTextEditor.mdx
+++ b/packages/rich-text/src/RichTextEditor.mdx
@@ -126,17 +126,7 @@ init(sdk => {
   } else if (sdk.location.is(locations.LOCATION_ENTRY_FIELD)) {
     render(
       <RichTextEditor
-        sdk={Object.assign(sdk, {
-          parameters: {
-            instance: {
-              permissions: {
-                canAccessAssets: true,
-                canCreateAssets: true,
-                canCreateEntryOfContentType: () => true
-              }
-            }
-          }
-        })}
+        sdk={sdk}
       />,
       document.getElementById('root')
     );

--- a/packages/rich-text/src/RichTextEditor.mdx
+++ b/packages/rich-text/src/RichTextEditor.mdx
@@ -74,16 +74,16 @@ import publishedAsset from '../../reference/src/__fixtures__/published_asset.jso
         selectSingleEntry: newEntitySelectorDummyDialog('selectSingleEntry', 'Entry')
       },
       access: {
-        can: async (access, entityType) => {
+        can: (access, entityType) => {
           if (entityType === 'Asset') {
             if (access === 'create') {
-              return false;
+              return Promise.resolve(false);
             }
             if (access === 'read') {
-              return true;
+              return Promise.resolve(true);
             }
           }
-          return false;
+          return Promise.resolve(false);
         }
       }
     };

--- a/packages/rich-text/src/RichTextEditor.spec.js
+++ b/packages/rich-text/src/RichTextEditor.spec.js
@@ -18,13 +18,17 @@ const fakeProps = props => ({
       id: 'FIELD_ID,',
       locale: 'FIELD_LOCALE'
     },
-    parameters: {
-      instance: {
-        permissions: {
-          canAccessAssets: true,
-          canCreateAssets: true,
-          canCreateEntryOfContentType: () => false
+    access: {
+      can: (access, entityType) => {
+        if (entityType === 'Asset') {
+          if (access === 'create') {
+            return Promise.resolve(true);
+          }
+          if (access === 'read') {
+            return Promise.resolve(true);
+          }
         }
+        return Promise.resolve(false);
       }
     }
   },

--- a/packages/rich-text/src/RichTextEditor.spec.js
+++ b/packages/rich-text/src/RichTextEditor.spec.js
@@ -19,16 +19,16 @@ const fakeProps = props => ({
       locale: 'FIELD_LOCALE'
     },
     access: {
-      can: (access, entityType) => {
+      can: async (access, entityType) => {
         if (entityType === 'Asset') {
           if (access === 'create') {
-            return Promise.resolve(true);
+            return true;
           }
           if (access === 'read') {
-            return Promise.resolve(true);
+            return true;
           }
         }
-        return Promise.resolve(false);
+        return false;
       }
     }
   },

--- a/packages/rich-text/src/Toolbar/Toolbar.spec.js
+++ b/packages/rich-text/src/Toolbar/Toolbar.spec.js
@@ -12,6 +12,7 @@ const fakeProps = () => ({
   isDisabled: false,
   editor: new Editor(),
   onChange: jest.fn(),
+  canAccessAssets: true,
   richTextAPI: {
     logToolbarAction: jest.fn(),
     logShortcutAction: jest.fn(),
@@ -19,9 +20,6 @@ const fakeProps = () => ({
     sdk: {
       field: {}
     }
-  },
-  permissions: {
-    canAccessAssets: true
   }
 });
 
@@ -154,7 +152,7 @@ describe('Toolbar', () => {
 
   it(`hides the ${BLOCKS.EMBEDDED_ASSET} dropdown option when the user has no asset access permissions`, () => {
     const props = fakeProps();
-    props.permissions.canAccessAssets = false;
+    props.canAccessAssets = false;
     props.richTextAPI.sdk.field.validations = [
       { [VALIDATIONS.ENABLED_NODE_TYPES]: VALIDATABLE_NODE_TYPES }
     ];

--- a/packages/rich-text/src/Toolbar/index.js
+++ b/packages/rich-text/src/Toolbar/index.js
@@ -58,9 +58,7 @@ export default class Toolbar extends React.Component {
     isDisabled: PropTypes.bool.isRequired,
     editor: PropTypes.object.isRequired,
     onChange: PropTypes.func.isRequired,
-    permissions: PropTypes.shape({
-      canAccessAssets: PropTypes.bool.isRequired
-    }).isRequired
+    canAccessAssets: PropTypes.bool.isRequired
   };
 
   state = {
@@ -89,7 +87,7 @@ export default class Toolbar extends React.Component {
     const inlineEntryEmbedEnabled = isNodeTypeEnabled(field, INLINES.EMBEDDED_ENTRY);
     const blockEntryEmbedEnabled = isNodeTypeEnabled(field, BLOCKS.EMBEDDED_ENTRY);
     const blockAssetEmbedEnabled =
-      this.props.permissions.canAccessAssets && isNodeTypeEnabled(field, BLOCKS.EMBEDDED_ASSET);
+      this.props.canAccessAssets && isNodeTypeEnabled(field, BLOCKS.EMBEDDED_ASSET);
 
     const numEnabledEmbeds = [
       inlineEntryEmbedEnabled,

--- a/packages/rich-text/src/plugins/CommandPalette/CommandPaletteService.js
+++ b/packages/rich-text/src/plugins/CommandPalette/CommandPaletteService.js
@@ -115,9 +115,9 @@ export class CommandPaletteActionBuilder {
         return false;
       }
 
-      const canCreateContentType = await this.sdk.access.can('create', contentType);
+      const canCreateEntryOfContentType = await this.sdk.access.can('create', contentType);
 
-      if (canCreateContentType === false) {
+      if (canCreateEntryOfContentType === false) {
         return false;
       }
     } else {

--- a/packages/rich-text/src/plugins/CommandPalette/CommandPaletteService.js
+++ b/packages/rich-text/src/plugins/CommandPalette/CommandPaletteService.js
@@ -115,7 +115,14 @@ export class CommandPaletteActionBuilder {
         return false;
       }
 
-      const canCreateEntryOfContentType = await this.sdk.access.can('create', contentType);
+      const canCreateEntryOfContentType = await this.sdk.access.can('create', {
+        sys: {
+          type: 'Entry',
+          contentType: {
+            sys: contentType.sys
+          }
+        }
+      });
 
       if (canCreateEntryOfContentType === false) {
         return false;

--- a/packages/single-line/package.json
+++ b/packages/single-line/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contentful/field-editor-single-line",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "main": "dist/index.js",
   "module": "dist/field-editor-single-line.esm.js",
   "typings": "dist/index.d.ts",
@@ -21,7 +21,7 @@
     "tsc": "tsc -p ./ --noEmit"
   },
   "dependencies": {
-    "@contentful/field-editor-shared": "^0.10.1",
+    "@contentful/field-editor-shared": "^0.10.2",
     "@contentful/forma-36-react-components": "^3.36.1",
     "@contentful/forma-36-tokens": "^0.5.1",
     "emotion": "^10.0.17",
@@ -29,7 +29,7 @@
     "lodash-es": "^4.17.15"
   },
   "devDependencies": {
-    "@contentful/field-editor-test-utils": "^0.6.1"
+    "@contentful/field-editor-test-utils": "^0.6.2"
   },
   "peerDependencies": {
     "react": ">=16.8.0"

--- a/packages/slug/package.json
+++ b/packages/slug/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contentful/field-editor-slug",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "main": "dist/index.js",
   "module": "dist/field-editor-slug.esm.js",
   "typings": "dist/index.d.ts",
@@ -21,7 +21,7 @@
     "tsc": "tsc -p ./ --noEmit"
   },
   "dependencies": {
-    "@contentful/field-editor-shared": "^0.10.1",
+    "@contentful/field-editor-shared": "^0.10.2",
     "@contentful/forma-36-react-components": "^3.36.1",
     "@contentful/forma-36-tokens": "^0.5.1",
     "@types/speakingurl": "^13.0.2",
@@ -31,7 +31,7 @@
     "speakingurl": "^13.0.0"
   },
   "devDependencies": {
-    "@contentful/field-editor-test-utils": "^0.6.1"
+    "@contentful/field-editor-test-utils": "^0.6.2"
   },
   "peerDependencies": {
     "react": ">=16.8.0"

--- a/packages/tags/package.json
+++ b/packages/tags/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contentful/field-editor-tags",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "main": "dist/index.js",
   "module": "dist/field-editor-tags.esm.js",
   "typings": "dist/index.d.ts",
@@ -21,7 +21,7 @@
     "tsc": "tsc -p ./ --noEmit"
   },
   "dependencies": {
-    "@contentful/field-editor-shared": "^0.10.1",
+    "@contentful/field-editor-shared": "^0.10.2",
     "@contentful/forma-36-react-components": "^3.36.1",
     "@contentful/forma-36-tokens": "^0.5.2",
     "array-move": "^2.2.1",
@@ -31,7 +31,7 @@
     "react-sortable-hoc": "^1.11.0"
   },
   "devDependencies": {
-    "@contentful/field-editor-test-utils": "^0.6.1"
+    "@contentful/field-editor-test-utils": "^0.6.2"
   },
   "peerDependencies": {
     "react": ">=16.8.0"

--- a/packages/url/package.json
+++ b/packages/url/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contentful/field-editor-url",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "main": "dist/index.js",
   "module": "dist/field-editor-url.esm.js",
   "typings": "dist/index.d.ts",
@@ -21,7 +21,7 @@
     "tsc": "tsc -p ./ --noEmit"
   },
   "dependencies": {
-    "@contentful/field-editor-shared": "^0.10.1",
+    "@contentful/field-editor-shared": "^0.10.2",
     "@contentful/forma-36-react-components": "^3.36.1",
     "@contentful/forma-36-tokens": "^0.5.2",
     "emotion": "^10.0.17",
@@ -29,7 +29,7 @@
     "lodash-es": "^4.17.15"
   },
   "devDependencies": {
-    "@contentful/field-editor-test-utils": "^0.6.1"
+    "@contentful/field-editor-test-utils": "^0.6.2"
   },
   "peerDependencies": {
     "react": ">=16.8.0"


### PR DESCRIPTION
Use new `sdk.access.can` methods for all field-editors to read permissions.

