### PR TITLE
fix: Remove renderCustomCard prop from media editors

### DIFF
--- a/packages/reference/src/assets/MultipleMediaEditor.tsx
+++ b/packages/reference/src/assets/MultipleMediaEditor.tsx
@@ -3,7 +3,10 @@ import { ReferenceEditorProps } from '../common/ReferenceEditor';
 import { MultipleReferenceEditor } from '../common/MultipleReferenceEditor';
 import { SortableLinkList } from './SortableElements';
 
-export function MultipleMediaEditor(props: ReferenceEditorProps) {
+// TODO: Implement `renderCustomCard` prop for MultipleMediaEditor.
+type EditorProps = Omit<ReferenceEditorProps, 'renderCustomCard'>;
+
+export function MultipleMediaEditor(props: EditorProps) {
   return (
     <MultipleReferenceEditor {...props} entityType="Asset">
       {(childrenProps) => (

--- a/packages/reference/src/assets/SingleMediaEditor.tsx
+++ b/packages/reference/src/assets/SingleMediaEditor.tsx
@@ -3,7 +3,10 @@ import { FetchingWrappedAssetCard } from './WrappedAssetCard/FetchingWrappedAsse
 import { ReferenceEditorProps } from '../common/ReferenceEditor';
 import { SingleReferenceEditor } from '../common/SingleReferenceEditor';
 
-export function SingleMediaEditor(props: ReferenceEditorProps) {
+// TODO: Implement `renderCustomCard` prop for SingleMediaEditor.
+type EditorProps = Omit<ReferenceEditorProps, 'renderCustomCard'>;
+
+export function SingleMediaEditor(props: EditorProps) {
   return (
     <SingleReferenceEditor {...props} entityType="Asset">
       {({ entityId, isDisabled, setValue }) => (


### PR DESCRIPTION
The `renderCustomCard` is not yet implemented for media (asset link) editors thus, it should be removed from their list of props and documentation.