### PR TITLE
feat: 🎸 listen to pubsub entity updates in reference editor

### DIFF
--- a/packages/reference/src/common/EntityStore.ts
+++ b/packages/reference/src/common/EntityStore.ts
@@ -28,32 +28,32 @@ function reducer(state: State, action: DispatchAction): State {
         ...state,
         entries: {
           ...state.entries,
-          [action.id]: action.entry
-        }
+          [action.id]: action.entry,
+        },
       };
     case 'set_entry_failed':
       return {
         ...state,
         entries: {
           ...state.entries,
-          [action.id]: 'failed'
-        }
+          [action.id]: 'failed',
+        },
       };
     case 'set_asset':
       return {
         ...state,
         assets: {
           ...state.assets,
-          [action.id]: action.asset
-        }
+          [action.id]: action.asset,
+        },
       };
     case 'set_asset_failed':
       return {
         ...state,
         assets: {
           ...state.assets,
-          [action.id]: 'failed'
-        }
+          [action.id]: 'failed',
+        },
       };
     default:
       return state;
@@ -62,7 +62,7 @@ function reducer(state: State, action: DispatchAction): State {
 
 const initialState: State = {
   entries: {},
-  assets: {}
+  assets: {},
 };
 
 function useEntitiesStore(props: { sdk: BaseExtensionSDK }) {
@@ -71,7 +71,7 @@ function useEntitiesStore(props: { sdk: BaseExtensionSDK }) {
   const loadEntry = (id: string) => {
     props.sdk.space
       .getEntry<Entry>(id)
-      .then(entry => {
+      .then((entry) => {
         dispatch({ type: 'set_entry', id, entry });
       })
       .catch(() => {
@@ -82,7 +82,7 @@ function useEntitiesStore(props: { sdk: BaseExtensionSDK }) {
   const loadAsset = (id: string) => {
     props.sdk.space
       .getAsset<Asset>(id)
-      .then(asset => {
+      .then((asset) => {
         dispatch({ type: 'set_asset', id, asset });
       })
       .catch(() => {
@@ -91,25 +91,49 @@ function useEntitiesStore(props: { sdk: BaseExtensionSDK }) {
   };
 
   React.useEffect(() => {
-    const unsubscribe = props.sdk.navigator.onSlideInNavigation(
-      ({ oldSlideLevel, newSlideLevel }) => {
-        if (oldSlideLevel > newSlideLevel) {
-          Object.keys(state.entries).map(id => {
-            if (state.entries[id] && state.entries[id] !== 'failed') {
-              loadEntry(id);
-            }
-          });
-          Object.keys(state.assets).map(id => {
-            if (state.assets[id] && state.assets[id] !== 'failed') {
-              loadAsset(id);
-            }
-          });
+    // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+    // @ts-ignore
+    if (typeof props.sdk.space.onEntityChanged !== 'undefined') {
+      // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+      // @ts-ignore
+      const onEntityChanged = props.sdk.space.onEntityChanged;
+      const listeners: Function[] = [];
+      Object.keys(state.entries).forEach((id) => {
+        if (state.entries[id] && state.entries['id'] !== 'failed') {
+          listeners.push(
+            onEntityChanged('Entry', id, (entry: Entry) =>
+              dispatch({ type: 'set_entry', id, entry })
+            )
+          );
         }
+      });
+      Object.keys(state.assets).forEach((id) => {
+        if (state.assets[id] && state.assets['id'] !== 'failed') {
+          listeners.push(
+            onEntityChanged('Asset', id, (asset: Asset) =>
+              dispatch({ type: 'set_asset', id, asset })
+            )
+          );
+        }
+      });
+
+      return () => listeners.forEach((off) => off());
+    }
+
+    return props.sdk.navigator.onSlideInNavigation(({ oldSlideLevel, newSlideLevel }) => {
+      if (oldSlideLevel > newSlideLevel) {
+        Object.keys(state.entries).map((id) => {
+          if (state.entries[id] && state.entries[id] !== 'failed') {
+            loadEntry(id);
+          }
+        });
+        Object.keys(state.assets).map((id) => {
+          if (state.assets[id] && state.assets[id] !== 'failed') {
+            loadAsset(id);
+          }
+        });
       }
-    );
-    return () => {
-      unsubscribe();
-    };
+    }) as { (): void };
   }, [props.sdk, state.assets, state.entries]);
 
   return { loadEntry, loadAsset, ...state };


### PR DESCRIPTION
If `sdk.space.onEntityChanged` is available, use it to listen to entity changes and update them in the store instead of refreshing everything in `navigator.onSlideInNavigator`.

Currently `sdk.space.onEntityChanged` allows subscribing to changes per entity, so a set of listeners — for all entries and assets already loaded in the store — is instantiated in the hook.