### PR TITLE
feat: Reference editor custom card render prop

### DIFF
--- a/cypress/integration/MultipleReferenceEditor.spec.ts
+++ b/cypress/integration/MultipleReferenceEditor.spec.ts
@@ -1,0 +1,28 @@
+describe('Multiple Reference Editor', () => {
+  beforeEach(() => {
+    cy.visit('/reference-multiple');
+  });
+
+  const getWrapper = () =>
+    cy.findByTestId('multiple-references-editor-custom-cards-integration-test');
+  const findLinkExistingBtn = () => getWrapper().findByTestId('linkEditor.linkExisting');
+  const findCustomCards = () => getWrapper().findAllByTestId('custom-card');
+  const findDefaultCards = () => getWrapper().findAllByTestId('cf-ui-entry-card');
+
+  it('is empty by default', () => {
+    findCustomCards().should('not.exist');
+    findLinkExistingBtn().click();
+  });
+
+  it('renders custom cards', () => {
+    findLinkExistingBtn().click();
+    findCustomCards().should('have.length', 2);
+  });
+
+  it('renders default card instead of custom card', () => {
+    findLinkExistingBtn().click();
+    findLinkExistingBtn().click(); // Inserts another card using standard card renderer.
+    findDefaultCards().should('have.length', 1);
+    findCustomCards().should('have.length', 2);
+  });
+});

--- a/packages/reference/src/__fixtures__/FakeSdk.ts
+++ b/packages/reference/src/__fixtures__/FakeSdk.ts
@@ -1,0 +1,80 @@
+import {
+  createFakeFieldAPI,
+  createFakeLocalesAPI,
+  createFakeSpaceAPI,
+} from '@contentful/field-editor-test-utils';
+import emptyEntry from './empty_entry.json';
+import publishedEntry from './published_entry.json';
+import changedEntry from './changed_entry.json';
+
+export function newReferenceEditorFakeSdk() {
+  const initialValue = window.localStorage.getItem('initialValue');
+  const [field, mitt] = createFakeFieldAPI((field) => field, initialValue);
+  const space = createFakeSpaceAPI();
+  const locales = createFakeLocalesAPI();
+  const links = [
+    {
+      sys: {
+        id: 'published_entry',
+      },
+    },
+    {
+      sys: {
+        id: 'changed_entry',
+      },
+    },
+    {
+      sys: {
+        id: 'empty_entry',
+      },
+    },
+  ];
+  let selectorCounter = 0;
+  const sdk = {
+    field,
+    locales,
+    space: {
+      ...space,
+      getEntry: async (id: string) => {
+        if (id === 'empty_entry') {
+          return emptyEntry;
+        }
+        if (id === 'published_entry') {
+          return publishedEntry;
+        }
+        if (id === 'changed_entry') {
+          return changedEntry;
+        }
+        return Promise.reject();
+      },
+      async getEntityScheduledActions() {
+        return [];
+      },
+    },
+    dialogs: {
+      selectSingleEntry: () => {
+        selectorCounter++;
+        return links[selectorCounter % links.length];
+      },
+      selectMultipleEntries: () => {
+        selectorCounter++;
+        return selectorCounter % 2 ? links.slice(0, 2) : [links[2]];
+      },
+    },
+    navigator: {
+      openNewEntry: async () => ({
+        entity: {
+          sys: {
+            id: 'empty_entry',
+          },
+        },
+      }),
+      openEntry: async () => {
+        alert('open entry in slide in');
+        return {};
+      },
+      onSlideInNavigation: () => () => ({}),
+    },
+  };
+  return [sdk, mitt];
+}

--- a/packages/reference/src/common/ReferenceEditor.tsx
+++ b/packages/reference/src/common/ReferenceEditor.tsx
@@ -14,7 +14,7 @@ export interface ReferenceEditorProps {
   isInitiallyDisabled: boolean;
   sdk: FieldExtensionSDK;
   viewType: ViewType;
-  renderCard?: (props: CustomEntryCardProps) => React.ReactElement | false;
+  renderCustomCard?: (props: CustomEntryCardProps) => React.ReactElement | false;
   getEntityUrl?: (entryId: string) => string;
   onAction?: (action: Action) => void;
   parameters: {

--- a/packages/reference/src/common/ReferenceEditor.tsx
+++ b/packages/reference/src/common/ReferenceEditor.tsx
@@ -2,24 +2,21 @@ import * as React from 'react';
 import deepEqual from 'deep-equal';
 import { FieldConnector } from '@contentful/field-editor-shared';
 import { EntityProvider } from './EntityStore';
-import { ViewType, FieldExtensionSDK, Action } from '../types';
+import { ViewType, FieldExtensionSDK, Action, Entry, ContentType } from '../types';
+
+// TODO: Rename common base for reference/media editors to something neutral,
+//  e.g. `LinkEditor<T>`.
 
 export interface ReferenceEditorProps {
   /**
-   * is the field disabled initially
+   * Whether or not the field should be disabled initially.
    */
   isInitiallyDisabled: boolean;
-
   sdk: FieldExtensionSDK;
-
   viewType: ViewType;
-
-  renderCard?: Function; // TODO: Work out correct type for renderCard
-
+  renderCard?: (props: CustomEntryCardProps) => React.ReactElement | false;
   getEntityUrl?: (entryId: string) => string;
-
   onAction?: (action: Action) => void;
-
   parameters: {
     instance: {
       showCreateEntityAction?: boolean;
@@ -28,6 +25,21 @@ export interface ReferenceEditorProps {
     };
   };
 }
+
+// TODO: When making this available to media editor, consider introducing a
+//  separate interface vs. making this more generic  using `entity` over `entry`
+export type CustomEntryCardProps = {
+  entry: Entry;
+  entryUrl?: string;
+  contentType?: ContentType;
+  localeCode: string;
+  defaultLocaleCode: string;
+  isDisabled: boolean;
+  size: 'default' | 'small';
+  cardDragHandle?: React.ReactElement;
+  onEdit?: () => void;
+  onRemove?: () => void;
+};
 
 export function ReferenceEditor<T>(
   props: ReferenceEditorProps & {

--- a/packages/reference/src/common/ReferenceEditor.tsx
+++ b/packages/reference/src/common/ReferenceEditor.tsx
@@ -14,6 +14,8 @@ export interface ReferenceEditorProps {
 
   viewType: ViewType;
 
+  renderCard?: Function; // TODO: Work out correct type for renderCard
+
   getEntityUrl?: (entryId: string) => string;
 
   onAction?: (action: Action) => void;

--- a/packages/reference/src/common/SingleReferenceEditor.tsx
+++ b/packages/reference/src/common/SingleReferenceEditor.tsx
@@ -10,7 +10,7 @@ type ChildProps = {
   isDisabled: boolean;
   setValue: (value: ReferenceValue | null | undefined) => void;
   allContentTypes: ContentType[];
-  renderCard?: (props: CustomEntryCardProps) => React.ReactElement | false;
+  renderCustomCard?: (props: CustomEntryCardProps) => React.ReactElement | false;
 };
 
 type EditorProps = ReferenceEditorProps &

--- a/packages/reference/src/common/SingleReferenceEditor.tsx
+++ b/packages/reference/src/common/SingleReferenceEditor.tsx
@@ -3,6 +3,7 @@ import { ReferenceValue, EntityType, ContentType } from '../types';
 import { fromFieldValidations } from '../utils/fromFieldValidations';
 import { LinkEntityActions } from '../components';
 import { ReferenceEditor, ReferenceEditorProps } from './ReferenceEditor';
+import { CustomEntryCardProps } from '../entries';
 
 type ChildProps = {
   entityId: string;
@@ -10,7 +11,7 @@ type ChildProps = {
   isDisabled: boolean;
   setValue: (value: ReferenceValue | null | undefined) => void;
   allContentTypes: ContentType[];
-  renderCard?: Function; // TODO: Work out correct type for renderCard
+  renderCard?: (props: CustomEntryCardProps) => React.ReactElement | false;
 };
 
 type EditorProps = ReferenceEditorProps &

--- a/packages/reference/src/common/SingleReferenceEditor.tsx
+++ b/packages/reference/src/common/SingleReferenceEditor.tsx
@@ -10,6 +10,7 @@ type ChildProps = {
   isDisabled: boolean;
   setValue: (value: ReferenceValue | null | undefined) => void;
   allContentTypes: ContentType[];
+  renderCard?: Function; // TODO: Work out correct type for renderCard
 };
 
 type EditorProps = ReferenceEditorProps &

--- a/packages/reference/src/common/SingleReferenceEditor.tsx
+++ b/packages/reference/src/common/SingleReferenceEditor.tsx
@@ -2,8 +2,7 @@ import * as React from 'react';
 import { ReferenceValue, EntityType, ContentType } from '../types';
 import { fromFieldValidations } from '../utils/fromFieldValidations';
 import { LinkEntityActions } from '../components';
-import { ReferenceEditor, ReferenceEditorProps } from './ReferenceEditor';
-import { CustomEntryCardProps } from '../entries';
+import { CustomEntryCardProps, ReferenceEditor, ReferenceEditorProps } from './ReferenceEditor';
 
 type ChildProps = {
   entityId: string;

--- a/packages/reference/src/entries/MultipleEntryReferenceEditor.mdx
+++ b/packages/reference/src/entries/MultipleEntryReferenceEditor.mdx
@@ -14,8 +14,20 @@ import { MultipleEntryReferenceEditor } from '@contentful/field-editor-reference
 ```
 
 import { Playground, Props } from 'docz';
-import { MultipleEntryReferenceEditor } from './MultipleEntryReferenceEditor.tsx'
-import { createFakeFieldAPI, createFakeSpaceAPI, createFakeLocalesAPI, ActionsPlayground } from '@contentful/field-editor-test-utils';
+import { MultipleEntryReferenceEditor } from './MultipleEntryReferenceEditor.tsx';
+import {
+  createFakeFieldAPI,
+  createFakeSpaceAPI,
+  createFakeLocalesAPI,
+  ActionsPlayground,
+} from '@contentful/field-editor-test-utils';
+import {
+  Card,
+  Button,
+  Typography,
+  Paragraph,
+  Heading,
+} from '@contentful/forma-36-react-components';
 import emptyEntry from '../__fixtures__/empty_entry.json';
 import publishedEntry from '../__fixtures__/published_entry.json';
 import changedEntry from '../__fixtures__/changed_entry.json';
@@ -96,6 +108,100 @@ import changedEntry from '../__fixtures__/changed_entry.json';
               canLinkEntity: true
             }
           }}
+         />
+        <ActionsPlayground mitt={mitt} />
+      </div>
+    );
+
+}}
+
+</Playground>
+
+## With custom card
+
+<Playground>
+  {() => {
+    const initialValue = window.localStorage.getItem('initialValue');
+    const isInitiallyDisabled = window.localStorage.getItem('initialDisabled');
+    const instanceParams = window.localStorage.getItem('instanceParams');
+    const [field, mitt] = createFakeFieldAPI(field => field, initialValue);
+    const space = createFakeSpaceAPI();
+    const locales = createFakeLocalesAPI();
+    const sdk = {
+      field,
+      locales,
+      space: {
+        ...space,
+        getEntry: (id) => {
+          if (id === 'empty_entry') {
+            return Promise.resolve(emptyEntry);
+          }
+          if (id === 'published_entry') {
+            return Promise.resolve(publishedEntry);
+          }
+          if (id === 'changed_entry') {
+            return Promise.resolve(changedEntry);
+          }
+          return Promise.reject();
+        },
+        getEntityScheduledActions() {
+          return Promise.resolve([]);
+        }
+      },
+      dialogs: {
+        selectMultipleEntries: () => {
+          return [
+            {
+              sys: {
+                id: 'published_entry'
+              }
+            },
+            {
+              sys: {
+                id: 'changed_entry'
+              }
+            }
+          ]
+        }
+      },
+      navigator: {
+        openNewEntry: async () => {
+          return {
+            entity: {
+              sys: {
+                id: 'empty_entry'
+              }
+            }
+          }
+        },
+        openEntry: () => {
+          alert('open entry in slide in');
+          return Promise.resolve({});
+        },
+        onSlideInNavigation: () => () => {}
+      }
+    };
+    return (
+      <div>
+        <MultipleEntryReferenceEditor
+          viewType="link"
+          sdk={sdk}
+          isInitiallyDisabled={false}
+          parameters={{
+            instance: {
+              canCreateEntity: true,
+              canLinkEntity: true
+            }
+          }}
+          renderCard={(props) => <Card>
+              <Typography style={{marginBottom: '20px'}}>
+                <Heading>{props.entry.fields.exField.en}</Heading>
+                <Paragraph>{props.entry.fields.exDesc.en}</Paragraph>
+              </Typography>
+              <Button onClick={props.onEdit} style={{marginRight: '10px'}}>Edit</Button>
+              <Button onClick={props.onRemove}>Remove</Button>
+            </Card>
+          }
          />
         <ActionsPlayground mitt={mitt} />
       </div>

--- a/packages/reference/src/entries/MultipleEntryReferenceEditor.mdx
+++ b/packages/reference/src/entries/MultipleEntryReferenceEditor.mdx
@@ -65,7 +65,7 @@ another reference rendered by the stardard card renderer.
     return (
       <div data-test-id="multiple-references-editor-custom-cards-integration-test">
         <MultipleEntryReferenceEditor
-          renderCard={(props) => props.entry.fields.exField ? <Card testId='custom-card'>
+          renderCustomCard={(props) => props.entry.fields.exField ? <Card testId='custom-card'>
               <Typography style={{marginBottom: '20px'}}>
                 <Heading>{props.entry.fields.exField.en}</Heading>
                 <Paragraph>{props.entry.fields.exDesc.en}</Paragraph>

--- a/packages/reference/src/entries/MultipleEntryReferenceEditor.mdx
+++ b/packages/reference/src/entries/MultipleEntryReferenceEditor.mdx
@@ -15,12 +15,7 @@ import { MultipleEntryReferenceEditor } from '@contentful/field-editor-reference
 
 import { Playground, Props } from 'docz';
 import { MultipleEntryReferenceEditor } from './MultipleEntryReferenceEditor.tsx';
-import {
-  createFakeFieldAPI,
-  createFakeSpaceAPI,
-  createFakeLocalesAPI,
-  ActionsPlayground,
-} from '@contentful/field-editor-test-utils';
+import { ActionsPlayground } from '@contentful/field-editor-test-utils';
 import {
   Card,
   Button,
@@ -28,82 +23,23 @@ import {
   Paragraph,
   Heading,
 } from '@contentful/forma-36-react-components';
-import emptyEntry from '../__fixtures__/empty_entry.json';
-import publishedEntry from '../__fixtures__/published_entry.json';
-import changedEntry from '../__fixtures__/changed_entry.json';
+import { newReferenceEditorFakeSdk } from '../__fixtures__/FakeSdk'
 
 ## In Action
 
 <Playground>
   {() => {
-    const initialValue = window.localStorage.getItem('initialValue');
     const isInitiallyDisabled = window.localStorage.getItem('initialDisabled');
     const instanceParams = window.localStorage.getItem('instanceParams');
-    const [field, mitt] = createFakeFieldAPI(field => field, initialValue);
-    const space = createFakeSpaceAPI();
-    const locales = createFakeLocalesAPI();
-    const sdk = {
-      field,
-      locales,
-      space: {
-        ...space,
-        getEntry: (id) => {
-          if (id === 'empty_entry') {
-            return Promise.resolve(emptyEntry);
-          }
-          if (id === 'published_entry') {
-            return Promise.resolve(publishedEntry);
-          }
-          if (id === 'changed_entry') {
-            return Promise.resolve(changedEntry);
-          }
-          return Promise.reject();
-        },
-        getEntityScheduledActions() {
-          return Promise.resolve([]);
-        }
-      },
-      dialogs: {
-        selectMultipleEntries: () => {
-          return [
-            {
-              sys: {
-                id: 'published_entry'
-              }
-            },
-            {
-              sys: {
-                id: 'changed_entry'
-              }
-            }
-          ]
-        }
-      },
-      navigator: {
-        openNewEntry: async () => {
-          return {
-            entity: {
-              sys: {
-                id: 'empty_entry'
-              }
-            }
-          }
-        },
-        openEntry: () => {
-          alert('open entry in slide in');
-          return Promise.resolve({});
-        },
-        onSlideInNavigation: () => () => {}
-      }
-    };
+    const [sdk, mitt] = newReferenceEditorFakeSdk();
     return (
       <div>
         <MultipleEntryReferenceEditor
           viewType="link"
           sdk={sdk}
-          isInitiallyDisabled={false}
+          isInitiallyDisabled={isInitiallyDisabled}
           parameters={{
-            instance: {
+            instance: instanceParams || {
               canCreateEntity: true,
               canLinkEntity: true
             }
@@ -112,103 +48,46 @@ import changedEntry from '../__fixtures__/changed_entry.json';
         <ActionsPlayground mitt={mitt} />
       </div>
     );
-
-}}
-
+  }}
 </Playground>
+
 
 ## With custom card
 
+Insert some references via _Link existing entries_. Click again to showcase inserting
+another reference rendered by the stardard card renderer.
+
 <Playground>
   {() => {
-    const initialValue = window.localStorage.getItem('initialValue');
     const isInitiallyDisabled = window.localStorage.getItem('initialDisabled');
     const instanceParams = window.localStorage.getItem('instanceParams');
-    const [field, mitt] = createFakeFieldAPI(field => field, initialValue);
-    const space = createFakeSpaceAPI();
-    const locales = createFakeLocalesAPI();
-    const sdk = {
-      field,
-      locales,
-      space: {
-        ...space,
-        getEntry: (id) => {
-          if (id === 'empty_entry') {
-            return Promise.resolve(emptyEntry);
-          }
-          if (id === 'published_entry') {
-            return Promise.resolve(publishedEntry);
-          }
-          if (id === 'changed_entry') {
-            return Promise.resolve(changedEntry);
-          }
-          return Promise.reject();
-        },
-        getEntityScheduledActions() {
-          return Promise.resolve([]);
-        }
-      },
-      dialogs: {
-        selectMultipleEntries: () => {
-          return [
-            {
-              sys: {
-                id: 'published_entry'
-              }
-            },
-            {
-              sys: {
-                id: 'changed_entry'
-              }
-            }
-          ]
-        }
-      },
-      navigator: {
-        openNewEntry: async () => {
-          return {
-            entity: {
-              sys: {
-                id: 'empty_entry'
-              }
-            }
-          }
-        },
-        openEntry: () => {
-          alert('open entry in slide in');
-          return Promise.resolve({});
-        },
-        onSlideInNavigation: () => () => {}
-      }
-    };
+    const [sdk, mitt] = newReferenceEditorFakeSdk();
     return (
-      <div>
+      <div data-test-id="multiple-references-editor-custom-cards-integration-test">
         <MultipleEntryReferenceEditor
-          viewType="link"
-          sdk={sdk}
-          isInitiallyDisabled={false}
-          parameters={{
-            instance: {
-              canCreateEntity: true,
-              canLinkEntity: true
-            }
-          }}
-          renderCard={(props) => <Card>
+          renderCard={(props) => props.entry.fields.exField ? <Card testId='custom-card'>
               <Typography style={{marginBottom: '20px'}}>
                 <Heading>{props.entry.fields.exField.en}</Heading>
                 <Paragraph>{props.entry.fields.exDesc.en}</Paragraph>
               </Typography>
               <Button onClick={props.onEdit} style={{marginRight: '10px'}}>Edit</Button>
               <Button onClick={props.onRemove}>Remove</Button>
-            </Card>
+            </Card> : false
           }
-         />
+          viewType="link"
+          sdk={sdk}
+          isInitiallyDisabled={isInitiallyDisabled}
+          parameters={{
+            instance: instanceParams || {
+              canCreateEntity: true,
+              canLinkEntity: true
+            }
+          }}
+        />
         <ActionsPlayground mitt={mitt} />
       </div>
     );
-
-}}
-
+  }}
 </Playground>
 
 ## Props

--- a/packages/reference/src/entries/SingleEntryReferenceEditor.mdx
+++ b/packages/reference/src/entries/SingleEntryReferenceEditor.mdx
@@ -15,12 +15,7 @@ import { SingleEntryReferenceEditor } from '@contentful/field-editor-reference';
 
 import { Playground, Props } from 'docz';
 import { SingleEntryReferenceEditor } from './SingleEntryReferenceEditor.tsx';
-import {
-  createFakeFieldAPI,
-  createFakeSpaceAPI,
-  createFakeLocalesAPI,
-  ActionsPlayground,
-} from '@contentful/field-editor-test-utils';
+import { ActionsPlayground } from '@contentful/field-editor-test-utils';
 import {
   Card,
   Button,
@@ -28,63 +23,15 @@ import {
   Paragraph,
   Heading,
 } from '@contentful/forma-36-react-components';
-import emptyEntry from '../__fixtures__/empty_entry.json';
-import publishedEntry from '../__fixtures__/published_entry.json';
+import { newReferenceEditorFakeSdk } from '../__fixtures__/FakeSdk'
 
 ## In Action
 
 <Playground>
   {() => {
-    const initialValue = window.localStorage.getItem('initialValue');
     const isInitiallyDisabled = window.localStorage.getItem('initialDisabled');
     const instanceParams = window.localStorage.getItem('instanceParams');
-    const [field, mitt] = createFakeFieldAPI(field => field, initialValue);
-    const space = createFakeSpaceAPI();
-    const locales = createFakeLocalesAPI();
-    const sdk = {
-      field,
-      locales,
-      space: {
-        ...space,
-        getEntry: (id) => {
-          if (id === 'empty_entry') {
-            return Promise.resolve(emptyEntry);
-          }
-          if (id === 'published_entry') {
-            return Promise.resolve(publishedEntry);
-          }
-          return Promise.reject();
-        },
-        getEntityScheduledActions() {
-          return Promise.resolve([]);
-        }
-      },
-      dialogs: {
-        selectSingleEntry: () => {
-          return {
-            sys: {
-              id: 'published_entry'
-            }
-          }
-        }
-      },
-      navigator: {
-        openNewEntry: async () => {
-          return {
-            entity: {
-              sys: {
-                id: 'empty_entry'
-              }
-            }
-          }
-        },
-        openEntry: () => {
-          alert('open entry in slide in');
-          return Promise.resolve({});
-        },
-        onSlideInNavigation: () => () => {}
-      }
-    };
+    const [sdk, mitt] = newReferenceEditorFakeSdk();
     return (
       <div>
         <SingleEntryReferenceEditor
@@ -101,82 +48,36 @@ import publishedEntry from '../__fixtures__/published_entry.json';
         <ActionsPlayground mitt={mitt} />
       </div>
     );
-
-}}
-
+  }}
 </Playground>
 
 ## With custom card
 
+Insert a reference via _Link existing entry_. Remove the inserted reference and click
+again to showcase inserting another reference rendered by the stardard card renderer.
+
 <Playground>
   {() => {
-    const initialValue = window.localStorage.getItem('initialValue');
     const isInitiallyDisabled = window.localStorage.getItem('initialDisabled');
     const instanceParams = window.localStorage.getItem('instanceParams');
-    const [field, mitt] = createFakeFieldAPI(field => field, initialValue);
-    const space = createFakeSpaceAPI();
-    const locales = createFakeLocalesAPI();
-    const sdk = {
-      field,
-      locales,
-      space: {
-        ...space,
-        getEntry: (id) => {
-          if (id === 'empty_entry') {
-            return Promise.resolve(emptyEntry);
-          }
-          if (id === 'published_entry') {
-            return Promise.resolve(publishedEntry);
-          }
-          return Promise.reject();
-        },
-        getEntityScheduledActions() {
-          return Promise.resolve([]);
-        }
-      },
-      dialogs: {
-        selectSingleEntry: () => {
-          return {
-            sys: {
-              id: 'published_entry'
-            }
-          }
-        }
-      },
-      navigator: {
-        openNewEntry: async () => {
-          return {
-            entity: {
-              sys: {
-                id: 'empty_entry'
-              }
-            }
-          }
-        },
-        openEntry: () => {
-          alert('open entry in slide in');
-          return Promise.resolve({});
-        },
-        onSlideInNavigation: () => () => {}
-      }
-    };
+    const [sdk, mitt] = newReferenceEditorFakeSdk();
     return (
       <div>
         <SingleEntryReferenceEditor
-          renderCard={(props) => <Card>
+          renderCard={(props) => props.entry.fields.exField ? <Card testId='custom-card'>
               <Typography style={{marginBottom: '20px'}}>
                 <Heading>{props.entry.fields.exField.en}</Heading>
                 <Paragraph>{props.entry.fields.exDesc.en}</Paragraph>
               </Typography>
               <Button onClick={props.onEdit} style={{marginRight: '10px'}}>Edit</Button>
               <Button onClick={props.onRemove}>Remove</Button>
-            </Card>
+            </Card> : false
           }
           viewType="card"
           sdk={sdk}
           isInitiallyDisabled={false}
           parameters={{
-            instance: {
+            instance: instanceParams || {
               canCreateEntity: true,
               canLinkEntity: true
             }
@@ -185,9 +86,7 @@ import publishedEntry from '../__fixtures__/published_entry.json';
         <ActionsPlayground mitt={mitt} />
       </div>
     );
-
-}}
-
+  }}
 </Playground>
 
 ## Props

--- a/packages/reference/src/entries/SingleEntryReferenceEditor.mdx
+++ b/packages/reference/src/entries/SingleEntryReferenceEditor.mdx
@@ -64,7 +64,7 @@ again to showcase inserting another reference rendered by the stardard card rend
     return (
       <div>
         <SingleEntryReferenceEditor
-          renderCard={(props) => props.entry.fields.exField ? <Card testId='custom-card'>
+          renderCustomCard={(props) => props.entry.fields.exField ? <Card testId='custom-card'>
               <Typography style={{marginBottom: '20px'}}>
                 <Heading>{props.entry.fields.exField.en}</Heading>
                 <Paragraph>{props.entry.fields.exDesc.en}</Paragraph>

--- a/packages/reference/src/entries/SingleEntryReferenceEditor.mdx
+++ b/packages/reference/src/entries/SingleEntryReferenceEditor.mdx
@@ -14,8 +14,20 @@ import { SingleEntryReferenceEditor } from '@contentful/field-editor-reference';
 ```
 
 import { Playground, Props } from 'docz';
-import { SingleEntryReferenceEditor } from './SingleEntryReferenceEditor.tsx'
-import { createFakeFieldAPI, createFakeSpaceAPI, createFakeLocalesAPI, ActionsPlayground } from '@contentful/field-editor-test-utils';
+import { SingleEntryReferenceEditor } from './SingleEntryReferenceEditor.tsx';
+import {
+  createFakeFieldAPI,
+  createFakeSpaceAPI,
+  createFakeLocalesAPI,
+  ActionsPlayground,
+} from '@contentful/field-editor-test-utils';
+import {
+  Card,
+  Button,
+  Typography,
+  Paragraph,
+  Heading,
+} from '@contentful/forma-36-react-components';
 import emptyEntry from '../__fixtures__/empty_entry.json';
 import publishedEntry from '../__fixtures__/published_entry.json';
 
@@ -94,10 +106,93 @@ import publishedEntry from '../__fixtures__/published_entry.json';
 
 </Playground>
 
+## With custom card
+
+<Playground>
+  {() => {
+    const initialValue = window.localStorage.getItem('initialValue');
+    const isInitiallyDisabled = window.localStorage.getItem('initialDisabled');
+    const instanceParams = window.localStorage.getItem('instanceParams');
+    const [field, mitt] = createFakeFieldAPI(field => field, initialValue);
+    const space = createFakeSpaceAPI();
+    const locales = createFakeLocalesAPI();
+    const sdk = {
+      field,
+      locales,
+      space: {
+        ...space,
+        getEntry: (id) => {
+          if (id === 'empty_entry') {
+            return Promise.resolve(emptyEntry);
+          }
+          if (id === 'published_entry') {
+            return Promise.resolve(publishedEntry);
+          }
+          return Promise.reject();
+        },
+        getEntityScheduledActions() {
+          return Promise.resolve([]);
+        }
+      },
+      dialogs: {
+        selectSingleEntry: () => {
+          return {
+            sys: {
+              id: 'published_entry'
+            }
+          }
+        }
+      },
+      navigator: {
+        openNewEntry: async () => {
+          return {
+            entity: {
+              sys: {
+                id: 'empty_entry'
+              }
+            }
+          }
+        },
+        openEntry: () => {
+          alert('open entry in slide in');
+          return Promise.resolve({});
+        },
+        onSlideInNavigation: () => () => {}
+      }
+    };
+    return (
+      <div>
+        <SingleEntryReferenceEditor
+          renderCard={(props) => <Card>
+              <Typography style={{marginBottom: '20px'}}>
+                <Heading>{props.entry.fields.exField.en}</Heading>
+                <Paragraph>{props.entry.fields.exDesc.en}</Paragraph>
+              </Typography>
+              <Button onClick={props.onEdit} style={{marginRight: '10px'}}>Edit</Button>
+              <Button onClick={props.onRemove}>Remove</Button>
+            </Card>
+          }
+          viewType="card"
+          sdk={sdk}
+          isInitiallyDisabled={false}
+          parameters={{
+            instance: {
+              canCreateEntity: true,
+              canLinkEntity: true
+            }
+          }}
+         />
+        <ActionsPlayground mitt={mitt} />
+      </div>
+    );
+
+}}
+
+</Playground>
+
 ## Props
 
 <Props of={SingleEntryReferenceEditor} />
-
 
 ## As field extension
 
@@ -105,7 +200,7 @@ import publishedEntry from '../__fixtures__/published_entry.json';
 import { SingleEntryReferenceEditor } from '@contentful/field-editor-reference';
 
 /// your extension code
-init(sdk => {
+init((sdk) => {
   if (sdk.location.is(locations.LOCATION_ENTRY_FIELD)) {
     render(
       <SingleEntryReferenceEditor viewType="card" sdk={sdk} />,

--- a/packages/reference/src/entries/SingleEntryReferenceEditor.tsx
+++ b/packages/reference/src/entries/SingleEntryReferenceEditor.tsx
@@ -3,16 +3,18 @@ import { ReferenceEditorProps } from '../common/ReferenceEditor';
 import { SingleReferenceEditor } from '../common/SingleReferenceEditor';
 import { FetchingWrappedEntryCard } from './WrappedEntryCard/FetchingWrappedEntryCard';
 
+// TODO:xxx Add renderCard prop
 export function SingleEntryReferenceEditor(props: ReferenceEditorProps) {
   return (
     <SingleReferenceEditor {...props} entityType="Entry">
-      {({ allContentTypes, isDisabled, entityId, setValue }) => {
+      {({ allContentTypes, isDisabled, entityId, setValue, renderCard }) => {
         return (
           <FetchingWrappedEntryCard
             {...props}
             allContentTypes={allContentTypes}
             isDisabled={isDisabled}
             entryId={entityId}
+            renderCard={renderCard}
             onRemove={() => {
               setValue(null);
             }}

--- a/packages/reference/src/entries/SingleEntryReferenceEditor.tsx
+++ b/packages/reference/src/entries/SingleEntryReferenceEditor.tsx
@@ -6,14 +6,14 @@ import { FetchingWrappedEntryCard } from './WrappedEntryCard/FetchingWrappedEntr
 export function SingleEntryReferenceEditor(props: ReferenceEditorProps) {
   return (
     <SingleReferenceEditor {...props} entityType="Entry">
-      {({ allContentTypes, isDisabled, entityId, setValue, renderCard }) => {
+      {({ allContentTypes, isDisabled, entityId, setValue, renderCustomCard }) => {
         return (
           <FetchingWrappedEntryCard
             {...props}
             allContentTypes={allContentTypes}
             isDisabled={isDisabled}
             entryId={entityId}
-            renderCard={renderCard}
+            renderCustomCard={renderCustomCard}
             onRemove={() => {
               setValue(null);
             }}

--- a/packages/reference/src/entries/SingleEntryReferenceEditor.tsx
+++ b/packages/reference/src/entries/SingleEntryReferenceEditor.tsx
@@ -3,7 +3,6 @@ import { ReferenceEditorProps } from '../common/ReferenceEditor';
 import { SingleReferenceEditor } from '../common/SingleReferenceEditor';
 import { FetchingWrappedEntryCard } from './WrappedEntryCard/FetchingWrappedEntryCard';
 
-// TODO:xxx Add renderCard prop
 export function SingleEntryReferenceEditor(props: ReferenceEditorProps) {
   return (
     <SingleReferenceEditor {...props} entityType="Entry">

--- a/packages/reference/src/entries/WrappedEntryCard/FetchingWrappedEntryCard.tsx
+++ b/packages/reference/src/entries/WrappedEntryCard/FetchingWrappedEntryCard.tsx
@@ -15,7 +15,7 @@ export type EntryCardReferenceEditorProps = ReferenceEditorProps & {
   isDisabled: boolean;
   onRemove: () => void;
   cardDragHandle?: React.ReactElement;
-  renderCard?: (props: CustomEntryCardProps) => React.ReactElement | false;
+  renderCustomCard?: (props: CustomEntryCardProps) => React.ReactElement | false;
 };
 
 async function openEntry(
@@ -122,8 +122,8 @@ export function FetchingWrappedEntryCard(props: EntryCardReferenceEditorProps) {
       onEdit,
       onRemove,
     };
-    if (props.renderCard) {
-      const renderedCustomCard = props.renderCard(sharedCardProps);
+    if (props.renderCustomCard) {
+      const renderedCustomCard = props.renderCustomCard(sharedCardProps);
       // Only `false` indicates to render the original card. E.g. `null` would result in no card.
       if (renderedCustomCard !== false) {
         return renderedCustomCard;

--- a/packages/reference/src/entries/WrappedEntryCard/FetchingWrappedEntryCard.tsx
+++ b/packages/reference/src/entries/WrappedEntryCard/FetchingWrappedEntryCard.tsx
@@ -13,6 +13,7 @@ export type EntryCardReferenceEditorProps = ReferenceEditorProps & {
   isDisabled: boolean;
   onRemove: () => void;
   cardDragHandle?: React.ReactElement;
+  renderCard: Function
 };
 
 async function openEntry(
@@ -61,6 +62,52 @@ export function FetchingWrappedEntryCard(props: EntryCardReferenceEditorProps) {
       ? 'undefined'
       : `:${entry.sys.id}:${entry.sys.version}`;
 
+  // TODO:xxx Expose `WrappedEntryCard` as part of this lib.
+  const cardProp: WrappedEntryCardProps = {
+    // TODO:xxx take props passed to `WrappedEntryCard` and define in here instead
+  };
+
+  const renderOriginalCard = () => (
+    <WrappedEntryCard
+      // TODO:xxx
+      // {...cardProps}
+      getAsset={props.sdk.space.getAsset}
+      getEntityScheduledActions={props.sdk.space.getEntityScheduledActions}
+      getEntryUrl={props.getEntityUrl}
+      isDisabled={props.isDisabled}
+      size={size}
+      localeCode={props.sdk.field.locale}
+      defaultLocaleCode={props.sdk.locales.default}
+      allContentTypes={props.allContentTypes}
+      entry={entry}
+      cardDragHandle={props.cardDragHandle}
+      onEdit={async () => {
+        const slide = await openEntry(props.sdk, entry.sys.id, {
+          bulkEditing: props.parameters.instance.bulkEditing,
+          index: props.index,
+        });
+        props.onAction &&
+        props.onAction({
+          entity: 'Entry',
+          type: 'edit',
+          id: entry.sys.id,
+          contentTypeId: entry.sys.contentType.sys.id,
+          slide,
+        });
+      }}
+      onRemove={() => {
+        props.onRemove();
+        props.onAction &&
+        props.onAction({
+          entity: 'Entry',
+          type: 'delete',
+          id: entry.sys.id,
+          contentTypeId: entry.sys.contentType.sys.id,
+        });
+      }}
+    />
+  );
+
   React.useEffect(() => {
     if (entry) {
       props.onAction && props.onAction({ type: 'rendered', entity: 'Entry' });
@@ -80,43 +127,12 @@ export function FetchingWrappedEntryCard(props: EntryCardReferenceEditorProps) {
     if (entry === undefined) {
       return <EntryCard size={size} loading />;
     }
-    return (
-      <WrappedEntryCard
-        getAsset={props.sdk.space.getAsset}
-        getEntityScheduledActions={props.sdk.space.getEntityScheduledActions}
-        getEntryUrl={props.getEntityUrl}
-        isDisabled={props.isDisabled}
-        size={size}
-        localeCode={props.sdk.field.locale}
-        defaultLocaleCode={props.sdk.locales.default}
-        allContentTypes={props.allContentTypes}
-        entry={entry}
-        cardDragHandle={props.cardDragHandle}
-        onEdit={async () => {
-          const slide = await openEntry(props.sdk, entry.sys.id, {
-            bulkEditing: props.parameters.instance.bulkEditing,
-            index: props.index,
-          });
-          props.onAction &&
-            props.onAction({
-              entity: 'Entry',
-              type: 'edit',
-              id: entry.sys.id,
-              contentTypeId: entry.sys.contentType.sys.id,
-              slide,
-            });
-        }}
-        onRemove={() => {
-          props.onRemove();
-          props.onAction &&
-            props.onAction({
-              entity: 'Entry',
-              type: 'delete',
-              id: entry.sys.id,
-              contentTypeId: entry.sys.contentType.sys.id,
-            });
-        }}
-      />
-    );
+    if(props.renderCard) {
+      const renderedCustomCard = props.renderCard(cardProps);
+      // Only `false` indicates to render the original card. E.g. `null` would result in no card.
+      return renderedCustomCard === false ? renderOriginalCard() : renderedCustomCard;
+    } else {
+      return renderOriginalCard()
+    }
   }, [props, entityKey]);
 }

--- a/packages/reference/src/entries/WrappedEntryCard/WrappedEntryCard.tsx
+++ b/packages/reference/src/entries/WrappedEntryCard/WrappedEntryCard.tsx
@@ -21,10 +21,10 @@ const styles = {
   }),
 };
 
-interface WrappedEntryCardProps {
+export interface WrappedEntryCardProps {
   getEntityScheduledActions: SpaceAPI['getEntityScheduledActions'];
   getAsset: (assetId: string) => Promise<unknown>;
-  getEntryUrl?: (entryId: string) => string;
+  entryUrl?: string;
   size: 'small' | 'default';
   isDisabled: boolean;
   isSelected?: boolean;
@@ -32,7 +32,7 @@ interface WrappedEntryCardProps {
   onEdit?: () => void;
   localeCode: string;
   defaultLocaleCode: string;
-  allContentTypes: ContentType[];
+  contentType?: ContentType;
   entry: Entry;
   cardDragHandle?: React.ReactElement;
   isClickable: boolean;
@@ -45,9 +45,7 @@ const defaultProps = {
 export function WrappedEntryCard(props: WrappedEntryCardProps) {
   const [file, setFile] = React.useState<null | File>(null);
 
-  const contentType = props.allContentTypes.find(
-    (contentType) => contentType.sys.id === props.entry?.sys.contentType.sys.id
-  );
+  const { contentType } = props;
 
   React.useEffect(() => {
     if (props.entry) {
@@ -97,8 +95,10 @@ export function WrappedEntryCard(props: WrappedEntryCardProps) {
   });
 
   return (
+    // TODO: There should be dedicated components for each `size` with a different
+    //  set of params (e.g. `file` should only be relevant for the "small" size card.
     <EntryCard
-      href={props.getEntryUrl ? props.getEntryUrl(props.entry.sys.id) : undefined}
+      href={props.entryUrl}
       title={title}
       description={description}
       contentType={contentType?.name}

--- a/packages/reference/src/index.tsx
+++ b/packages/reference/src/index.tsx
@@ -13,3 +13,4 @@ export {
 } from './entries';
 export { SingleMediaEditor, MultipleMediaEditor, WrappedAssetCard } from './assets';
 export { EntityProvider, useEntities } from './common/EntityStore';
+export { CustomEntryCardProps } from './common/ReferenceEditor';

--- a/packages/reference/tsconfig.json
+++ b/packages/reference/tsconfig.json
@@ -8,6 +8,7 @@
     "baseUrl": "./",
     "paths": {
       "*": ["node_modules/*"]
-    }
+    },
+    "resolveJsonModule": true
   }
 }

--- a/packages/rich-text/src/plugins/EmbeddedEntityBlock/FetchingWrappedEntryCard.js
+++ b/packages/rich-text/src/plugins/EmbeddedEntityBlock/FetchingWrappedEntryCard.js
@@ -36,19 +36,21 @@ export function FetchingWrappedEntryCard(props) {
     return <EntryCard size="default" loading />;
   }
 
-  const allContentTypes = props.sdk.space.getCachedContentTypes();
+  const contentType = props.sdk.space
+    .getCachedContentTypes()
+    .find((contentType) => contentType.sys.id === entry.sys.contentType.sys.id);
 
   return (
     <WrappedEntryCard
       getAsset={props.sdk.space.getAsset}
       getEntityScheduledActions={props.sdk.space.getEntityScheduledActions}
-      getEntryUrl={props.getEntryUrl}
+      entryUrl={props.getEntryUrl && props.getEntryUrl(entry.sys.id)}
       size="default"
       isSelected={props.isSelected}
       isDisabled={props.isDisabled}
       localeCode={props.locale}
       defaultLocaleCode={props.sdk.locales.default}
-      allContentTypes={allContentTypes}
+      contentType={contentType}
       entry={entry}
       onEdit={props.onEdit}
       onRemove={props.onRemove}


### PR DESCRIPTION
Adds a `renderCard: (props: CustomEntryCardProps) => React.ReactElement | false;` prop to reference editors.

Closes https://github.com/contentful/field-editors/issues/283