### PR TITLE
refactor: [slug-editor] Expose makeSlug function

### DIFF
--- a/packages/slug/src/index.tsx
+++ b/packages/slug/src/index.tsx
@@ -1,2 +1,3 @@
 export { SlugEditor } from './SlugEditor';
 export { slugify } from './services/slugify';
+export { makeSlug } from './services/makeSlug';


### PR DESCRIPTION
Expose makeSlug function for slugEditor, to be able to re-use the functionality of making slug out of a string with a fallback to default date-based slug