### PR TITLE
fix: 🐛 Improve link rendering performance

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -21656,7 +21656,7 @@ yargs-parser@10.x, yargs-parser@^10.0.0:
   dependencies:
     camelcase "^4.1.0"
 
-yargs-parser@13.1.2, yargs-parser@^13.1.1, yargs-parser@^13.1.2:
+yargs-parser@13.1.2, yargs-parser@^13.1.2:
   version "13.1.2"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-13.1.2.tgz#130f09702ebaeef2650d54ce6e3e5706f7a4fb38"
   integrity sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==


### PR DESCRIPTION
improves performance on rendering lots of links as we were doing `n^2` renderings of the link card where `n` is the number of links. We now do ~`n*2` renderings (one for loaded state, one for fetched link state)