### PR TITLE
fix(reference): optimize multiple references field rendering

### DIFF
--- a/packages/reference/src/assets/WrappedAssetCard/FetchingWrappedAssetCard.tsx
+++ b/packages/reference/src/assets/WrappedAssetCard/FetchingWrappedAssetCard.tsx
@@ -25,6 +25,12 @@ export function FetchingWrappedAssetCard(props: FetchingWrappedAssetCardProps) {
   }, [props.assetId]);
 
   const asset = assets[props.assetId];
+  const entityKey =
+    asset === 'failed'
+      ? 'failed'
+      : asset === undefined
+      ? 'undefined'
+      : `:${asset.sys.id}:${asset.sys.version}`;
 
   React.useEffect(() => {
     if (asset) {
@@ -32,54 +38,56 @@ export function FetchingWrappedAssetCard(props: FetchingWrappedAssetCardProps) {
     }
   }, [asset]);
 
-  if (asset === 'failed') {
-    return (
-      <MissingEntityCard
-        entityType="Asset"
-        asSquare={props.viewType !== 'link'}
-        isDisabled={props.isDisabled}
-        onRemove={props.onRemove}
-      />
-    );
-  }
-
-  const commonProps = {
-    isDisabled: props.isDisabled,
-    href: props.getEntityUrl ? props.getEntityUrl(props.assetId) : '',
-    localeCode: props.sdk.field.locale,
-    defaultLocaleCode: props.sdk.locales.default,
-    asset: asset as Asset,
-    onEdit: async () => {
-      const { slide } = await props.sdk.navigator.openAsset(props.assetId, { slideIn: true });
-      props.onAction &&
-        props.onAction({
-          entity: 'Asset',
-          type: 'edit',
-          id: props.assetId,
-          contentTypeId: '',
-          slide,
-        });
-    },
-    cardDragHandle: props.cardDragHandle,
-    onRemove: () => {
-      props.onRemove();
-      props.onAction &&
-        props.onAction({ entity: 'Asset', type: 'delete', id: props.assetId, contentTypeId: '' });
-    },
-  };
-
-  if (props.viewType === 'link') {
-    if (asset === undefined) {
-      return <EntryCard size="small" loading />;
+  return React.useMemo(() => {
+    if (asset === 'failed') {
+      return (
+        <MissingEntityCard
+          entityType="Asset"
+          asSquare={props.viewType !== 'link'}
+          isDisabled={props.isDisabled}
+          onRemove={props.onRemove}
+        />
+      );
     }
-    return <WrappedAssetLink {...commonProps} />;
-  }
 
-  const size = props.viewType === 'big_card' ? 'default' : 'small';
+    const commonProps = {
+      isDisabled: props.isDisabled,
+      href: props.getEntityUrl ? props.getEntityUrl(props.assetId) : '',
+      localeCode: props.sdk.field.locale,
+      defaultLocaleCode: props.sdk.locales.default,
+      asset: asset as Asset,
+      onEdit: async () => {
+        const { slide } = await props.sdk.navigator.openAsset(props.assetId, { slideIn: true });
+        props.onAction &&
+          props.onAction({
+            entity: 'Asset',
+            type: 'edit',
+            id: props.assetId,
+            contentTypeId: '',
+            slide,
+          });
+      },
+      cardDragHandle: props.cardDragHandle,
+      onRemove: () => {
+        props.onRemove();
+        props.onAction &&
+          props.onAction({ entity: 'Asset', type: 'delete', id: props.assetId, contentTypeId: '' });
+      },
+    };
 
-  if (asset === undefined) {
-    return <AssetCard size={size} isLoading title="" src="" href="" />;
-  }
+    if (props.viewType === 'link') {
+      if (asset === undefined) {
+        return <EntryCard size="small" loading />;
+      }
+      return <WrappedAssetLink {...commonProps} />;
+    }
 
-  return <WrappedAssetCard size={size} {...commonProps} />;
+    const size = props.viewType === 'big_card' ? 'default' : 'small';
+
+    if (asset === undefined) {
+      return <AssetCard size={size} isLoading title="" src="" href="" />;
+    }
+
+    return <WrappedAssetCard size={size} {...commonProps} />;
+  }, [props, entityKey]);
 }

--- a/packages/reference/src/entries/WrappedEntryCard/FetchingWrappedEntryCard.tsx
+++ b/packages/reference/src/entries/WrappedEntryCard/FetchingWrappedEntryCard.tsx
@@ -54,12 +54,12 @@ export function FetchingWrappedEntryCard(props: EntryCardReferenceEditorProps) {
 
   const size = props.viewType === 'link' ? 'small' : 'default';
   const entry = entries[props.entryId];
-  const entryKey =
-    entry === 'failed' // TODO: Why mixed values???
+  const entityKey =
+    entry === 'failed'
       ? 'failed'
       : entry === undefined
       ? 'undefined'
-      : `:${entry.sys.id}`;
+      : `:${entry.sys.id}:${entry.sys.version}`;
 
   React.useEffect(() => {
     if (entry) {
@@ -118,5 +118,5 @@ export function FetchingWrappedEntryCard(props: EntryCardReferenceEditorProps) {
         }}
       />
     );
-  }, [entryKey]);
+  }, [props, entityKey]);
 }


### PR DESCRIPTION
The `useEntities` hook used inside `FetchingWrappedEntryCard` and `FetchingWrappedAssetCard` provides the list of all entities `entries`/`assets` from the store and the `loadEntry`/`loadAsset` function. The problem is that each successful load call triggers a re-render of all components using the hook, even though we fetch all entities in one request because of optimization. So a list of 500 cards ends up being rendered 500^2 times before the page is fully loaded.

The recent fix https://github.com/contentful/field-editors/commit/f6e844dcd2f25ff5453d2ce6301ea021b5fcaca3 added `useMemo` inside `FetchingWrappedEntryCard` to re-render only when an entity changes. But it doesn't consider component props and introduced a few bugs, like card not updating after an edit or cards not switching to initialized state (when a `DragHandle` is displayed and `Remove` button is enabled).

To fix the bugs, `props` dependency must be added to `useMemo`, but even then there are **15** initial re-renders, where most of them are not needed and happen only because the parent `SortableLinkList` is re-rendered and passed down new instances of `onRemove` and `cardDragHandler`, whereas all other card props are the same. Maybe I'm missing some obvious way of optimizing it (like memozing `onRemove` and `cardDragHandler`)?

In this PR I added the same technic for assets (`useMemo` in `FetchingWrappedAssetCard`). 