### PR TITLE
fix: 🐛 (REACT-324) add asset button in rich text is unavailable

### DIFF
--- a/packages/rich-text/src/RichTextEditor.jsx
+++ b/packages/rich-text/src/RichTextEditor.jsx
@@ -122,7 +122,6 @@ export class ConnectedRichTextEditor extends React.Component {
 
   state = {
     lastOperations: List(),
-    canAccessAssets: false,
     value:
       this.props.value && this.props.value.nodeType === BLOCKS.DOCUMENT
         ? createSlateValue(this.props.value)
@@ -137,12 +136,6 @@ export class ConnectedRichTextEditor extends React.Component {
   });
 
   slatePlugins = buildPlugins(this.richTextAPI);
-
-  componentDidMount() {
-    this.props.sdk.access.can('read', 'Asset').then((canReadAssets) => {
-      this.setState({ canAccessAssets: canReadAssets });
-    });
-  }
 
   onChange = (editor) => {
     const { value, operations } = editor;
@@ -209,7 +202,6 @@ export class ConnectedRichTextEditor extends React.Component {
               editor={this.editor.current || new BasicEditor({ readOnly: true })}
               onChange={this.onChange}
               isDisabled={this.props.isDisabled}
-              canAccessAssets={this.state.canAccessAssets}
               richTextAPI={this.richTextAPI}
             />
           </StickyToolbarWrapper>

--- a/packages/rich-text/src/RichTextEditor.spec.js
+++ b/packages/rich-text/src/RichTextEditor.spec.js
@@ -12,11 +12,11 @@ jest.mock('redux/store', () => ({}), { virtual: true });
 jest.mock('ng/entityCreator', () => ({}), { virtual: true });
 jest.mock('ng/debounce', () => jest.fn(), { virtual: true });
 
-const fakeProps = props => ({
+const fakeProps = (props) => ({
   sdk: {
     field: {
       id: 'FIELD_ID,',
-      locale: 'FIELD_LOCALE'
+      locale: 'FIELD_LOCALE',
     },
     access: {
       can: async (access, entityType) => {
@@ -29,36 +29,36 @@ const fakeProps = props => ({
           }
         }
         return false;
-      }
-    }
+      },
+    },
   },
   navigator: {
     onSlideInNavigation: () => () => {
       return;
-    }
+    },
   },
   value: undefined,
   onChange: jest.fn(),
   onAction: jest.fn(),
   isDisabled: false,
   showToolbar: false,
-  ...props
+  ...props,
 });
 
 describe('RichTextEditor', () => {
-  it('renders the editor', function() {
+  it('renders the editor', function () {
     const wrapper = Enzyme.shallow(<RichTextEditor {...fakeProps()} />);
 
     expect(wrapper.find('[data-test-id="editor"]').props().readOnly).toBe(false);
   });
 
-  it('renders toolbar', function() {
+  it('renders toolbar', function () {
     const wrapper = Enzyme.shallow(<RichTextEditor {...fakeProps()} />);
 
     expect(wrapper.find(Toolbar)).toHaveLength(1);
   });
 
-  it('renders readonly editor and toolbar', function() {
+  it('renders readonly editor and toolbar', function () {
     const wrapper = Enzyme.shallow(<RichTextEditor {...fakeProps({ isDisabled: true })} />);
 
     expect(wrapper.find('[data-test-id="editor"]').props().readOnly).toBe(true);

--- a/packages/rich-text/src/Toolbar/Toolbar.spec.js
+++ b/packages/rich-text/src/Toolbar/Toolbar.spec.js
@@ -12,21 +12,23 @@ const fakeProps = () => ({
   isDisabled: false,
   editor: new Editor(),
   onChange: jest.fn(),
-  canAccessAssets: true,
   richTextAPI: {
     logToolbarAction: jest.fn(),
     logShortcutAction: jest.fn(),
     logViewportAction: jest.fn(),
     sdk: {
-      field: {}
-    }
-  }
+      field: {},
+      access: {
+        can: jest.fn().mockResolvedValue(true),
+      },
+    },
+  },
 });
 
 const dropDownEmbedNodeTypes = [
   BLOCKS.EMBEDDED_ASSET,
   BLOCKS.EMBEDDED_ENTRY,
-  INLINES.EMBEDDED_ENTRY
+  INLINES.EMBEDDED_ENTRY,
 ];
 
 describe('Toolbar', () => {
@@ -56,7 +58,7 @@ describe('Toolbar', () => {
     const props = fakeProps();
     props.richTextAPI.sdk.field.validations = [
       { [VALIDATIONS.ENABLED_NODE_TYPES]: [] },
-      { [VALIDATIONS.ENABLED_MARKS]: [] }
+      { [VALIDATIONS.ENABLED_MARKS]: [] },
     ];
 
     const toolbar = Enzyme.mount(<Toolbar {...props} />);
@@ -92,9 +94,10 @@ describe('Toolbar', () => {
     props.richTextAPI.sdk.field.validations = [
       {
         [VALIDATIONS.ENABLED_NODE_TYPES]: VALIDATABLE_NODE_TYPES.filter(
-          nodeType => ![BLOCKS.OL_LIST, BLOCKS.UL_LIST, BLOCKS.QUOTE, BLOCKS.HR].includes(nodeType)
-        )
-      }
+          (nodeType) =>
+            ![BLOCKS.OL_LIST, BLOCKS.UL_LIST, BLOCKS.QUOTE, BLOCKS.HR].includes(nodeType)
+        ),
+      },
     ];
     const toolbar = Enzyme.mount(<Toolbar {...props} />);
     expect(toolbar.find('[data-test-id="list-divider"]')).toHaveLength(0);
@@ -105,12 +108,12 @@ describe('Toolbar', () => {
     props.richTextAPI.sdk.field.validations = [
       {
         [VALIDATIONS.ENABLED_NODE_TYPES]: VALIDATABLE_NODE_TYPES.filter(
-          nodeType =>
+          (nodeType) =>
             ![INLINES.ASSET_HYPERLINK, INLINES.HYPERLINK, INLINES.ENTRY_HYPERLINK].includes(
               nodeType
             )
-        )
-      }
+        ),
+      },
     ];
     const toolbar = Enzyme.mount(<Toolbar {...props} />);
     expect(toolbar.find('[data-test-id="hyperlink-divider"]')).toHaveLength(0);
@@ -121,30 +124,32 @@ describe('Toolbar', () => {
     props.richTextAPI.sdk.field.validations = [
       {
         [VALIDATIONS.ENABLED_NODE_TYPES]: VALIDATABLE_NODE_TYPES.filter(
-          nodeType => !dropDownEmbedNodeTypes.includes(nodeType)
-        )
-      }
+          (nodeType) => !dropDownEmbedNodeTypes.includes(nodeType)
+        ),
+      },
     ];
     const toolbar = Enzyme.mount(<Toolbar {...props} />);
     expect(toolbar.find('[data-test-id="toolbar-entry-dropdown-toggle"]')).toHaveLength(0);
   });
 
-  it('hides embed dropdown option when no relevant embed is enabled', () => {
+  it('hides embed dropdown option when no relevant embed is enabled', async () => {
     for (const embedNodeType of dropDownEmbedNodeTypes) {
       const props = fakeProps();
       props.richTextAPI.sdk.field.validations = [
         {
           [VALIDATIONS.ENABLED_NODE_TYPES]: VALIDATABLE_NODE_TYPES.filter(
-            nodeType => nodeType !== embedNodeType
-          )
-        }
+            (nodeType) => nodeType !== embedNodeType
+          ),
+        },
       ];
-      const toolbar = Enzyme.mount(<Toolbar {...props} />);
+      let toolbar = Enzyme.mount(<Toolbar {...props} />);
+      await toolbar.instance().busy;
+      toolbar = toolbar.update();
       toolbar.find('button[data-test-id="toolbar-entry-dropdown-toggle"]').simulate('mouseDown');
       expect(toolbar.find(`[data-test-id="toolbar-toggle-${embedNodeType}"]`)).toHaveLength(0);
       dropDownEmbedNodeTypes
-        .filter(nodeType => nodeType !== embedNodeType)
-        .forEach(nodeType => {
+        .filter((nodeType) => nodeType !== embedNodeType)
+        .forEach((nodeType) => {
           expect(toolbar.find(`[data-test-id="toolbar-toggle-${nodeType}"]`)).toHaveLength(1);
         });
     }
@@ -152,9 +157,9 @@ describe('Toolbar', () => {
 
   it(`hides the ${BLOCKS.EMBEDDED_ASSET} dropdown option when the user has no asset access permissions`, () => {
     const props = fakeProps();
-    props.canAccessAssets = false;
+    props.richTextAPI.sdk.access.can = jest.fn().mockResolvedValue(false);
     props.richTextAPI.sdk.field.validations = [
-      { [VALIDATIONS.ENABLED_NODE_TYPES]: VALIDATABLE_NODE_TYPES }
+      { [VALIDATIONS.ENABLED_NODE_TYPES]: VALIDATABLE_NODE_TYPES },
     ];
     const toolbar = Enzyme.mount(<Toolbar {...props} />);
     toolbar.find('button[data-test-id="toolbar-entry-dropdown-toggle"]').simulate('mouseDown');
@@ -162,8 +167,8 @@ describe('Toolbar', () => {
       0
     );
     dropDownEmbedNodeTypes
-      .filter(nodeType => nodeType !== BLOCKS.EMBEDDED_ASSET)
-      .forEach(nodeType => {
+      .filter((nodeType) => nodeType !== BLOCKS.EMBEDDED_ASSET)
+      .forEach((nodeType) => {
         expect(toolbar.find(`[data-test-id="toolbar-toggle-${nodeType}"]`)).toHaveLength(1);
       });
   });

--- a/packages/rich-text/src/Toolbar/index.js
+++ b/packages/rich-text/src/Toolbar/index.js
@@ -16,7 +16,7 @@ import {
   Heading5,
   Heading6,
   Paragraph,
-  HeadingDropdown
+  HeadingDropdown,
 } from '../plugins/Heading';
 
 import Hyperlink from '../plugins/Hyperlink';
@@ -39,7 +39,7 @@ const styles = {
     webkitAlignSelf: 'flex-start',
     alignSelf: 'flex-start',
     msFlexItemAlign: 'start',
-    marginLeft: 'auto'
+    marginLeft: 'auto',
   }),
   formattingOptionsWrapper: css({
     display: ['-webkit-box', '-ms-flexbox', 'flex'],
@@ -48,8 +48,8 @@ const styles = {
     alignItems: 'center',
     msFlexWrap: 'wrap',
     flexWrap: 'wrap',
-    marginRight: '20px'
-  })
+    marginRight: '20px',
+  }),
 };
 
 export default class Toolbar extends React.Component {
@@ -58,13 +58,19 @@ export default class Toolbar extends React.Component {
     isDisabled: PropTypes.bool.isRequired,
     editor: PropTypes.object.isRequired,
     onChange: PropTypes.func.isRequired,
-    canAccessAssets: PropTypes.bool.isRequired
   };
 
   state = {
     headingMenuOpen: false,
-    ...getValidationInfo(this.props.richTextAPI.sdk.field)
+    canAccessAssets: false,
+    ...getValidationInfo(this.props.richTextAPI.sdk.field),
   };
+
+  componentDidMount() {
+    this.props.richTextAPI.sdk.access
+      .can('read', 'Asset')
+      .then((canReadAssets) => this.setState({ canAccessAssets: canReadAssets }));
+  }
 
   onChange = (...args) => {
     this.setState({ headingMenuOpen: false });
@@ -72,27 +78,27 @@ export default class Toolbar extends React.Component {
   };
 
   toggleEmbedDropdown = () =>
-    this.setState(prevState => ({
-      isEmbedDropdownOpen: !prevState.isEmbedDropdownOpen
+    this.setState((prevState) => ({
+      isEmbedDropdownOpen: !prevState.isEmbedDropdownOpen,
     }));
 
   handleEmbedDropdownClose = () =>
     this.setState({
-      isEmbedDropdownOpen: false
+      isEmbedDropdownOpen: false,
     });
 
-  renderEmbeds = props => {
+  renderEmbeds = (props) => {
     const field = this.props.richTextAPI.sdk.field;
 
     const inlineEntryEmbedEnabled = isNodeTypeEnabled(field, INLINES.EMBEDDED_ENTRY);
     const blockEntryEmbedEnabled = isNodeTypeEnabled(field, BLOCKS.EMBEDDED_ENTRY);
     const blockAssetEmbedEnabled =
-      this.props.canAccessAssets && isNodeTypeEnabled(field, BLOCKS.EMBEDDED_ASSET);
+      this.state.canAccessAssets && isNodeTypeEnabled(field, BLOCKS.EMBEDDED_ASSET);
 
     const numEnabledEmbeds = [
       inlineEntryEmbedEnabled,
       blockEntryEmbedEnabled,
-      blockAssetEmbedEnabled
+      blockAssetEmbedEnabled,
     ].filter(Boolean).length;
 
     return (
@@ -126,16 +132,16 @@ export default class Toolbar extends React.Component {
     );
   };
 
-  toggleHeadingMenu = event => {
+  toggleHeadingMenu = (event) => {
     event.preventDefault();
-    this.setState(prevState => ({
-      headingMenuOpen: !prevState.headingMenuOpen
+    this.setState((prevState) => ({
+      headingMenuOpen: !prevState.headingMenuOpen,
     }));
   };
 
   closeHeadingMenu = () =>
     this.setState({
-      headingMenuOpen: false
+      headingMenuOpen: false,
     });
 
   render() {
@@ -145,7 +151,7 @@ export default class Toolbar extends React.Component {
       onToggle: this.onChange,
       onCloseEmbedMenu: this.toggleEmbedDropdown,
       disabled: isDisabled,
-      richTextAPI
+      richTextAPI,
     };
     const { field } = richTextAPI.sdk;
     const { isAnyHyperlinkEnabled, isAnyListEnabled, isAnyMarkEnabled } = this.state;
@@ -211,6 +217,6 @@ function getValidationInfo(field) {
   return {
     isAnyMarkEnabled,
     isAnyHyperlinkEnabled,
-    isAnyListEnabled
+    isAnyListEnabled,
   };
 }


### PR DESCRIPTION
Moved async function to get asset access for the user into Tooltip
component, to avoid stale state

I looked into this bug (https://contentful.atlassian.net/browse/REACT-324) and it seems to me that state of the `RichTextEditor` component doesn't propagate to the `Toolbar` component on the first render of the `Toolbar` component. `setState` in `componentDidMount` didn't trigger re-render of the component. To avoid this, I moved this async function to `Toolbar`, as we provide the function needed anyway, and asset access seems to be related to the `Toolbar`.
I wasn't able to find an explanation for this reacts behaviour with un-updated props, so if anyone has any pointers, highly appreciated. 

✅ Closes: REACT-324