### PR TITLE
fix(reference): trigger 'rendered' event in multiple references once all entities are loaded

### DIFF
--- a/packages/reference/src/common/MultipleReferenceEditor.tsx
+++ b/packages/reference/src/common/MultipleReferenceEditor.tsx
@@ -5,6 +5,7 @@ import { fromFieldValidations } from '../utils/fromFieldValidations';
 import { ReferenceEditor, ReferenceEditorProps } from './ReferenceEditor';
 import { LinkEntityActions } from '../components';
 import { SortEndHandler, SortStartHandler } from 'react-sortable-hoc';
+import { useMultipleReferenceLoadTracking } from './useMultipleReferenceLoadTracking';
 
 type ChildProps = {
   entityType: EntityType;
@@ -128,11 +129,16 @@ export function MultipleReferenceEditor(
   }
 ) {
   const allContentTypes = props.sdk.space.getCachedContentTypes();
+  const [onAction, setItemsToLoadCount] = useMultipleReferenceLoadTracking(props.onAction);
 
   return (
     <ReferenceEditor<ReferenceValue[]> {...props}>
       {({ value, disabled, setValue, externalReset }) => {
         const items = value || [];
+        if (value) {
+          setItemsToLoadCount(value.length);
+        }
+
         return (
           <Editor
             {...props}
@@ -141,6 +147,7 @@ export function MultipleReferenceEditor(
             setValue={setValue}
             key={`${externalReset}-list`}
             allContentTypes={allContentTypes}
+            onAction={onAction}
           />
         );
       }}

--- a/packages/reference/src/common/useMultipleReferenceLoadTracking.ts
+++ b/packages/reference/src/common/useMultipleReferenceLoadTracking.ts
@@ -1,0 +1,46 @@
+import noop from 'lodash/noop';
+import { Action } from '../types';
+import { useEffect, useRef, useState } from 'react';
+
+type OnAction = (action: Action) => void;
+
+/**
+ * Intercept "rendered" event to count rendered entities cards.
+ * Once the expected number of events is counted (i.e. all cards are rendered), forward the event further.
+ */
+export function useMultipleReferenceLoadTracking(
+  onAction?: OnAction
+): [OnAction | undefined, (count: number) => void] {
+  const [rendered, setRendered] = useState(false);
+  const countRef = useRef({ toRender: -1, rendered: 0 });
+
+  useEffect(() => {
+    if (rendered && onAction) {
+      onAction({ type: 'rendered' });
+    }
+  }, [rendered]);
+
+  if (!onAction) {
+    return [onAction, noop];
+  }
+
+  function modifiedOnAction(action: Action) {
+    if (action.type === 'rendered') {
+      countRef.current.rendered += 1;
+      if (countRef.current.rendered === countRef.current.toRender) {
+        setRendered(true);
+      }
+      return;
+    }
+
+    return onAction!(action);
+  }
+
+  function setItemsToLoadCount(count: number) {
+    if (countRef.current.toRender === -1) {
+      countRef.current.toRender = count;
+    }
+  }
+
+  return [modifiedOnAction, setItemsToLoadCount];
+}

--- a/packages/reference/src/types.ts
+++ b/packages/reference/src/types.ts
@@ -8,7 +8,7 @@ export {
   ContentTypeField,
   Link,
   EntityType,
-  NavigatorSlideInfo
+  NavigatorSlideInfo,
 } from 'contentful-ui-extensions-sdk';
 
 export { Entry, File, Asset } from '@contentful/field-editor-shared';
@@ -55,4 +55,4 @@ export type Action =
       slide?: NavigatorSlideInfo;
     }
   | { type: 'delete'; contentTypeId: string; id: string; entity: EntityType }
-  | { type: 'rendered'; entity: EntityType };
+  | { type: 'rendered'; entity?: EntityType };


### PR DESCRIPTION
We want to track when **all** entities are loaded in a multiple reference field. To do so `rendered` events coming from `FetchingWrapped*Card` must be counted until to determine when all of them are loaded, then the actual `rendered` event can be triggered.

This is implemented as a `useMultipleReferenceLoadTracking` hook which intercepts and counts events passed to `onAction`.