### PR TITLE
ci: enable dependabot automerges

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -9,3 +9,10 @@ update_configs:
       - 'dependabot'
     commit_message:
       prefix: 'chore'
+    automerged_updates:
+      - match:
+          dependency_type: 'development'
+          update_type: 'semver:minor'
+      - match:
+          dependency_type: 'production'
+          update_type: 'semver:patch'

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -1,0 +1,12 @@
+name: Auto approve
+
+on: pull_request
+
+jobs:
+  auto-approve:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: hmarr/auto-approve-action@v2.0.0
+        if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
+        with:
+          github-token: '${{ secrets.GITHUB_TOKEN }}'


### PR DESCRIPTION
To reduce a number of dependabot requests to approve