### PR TITLE
fix: prevent rich text references from opening on click

### DIFF
--- a/packages/reference/src/assets/WrappedAssetCard/WrappedAssetCard.tsx
+++ b/packages/reference/src/assets/WrappedAssetCard/WrappedAssetCard.tsx
@@ -35,7 +35,12 @@ export interface WrappedAssetCardProps {
   onRemove?: () => void;
   size: 'default' | 'small';
   cardDragHandle?: React.ReactElement;
+  isClickable: boolean;
 }
+
+const defaultProps = {
+  isClickable: true,
+};
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function getFileType(file?: File): any {
@@ -52,7 +57,16 @@ function getFileType(file?: File): any {
 }
 
 export const WrappedAssetCard = (props: WrappedAssetCardProps) => {
-  const { className, onEdit, getAssetUrl, onRemove, size, isDisabled, isSelected } = props;
+  const {
+    className,
+    onEdit,
+    getAssetUrl,
+    onRemove,
+    size,
+    isDisabled,
+    isSelected,
+    isClickable,
+  } = props;
 
   const status = entityHelpers.getEntryStatus(props.asset.sys);
 
@@ -85,7 +99,7 @@ export const WrappedAssetCard = (props: WrappedAssetCardProps) => {
       className={className}
       // @ts-ignore
       selected={isSelected}
-      href={getAssetUrl ? getAssetUrl(props.asset.sys.id) : undefined}
+      href={isClickable && getAssetUrl ? getAssetUrl(props.asset.sys.id) : undefined}
       status={status}
       src={
         entityFile
@@ -97,6 +111,7 @@ export const WrappedAssetCard = (props: WrappedAssetCardProps) => {
       // @ts-ignore
       onClick={(e: React.MouseEvent<HTMLElement>) => {
         e.preventDefault();
+        if (!props.isClickable) return;
         onEdit && onEdit();
       }}
       cardDragHandleComponent={props.cardDragHandle}
@@ -111,3 +126,5 @@ export const WrappedAssetCard = (props: WrappedAssetCardProps) => {
     />
   );
 };
+
+WrappedAssetCard.defaultProps = defaultProps;

--- a/packages/reference/src/entries/WrappedEntryCard/WrappedEntryCard.tsx
+++ b/packages/reference/src/entries/WrappedEntryCard/WrappedEntryCard.tsx
@@ -35,7 +35,12 @@ interface WrappedEntryCardProps {
   allContentTypes: ContentType[];
   entry: Entry;
   cardDragHandle?: React.ReactElement;
+  isClickable: boolean;
 }
+
+const defaultProps = {
+  isClickable: true,
+};
 
 export function WrappedEntryCard(props: WrappedEntryCardProps) {
   const [file, setFile] = React.useState<null | File>(null);
@@ -93,7 +98,9 @@ export function WrappedEntryCard(props: WrappedEntryCardProps) {
 
   return (
     <EntryCard
-      href={props.getEntryUrl ? props.getEntryUrl(props.entry.sys.id) : undefined}
+      href={
+        props.getEntryUrl && props.isClickable ? props.getEntryUrl(props.entry.sys.id) : undefined
+      }
       title={title}
       description={description}
       contentType={contentType?.name}
@@ -152,8 +159,11 @@ export function WrappedEntryCard(props: WrappedEntryCardProps) {
       }
       onClick={(e) => {
         e.preventDefault();
+        if (!props.isClickable) return;
         props.onEdit && props.onEdit();
       }}
     />
   );
 }
+
+WrappedEntryCard.defaultProps = defaultProps;

--- a/packages/rich-text/src/RichTextEditor.mdx
+++ b/packages/rich-text/src/RichTextEditor.mdx
@@ -4,7 +4,7 @@ route: /rich-text
 menu: Editors
 ---
 
-import Readme from '../README.md'
+import Readme from '../README.md';
 
 <Readme />
 
@@ -15,7 +15,7 @@ import {
   ActionsPlayground,
   createFakeSpaceAPI,
   createFakeLocalesAPI,
-  createFakeNavigatorAPI
+  createFakeNavigatorAPI,
 } from '@contentful/field-editor-test-utils';
 import { documentToReactComponents } from '@contentful/rich-text-react-renderer';
 import { css } from 'emotion';
@@ -85,6 +85,11 @@ import publishedAsset from '../../reference/src/__fixtures__/published_asset.jso
           }
           return Promise.resolve(false);
         }
+      },
+      parameters: {
+        instance: {
+          getEntryUrl: () => '#'
+        }
       }
     };
 
@@ -110,26 +115,22 @@ import publishedAsset from '../../reference/src/__fixtures__/published_asset.jso
         <ActionsPlayground mitt={mitt} renderValue={renderRT} />
       </div>
     );
-  }}
+
+}}
+
 </Playground>
 
 ## As field extension
-
 
 ```js
 import { RichTextEditor, renderRichTextDialog } from '@contentful/field-editor-rich-text';
 
 /// your extension code
-init(sdk => {
+init((sdk) => {
   if (sdk.location.is(locations.LOCATION_DIALOG)) {
     render(renderRichTextDialog(sdk), document.getElementById('root'));
   } else if (sdk.location.is(locations.LOCATION_ENTRY_FIELD)) {
-    render(
-      <RichTextEditor
-        sdk={sdk}
-      />,
-      document.getElementById('root')
-    );
+    render(<RichTextEditor sdk={sdk} />, document.getElementById('root'));
   }
 });
 ```

--- a/packages/rich-text/src/plugins/EmbeddedEntityBlock/FetchingWrappedAssetCard.js
+++ b/packages/rich-text/src/plugins/EmbeddedEntityBlock/FetchingWrappedAssetCard.js
@@ -4,7 +4,7 @@ import { AssetCard } from '@contentful/forma-36-react-components';
 import {
   useEntities,
   MissingEntityCard,
-  WrappedAssetCard
+  WrappedAssetCard,
 } from '@contentful/field-editor-reference';
 
 export function FetchingWrappedAssetCard(props) {
@@ -49,6 +49,7 @@ export function FetchingWrappedAssetCard(props) {
       asset={asset}
       onEdit={props.onEdit}
       onRemove={props.onRemove}
+      isClickable={false}
     />
   );
 }
@@ -62,5 +63,5 @@ FetchingWrappedAssetCard.propTypes = {
   onRemove: PropTypes.func,
   onEdit: PropTypes.func,
   getAssetUrl: PropTypes.func,
-  onEntityFetchComplete: PropTypes.func
+  onEntityFetchComplete: PropTypes.func,
 };

--- a/packages/rich-text/src/plugins/EmbeddedEntityBlock/FetchingWrappedEntryCard.js
+++ b/packages/rich-text/src/plugins/EmbeddedEntityBlock/FetchingWrappedEntryCard.js
@@ -4,7 +4,7 @@ import { EntryCard } from '@contentful/forma-36-react-components';
 import {
   useEntities,
   MissingEntityCard,
-  WrappedEntryCard
+  WrappedEntryCard,
 } from '@contentful/field-editor-reference';
 
 export function FetchingWrappedEntryCard(props) {
@@ -52,6 +52,7 @@ export function FetchingWrappedEntryCard(props) {
       entry={entry}
       onEdit={props.onEdit}
       onRemove={props.onRemove}
+      isClickable={false}
     />
   );
 }
@@ -65,5 +66,5 @@ FetchingWrappedEntryCard.propTypes = {
   onRemove: PropTypes.func,
   onEdit: PropTypes.func,
   getEntryUrl: PropTypes.func,
-  onEntityFetchComplete: PropTypes.func
+  onEntityFetchComplete: PropTypes.func,
 };


### PR DESCRIPTION
When clicking on reference cards within the rich text editor, the entry is immediately opened. This PR changes that so that clicking on a reference card only selects the card which allows the user to then press backspace to remove the referenced entry from the rich text editor field.