### PR TITLE
fix: allow draggable embeds in rich text

### DIFF
--- a/packages/reference/src/assets/WrappedAssetCard/WrappedAssetCard.tsx
+++ b/packages/reference/src/assets/WrappedAssetCard/WrappedAssetCard.tsx
@@ -99,7 +99,7 @@ export const WrappedAssetCard = (props: WrappedAssetCardProps) => {
       className={className}
       // @ts-ignore
       selected={isSelected}
-      href={isClickable && getAssetUrl ? getAssetUrl(props.asset.sys.id) : undefined}
+      href={getAssetUrl ? getAssetUrl(props.asset.sys.id) : undefined}
       status={status}
       src={
         entityFile
@@ -111,7 +111,7 @@ export const WrappedAssetCard = (props: WrappedAssetCardProps) => {
       // @ts-ignore
       onClick={(e: React.MouseEvent<HTMLElement>) => {
         e.preventDefault();
-        if (!props.isClickable) return;
+        if (!isClickable) return;
         onEdit && onEdit();
       }}
       cardDragHandleComponent={props.cardDragHandle}

--- a/packages/reference/src/entries/WrappedEntryCard/WrappedEntryCard.tsx
+++ b/packages/reference/src/entries/WrappedEntryCard/WrappedEntryCard.tsx
@@ -98,9 +98,7 @@ export function WrappedEntryCard(props: WrappedEntryCardProps) {
 
   return (
     <EntryCard
-      href={
-        props.getEntryUrl && props.isClickable ? props.getEntryUrl(props.entry.sys.id) : undefined
-      }
+      href={props.getEntryUrl ? props.getEntryUrl(props.entry.sys.id) : undefined}
       title={title}
       description={description}
       contentType={contentType?.name}


### PR DESCRIPTION
This PR allows embeds in the rich text editor to be draggable for purposes of moving within the rich text content, but will still prevent the embedded entry/asset cards from opening on click