### PR TITLE
fix: 🐛 Open media links without exposing window.opener

### DIFF
--- a/packages/reference/src/assets/WrappedAssetCard/AssetCardActions.tsx
+++ b/packages/reference/src/assets/WrappedAssetCard/AssetCardActions.tsx
@@ -18,7 +18,7 @@ const styles = {
 };
 
 function downloadAsset(url: string) {
-  window.open(url, '_blank');
+  window.open(url, '_blank', 'noopener,noreferrer');
 }
 
 export function renderAssetInfo(props: { entityFile: File }) {

--- a/packages/rich-text/src/Toolbar/StickyToolbarWrapper.js
+++ b/packages/rich-text/src/Toolbar/StickyToolbarWrapper.js
@@ -8,16 +8,16 @@ const styles = {
     position: sticky;
     top: -1px;
     z-index: 2;
-  `
+  `,
 };
 
 const StickyToolbarWrapper = ({ isDisabled, children }) => (
-  <div className={!isDisabled && styles.nativeSticky}>{children}</div>
+  <div className={isDisabled ? '' : styles.nativeSticky}>{children}</div>
 );
 
 StickyToolbarWrapper.propTypes = {
   isDisabled: PropTypes.bool,
-  children: PropTypes.node
+  children: PropTypes.node,
 };
 
 export default StickyToolbarWrapper;


### PR DESCRIPTION
Do not expose `opener` property when opening Media files in a new tab.
Also a small fix for the invalid `className` value in the other file.

https://contentful.atlassian.net/browse/PEN-1091