### PR TITLE
feat: rename reference initialization params

### DIFF
--- a/extensions/entry-extension-collapsible/src/Field.tsx
+++ b/extensions/entry-extension-collapsible/src/Field.tsx
@@ -210,7 +210,9 @@ export const Field: React.FC<FieldProps> = ({ field, locales }: FieldProps) => {
             name={fieldDetails.name}
             required={fieldDetails.required}>
             <SingleEntryReferenceEditor
-              parameters={{ instance: { canCreateEntity: true, canLinkEntity: true } }}
+              parameters={{
+                instance: { showCreateEntityAction: true, showLinkEntityAction: true }
+              }}
               viewType="link"
               sdk={fieldSdk}
             />
@@ -229,7 +231,9 @@ export const Field: React.FC<FieldProps> = ({ field, locales }: FieldProps) => {
             name={fieldDetails.name}
             required={fieldDetails.required}>
             <SingleEntryReferenceEditor
-              parameters={{ instance: { canCreateEntity: true, canLinkEntity: true } }}
+              parameters={{
+                instance: { showCreateEntityAction: true, showLinkEntityAction: true }
+              }}
               viewType="card"
               sdk={fieldSdk}
             />
@@ -249,7 +253,9 @@ export const Field: React.FC<FieldProps> = ({ field, locales }: FieldProps) => {
             required={fieldDetails.required}>
             <MultipleEntryReferenceEditor
               isInitiallyDisabled={false}
-              parameters={{ instance: { canCreateEntity: true, canLinkEntity: true } }}
+              parameters={{
+                instance: { showCreateEntityAction: true, showLinkEntityAction: true }
+              }}
               viewType="link"
               sdk={fieldSdk}
             />
@@ -269,7 +275,9 @@ export const Field: React.FC<FieldProps> = ({ field, locales }: FieldProps) => {
             required={fieldDetails.required}>
             <MultipleEntryReferenceEditor
               isInitiallyDisabled={false}
-              parameters={{ instance: { canCreateEntity: true, canLinkEntity: true } }}
+              parameters={{
+                instance: { showCreateEntityAction: true, showLinkEntityAction: true }
+              }}
               viewType="card"
               sdk={fieldSdk}
             />
@@ -288,7 +296,9 @@ export const Field: React.FC<FieldProps> = ({ field, locales }: FieldProps) => {
             name={fieldDetails.name}
             required={fieldDetails.required}>
             <SingleMediaEditor
-              parameters={{ instance: { canCreateEntity: true, canLinkEntity: true } }}
+              parameters={{
+                instance: { showCreateEntityAction: true, showLinkEntityAction: true }
+              }}
               viewType="link"
               sdk={fieldSdk}
             />
@@ -307,7 +317,9 @@ export const Field: React.FC<FieldProps> = ({ field, locales }: FieldProps) => {
             name={fieldDetails.name}
             required={fieldDetails.required}>
             <MultipleMediaEditor
-              parameters={{ instance: { canCreateEntity: true, canLinkEntity: true } }}
+              parameters={{
+                instance: { showCreateEntityAction: true, showLinkEntityAction: true }
+              }}
               viewType="link"
               sdk={fieldSdk}
             />
@@ -326,7 +338,9 @@ export const Field: React.FC<FieldProps> = ({ field, locales }: FieldProps) => {
             name={fieldDetails.name}
             required={fieldDetails.required}>
             <MultipleMediaEditor
-              parameters={{ instance: { canCreateEntity: true, canLinkEntity: true } }}
+              parameters={{
+                instance: { showCreateEntityAction: true, showLinkEntityAction: true }
+              }}
               viewType="card"
               sdk={fieldSdk}
             />

--- a/extensions/markdown-extension/src/index.tsx
+++ b/extensions/markdown-extension/src/index.tsx
@@ -1,11 +1,6 @@
 import * as React from 'react';
 import { render } from 'react-dom';
-import {
-  init,
-  locations,
-  FieldExtensionSDK,
-  DialogExtensionSDK
-} from 'contentful-ui-extensions-sdk';
+import { init, locations, FieldExtensionSDK } from 'contentful-ui-extensions-sdk';
 import '@contentful/forma-36-react-components/dist/styles.css';
 import '@contentful/forma-36-fcss/dist/styles.css';
 import './index.css';
@@ -26,8 +21,7 @@ export class App extends React.Component<AppProps> {
 init((sdk: FieldExtensionSDK) => {
   sdk.window.startAutoResizer();
   if (sdk.location.is(locations.LOCATION_DIALOG)) {
-    const dialogSdk = sdk as DialogExtensionSDK;
-    render(renderMarkdownDialog(dialogSdk as any), document.getElementById('root'));
+    render(renderMarkdownDialog(sdk as any), document.getElementById('root'));
   } else {
     render(<App sdk={sdk as FieldExtensionSDK} />, document.getElementById('root'));
   }

--- a/extensions/multiple-references-extension/src/index.tsx
+++ b/extensions/multiple-references-extension/src/index.tsx
@@ -18,8 +18,8 @@ init<FieldExtensionSDK>(sdk => {
         isInitiallyDisabled={true}
         parameters={{
           instance: {
-            canCreateEntity: true,
-            canLinkEntity: true
+            showCreateEntityAction: true,
+            showLinkEntityAction: true
           }
         }}
       />

--- a/packages/reference/src/common/MultipleReferenceEditor.tsx
+++ b/packages/reference/src/common/MultipleReferenceEditor.tsx
@@ -42,15 +42,15 @@ class Editor extends React.Component<EditorProps, EditorState> {
   }
 
   canCreateEntity = () => {
-    if (this.props.parameters.instance.canCreateEntity === false) {
+    if (this.props.parameters.instance.showCreateEntityAction === false) {
       return false;
     }
     return this.state.canCreateEntity;
   };
 
   canLinkEntity = () => {
-    if (this.props.parameters.instance.canLinkEntity !== undefined) {
-      return this.props.parameters.instance.canLinkEntity;
+    if (this.props.parameters.instance.showLinkEntityAction !== undefined) {
+      return this.props.parameters.instance.showLinkEntityAction;
     }
     return true;
   };

--- a/packages/reference/src/common/ReferenceEditor.tsx
+++ b/packages/reference/src/common/ReferenceEditor.tsx
@@ -20,8 +20,8 @@ export interface ReferenceEditorProps {
 
   parameters: {
     instance: {
-      canCreateEntity?: boolean;
-      canLinkEntity?: boolean;
+      showCreateEntityAction?: boolean;
+      showLinkEntityAction?: boolean;
       bulkEditing?: boolean;
     };
   };

--- a/packages/reference/src/common/SingleReferenceEditor.tsx
+++ b/packages/reference/src/common/SingleReferenceEditor.tsx
@@ -38,15 +38,15 @@ class Editor extends React.Component<EditorProps, EditorState> {
   }
 
   canCreateEntity = () => {
-    if (this.props.parameters.instance.canCreateEntity === false) {
+    if (this.props.parameters.instance.showCreateEntityAction === false) {
       return false;
     }
     return this.state.canCreateEntity;
   };
 
   canLinkEntity = () => {
-    if (this.props.parameters.instance.canLinkEntity !== undefined) {
-      return this.props.parameters.instance.canLinkEntity;
+    if (this.props.parameters.instance.showLinkEntityAction !== undefined) {
+      return this.props.parameters.instance.showLinkEntityAction;
     }
     return true;
   };


### PR DESCRIPTION
Renames `canCreateEntity` and `canLinkEntity` to `showCreateEntityAction` and `showLinkEntityAction` correspondingly.

1. After we introduced `sdk.access` methods the actual permissions check happens within field editors and these params control only visibility of the buttons.

2. We plan to expose these settings to be controlled from Appearance tab in the Web app.