### PR TITLE
fix: use dialogs.openCurrent to open dialogs

### DIFF
--- a/extensions/entry-extension-collapsible/package.json
+++ b/extensions/entry-extension-collapsible/package.json
@@ -33,7 +33,7 @@
     "@contentful/forma-36-fcss": "^0.0.35",
     "@contentful/forma-36-react-components": "^3.36.1",
     "@contentful/forma-36-tokens": "^0.5.2",
-    "contentful-ui-extensions-sdk": "^3.14.3",
+    "contentful-ui-extensions-sdk": "^3.15.0",
     "emotion": "^10.0.17",
     "prop-types": "^15.7.2",
     "react": "^16.8.6",

--- a/extensions/markdown-extension/package.json
+++ b/extensions/markdown-extension/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@contentful/forma-36-fcss": "^0.0.35",
     "@contentful/forma-36-react-components": "^3.36.1",
-    "contentful-ui-extensions-sdk": "^3.14.3",
+    "contentful-ui-extensions-sdk": "^3.15.0",
     "prop-types": "^15.7.2",
     "react": "^16.8.6",
     "react-dom": "^16.8.6"

--- a/extensions/multiple-references-extension/package.json
+++ b/extensions/multiple-references-extension/package.json
@@ -14,7 +14,7 @@
     "@contentful/forma-36-fcss": "^0.0.34",
     "@contentful/forma-36-react-components": "^3.28.21",
     "@contentful/forma-36-tokens": "^0.5.2",
-    "contentful-ui-extensions-sdk": "^3.14.3",
+    "contentful-ui-extensions-sdk": "^3.15.0",
     "prop-types": "^15.7.2",
     "react": "^16.12.0",
     "react-dom": "^16.12.0"

--- a/extensions/rich-text-extension/package.json
+++ b/extensions/rich-text-extension/package.json
@@ -32,7 +32,7 @@
     "@contentful/forma-36-fcss": "^0.0.35",
     "@contentful/forma-36-react-components": "^3.36.1",
     "@contentful/forma-36-tokens": "^0.5.2",
-    "contentful-ui-extensions-sdk": "^3.14.3",
+    "contentful-ui-extensions-sdk": "^3.15.0",
     "prop-types": "^15.7.2",
     "react": "^16.8.6",
     "react-dom": "^16.8.6"

--- a/extensions/singleline-extension/package.json
+++ b/extensions/singleline-extension/package.json
@@ -32,7 +32,7 @@
     "@contentful/forma-36-fcss": "^0.0.35",
     "@contentful/forma-36-react-components": "^3.36.1",
     "@contentful/forma-36-tokens": "^0.5.2",
-    "contentful-ui-extensions-sdk": "^3.14.3",
+    "contentful-ui-extensions-sdk": "^3.15.0",
     "prop-types": "^15.7.2",
     "react": "^16.8.6",
     "react-dom": "^16.8.6"

--- a/packages/_shared/package.json
+++ b/packages/_shared/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@contentful/forma-36-tokens": "^0.5.1",
-    "contentful-ui-extensions-sdk": "^3.14.3",
+    "contentful-ui-extensions-sdk": "^3.15.0",
     "emotion": "^10.0.17",
     "lodash": "^4.17.15",
     "lodash-es": "^4.17.15"

--- a/packages/_test/package.json
+++ b/packages/_test/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@contentful/field-editor-shared": "^0.10.3",
     "@contentful/forma-36-tokens": "^0.5.2",
-    "contentful-ui-extensions-sdk": "^3.14.3",
+    "contentful-ui-extensions-sdk": "^3.15.0",
     "emotion": "^10.0.17",
     "lodash": "^4.17.15",
     "lodash-es": "^4.17.15",

--- a/packages/markdown/src/MarkdownEditor.mdx
+++ b/packages/markdown/src/MarkdownEditor.mdx
@@ -38,7 +38,7 @@ import { createFakeFieldAPI, ActionsPlayground } from '@contentful/field-editor-
         }
       },
       dialogs: {
-        openExtension: openMarkdownDialog(sdk),
+        openCurrent: openMarkdownDialog(sdk),
         selectMultipleAssets: () => {
           alert('select multiple assets dialog')
         }

--- a/packages/markdown/src/dialogs/CheatsheetModalDialog.tsx
+++ b/packages/markdown/src/dialogs/CheatsheetModalDialog.tsx
@@ -148,7 +148,7 @@ export const CheatsheetModalDialog = () => {
 };
 
 export const openCheatsheetModal = (dialogs: DialogsAPI): Promise<void> => {
-  return dialogs.openExtension({
+  return dialogs.openDialog({
     title: 'Markdown formatting help',
     width: 'large',
     minHeight: '425px',

--- a/packages/markdown/src/dialogs/CheatsheetModalDialog.tsx
+++ b/packages/markdown/src/dialogs/CheatsheetModalDialog.tsx
@@ -148,7 +148,7 @@ export const CheatsheetModalDialog = () => {
 };
 
 export const openCheatsheetModal = (dialogs: DialogsAPI): Promise<void> => {
-  return dialogs.openDialog({
+  return dialogs.openCurrent({
     title: 'Markdown formatting help',
     width: 'large',
     minHeight: '425px',

--- a/packages/markdown/src/dialogs/ConfirmInsertAssetModalDialog.tsx
+++ b/packages/markdown/src/dialogs/ConfirmInsertAssetModalDialog.tsx
@@ -88,7 +88,7 @@ export const openConfirmInsertAsset = (
     }>;
   }
 ): Promise<boolean> => {
-  return dialogs.openDialog({
+  return dialogs.openCurrent({
     title: 'Confirm using fallback assets',
     width: 'medium',
     minHeight: '290px',

--- a/packages/markdown/src/dialogs/ConfirmInsertAssetModalDialog.tsx
+++ b/packages/markdown/src/dialogs/ConfirmInsertAssetModalDialog.tsx
@@ -88,7 +88,7 @@ export const openConfirmInsertAsset = (
     }>;
   }
 ): Promise<boolean> => {
-  return dialogs.openExtension({
+  return dialogs.openDialog({
     title: 'Confirm using fallback assets',
     width: 'medium',
     minHeight: '290px',

--- a/packages/markdown/src/dialogs/EmdebExternalContentDialog.tsx
+++ b/packages/markdown/src/dialogs/EmdebExternalContentDialog.tsx
@@ -186,7 +186,7 @@ export const EmbedExternalContentModal = ({ onClose }: EmbedExternalContentModal
 export const openEmbedExternalContentDialog = (
   dialogs: DialogsAPI
 ): Promise<EmbedExternalContentModalResult> => {
-  return dialogs.openExtension({
+  return dialogs.openDialog({
     title: 'Embed external content',
     width: 'large',
     minHeight: '475px',

--- a/packages/markdown/src/dialogs/EmdebExternalContentDialog.tsx
+++ b/packages/markdown/src/dialogs/EmdebExternalContentDialog.tsx
@@ -186,7 +186,7 @@ export const EmbedExternalContentModal = ({ onClose }: EmbedExternalContentModal
 export const openEmbedExternalContentDialog = (
   dialogs: DialogsAPI
 ): Promise<EmbedExternalContentModalResult> => {
-  return dialogs.openDialog({
+  return dialogs.openCurrent({
     title: 'Embed external content',
     width: 'large',
     minHeight: '475px',

--- a/packages/markdown/src/dialogs/InsertLinkModalDialog.tsx
+++ b/packages/markdown/src/dialogs/InsertLinkModalDialog.tsx
@@ -109,7 +109,7 @@ export const openInsertLinkDialog = (
   dialogs: DialogsAPI,
   params: { selectedText?: string }
 ): Promise<InsertLinkModalResult> => {
-  return dialogs.openDialog({
+  return dialogs.openCurrent({
     title: 'Insert link',
     width: 'large',
     minHeight: '441px',

--- a/packages/markdown/src/dialogs/InsertLinkModalDialog.tsx
+++ b/packages/markdown/src/dialogs/InsertLinkModalDialog.tsx
@@ -109,7 +109,7 @@ export const openInsertLinkDialog = (
   dialogs: DialogsAPI,
   params: { selectedText?: string }
 ): Promise<InsertLinkModalResult> => {
-  return dialogs.openExtension({
+  return dialogs.openDialog({
     title: 'Insert link',
     width: 'large',
     minHeight: '441px',

--- a/packages/markdown/src/dialogs/InsertTableModalDialog.tsx
+++ b/packages/markdown/src/dialogs/InsertTableModalDialog.tsx
@@ -92,7 +92,7 @@ export const InsertTableModal = ({ onClose }: InsertTableModalProps) => {
 };
 
 export const openInsertTableDialog = (dialogs: DialogsAPI): Promise<InsertTableModalResult> => {
-  return dialogs.openDialog({
+  return dialogs.openCurrent({
     title: 'Insert table',
     width: 'medium',
     minHeight: '290px',

--- a/packages/markdown/src/dialogs/InsertTableModalDialog.tsx
+++ b/packages/markdown/src/dialogs/InsertTableModalDialog.tsx
@@ -92,7 +92,7 @@ export const InsertTableModal = ({ onClose }: InsertTableModalProps) => {
 };
 
 export const openInsertTableDialog = (dialogs: DialogsAPI): Promise<InsertTableModalResult> => {
-  return dialogs.openExtension({
+  return dialogs.openDialog({
     title: 'Insert table',
     width: 'medium',
     minHeight: '290px',

--- a/packages/markdown/src/dialogs/SpecialCharacterModalDialog.tsx
+++ b/packages/markdown/src/dialogs/SpecialCharacterModalDialog.tsx
@@ -100,7 +100,7 @@ export const SpecialCharacterModalDialog = ({ onClose }: SpecialCharacterModalDi
 export const openInsertSpecialCharacter = (
   dialogs: DialogsAPI
 ): Promise<SpecialCharacterModalResult> => {
-  return dialogs.openExtension({
+  return dialogs.openDialog({
     title: 'Insert special character',
     width: 'large',
     minHeight: '615px',

--- a/packages/markdown/src/dialogs/SpecialCharacterModalDialog.tsx
+++ b/packages/markdown/src/dialogs/SpecialCharacterModalDialog.tsx
@@ -100,7 +100,7 @@ export const SpecialCharacterModalDialog = ({ onClose }: SpecialCharacterModalDi
 export const openInsertSpecialCharacter = (
   dialogs: DialogsAPI
 ): Promise<SpecialCharacterModalResult> => {
-  return dialogs.openDialog({
+  return dialogs.openCurrent({
     title: 'Insert special character',
     width: 'large',
     minHeight: '615px',

--- a/packages/markdown/src/dialogs/ZenModeModalDialog.tsx
+++ b/packages/markdown/src/dialogs/ZenModeModalDialog.tsx
@@ -210,7 +210,7 @@ export const openZenMode = (
   dialogs: DialogsAPI,
   options: { initialValue: string; locale: string }
 ): Promise<ZenModeResult> => {
-  return dialogs.openExtension({
+  return dialogs.openDialog({
     width: 'zen' as any, // eslint-disable-line @typescript-eslint/no-explicit-any
     shouldCloseOnEscapePress: false,
     minHeight: '100vh',

--- a/packages/markdown/src/dialogs/ZenModeModalDialog.tsx
+++ b/packages/markdown/src/dialogs/ZenModeModalDialog.tsx
@@ -210,7 +210,7 @@ export const openZenMode = (
   dialogs: DialogsAPI,
   options: { initialValue: string; locale: string }
 ): Promise<ZenModeResult> => {
-  return dialogs.openDialog({
+  return dialogs.openCurrent({
     width: 'zen' as any, // eslint-disable-line @typescript-eslint/no-explicit-any
     shouldCloseOnEscapePress: false,
     minHeight: '100vh',

--- a/packages/reference/package.json
+++ b/packages/reference/package.json
@@ -27,7 +27,7 @@
     "@contentful/mimetype": "^1.1.4",
     "array-move": "^2.2.1",
     "constate": "2.0.0",
-    "contentful-ui-extensions-sdk": "^3.14.3",
+    "contentful-ui-extensions-sdk": "^3.15.0",
     "deep-equal": "2.0.3",
     "emotion": "^10.0.17",
     "lodash": "^4.17.15",

--- a/packages/rich-text/src/RichTextEditor.mdx
+++ b/packages/rich-text/src/RichTextEditor.mdx
@@ -88,7 +88,7 @@ import publishedAsset from '../../reference/src/__fixtures__/published_asset.jso
       }
     };
 
-    sdk.dialogs.openExtension = openRichTextDialog(sdk);
+    sdk.dialogs.openCurrent = openRichTextDialog(sdk);
 
 
     const renderRT = (value, type) => {

--- a/packages/rich-text/src/dialogs/HypelinkDialog/HyperlinkDialog.jsx
+++ b/packages/rich-text/src/dialogs/HypelinkDialog/HyperlinkDialog.jsx
@@ -294,7 +294,7 @@ export const openHyperlinkDialog = (
     entitySelectorConfigs,
   };
 
-  return dialogs.openExtension({
+  return dialogs.openCurrent({
     title: props.labels.title,
     width: 'large',
     shouldCloseOnEscapePress: true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -7030,13 +7030,6 @@ contentful-sdk-core@^6.4.0:
     lodash "^4.17.10"
     qs "^6.5.2"
 
-contentful-ui-extensions-sdk@^3.14.3:
-  version "3.14.3"
-  resolved "https://registry.yarnpkg.com/contentful-ui-extensions-sdk/-/contentful-ui-extensions-sdk-3.14.3.tgz#cc95d5c2a2576e5863878868b0d16f2e34f729c7"
-  integrity sha512-Qu5BLtv08YfxhoserC4qAZ+vOGYG0cqCCpldO+QOwtZEsjUGF/12i9+Pfw+jQJSyOmPJzfz7TkNIoUbZFcxpaw==
-  dependencies:
-    es6-promise "^4.2.8"
-
 contentful-ui-extensions-sdk@^3.15.0:
   version "3.15.0"
   resolved "https://registry.yarnpkg.com/contentful-ui-extensions-sdk/-/contentful-ui-extensions-sdk-3.15.0.tgz#9480f80f7d7113bcc44ded390a0c6a4dbee8f331"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7037,6 +7037,13 @@ contentful-ui-extensions-sdk@^3.14.3:
   dependencies:
     es6-promise "^4.2.8"
 
+contentful-ui-extensions-sdk@^3.15.0:
+  version "3.15.0"
+  resolved "https://registry.yarnpkg.com/contentful-ui-extensions-sdk/-/contentful-ui-extensions-sdk-3.15.0.tgz#9480f80f7d7113bcc44ded390a0c6a4dbee8f331"
+  integrity sha512-I1W+eprrsaD+h0iMTIqPFc0uMKz3Vdg6AQlxFOATpOwYqQAD14ZJwx16GmfX73e2dycaOT/5HaXSQT48J0jx/w==
+  dependencies:
+    es6-promise "^4.2.8"
+
 contentful@^7.14.0:
   version "7.14.3"
   resolved "https://registry.yarnpkg.com/contentful/-/contentful-7.14.3.tgz#bc4986f6163462168b6e51b06104cb0b6931a6af"


### PR DESCRIPTION
The field editors throw an error if you open any form of a dialog from within an app. The method `openCurrent` handles this behaviour and decides if you should `openExtension` or `openCurrentApp`.