### PR TITLE
feat: add hascardeditactions flag to reference editor

### DIFF
--- a/packages/reference/src/assets/MultipleMediaEditor.tsx
+++ b/packages/reference/src/assets/MultipleMediaEditor.tsx
@@ -4,7 +4,7 @@ import { MultipleReferenceEditor } from '../common/MultipleReferenceEditor';
 import { SortableLinkList } from './SortableElements';
 
 // TODO: Implement `renderCustomCard` prop for MultipleMediaEditor.
-type EditorProps = Omit<ReferenceEditorProps, 'renderCustomCard'>;
+type EditorProps = Omit<ReferenceEditorProps, 'renderCustomCard' | 'hasCardEditActions'>;
 
 export function MultipleMediaEditor(props: EditorProps) {
   return (

--- a/packages/reference/src/assets/SingleMediaEditor.tsx
+++ b/packages/reference/src/assets/SingleMediaEditor.tsx
@@ -4,7 +4,7 @@ import { ReferenceEditorProps } from '../common/ReferenceEditor';
 import { SingleReferenceEditor } from '../common/SingleReferenceEditor';
 
 // TODO: Implement `renderCustomCard` prop for SingleMediaEditor.
-type EditorProps = Omit<ReferenceEditorProps, 'renderCustomCard'>;
+type EditorProps = Omit<ReferenceEditorProps, 'renderCustomCard' | 'hasCardEditActions'>;
 
 export function SingleMediaEditor(props: EditorProps) {
   return (

--- a/packages/reference/src/common/MultipleReferenceEditor.tsx
+++ b/packages/reference/src/common/MultipleReferenceEditor.tsx
@@ -147,3 +147,7 @@ export function MultipleReferenceEditor(
     </ReferenceEditor>
   );
 }
+
+MultipleReferenceEditor.defaultProps = {
+  hasCardEditActions: true,
+};

--- a/packages/reference/src/common/ReferenceEditor.tsx
+++ b/packages/reference/src/common/ReferenceEditor.tsx
@@ -15,6 +15,7 @@ export interface ReferenceEditorProps {
   sdk: FieldExtensionSDK;
   viewType: ViewType;
   renderCustomCard?: (props: CustomEntryCardProps) => React.ReactElement | false;
+  hasCardEditActions: boolean;
   getEntityUrl?: (entryId: string) => string;
   onAction?: (action: Action) => void;
   parameters: {
@@ -63,4 +64,5 @@ export function ReferenceEditor<T>(
 
 ReferenceEditor.defaultProps = {
   isInitiallyDisabled: true,
+  hasCardEditActions: true,
 };

--- a/packages/reference/src/common/SingleReferenceEditor.tsx
+++ b/packages/reference/src/common/SingleReferenceEditor.tsx
@@ -11,6 +11,7 @@ type ChildProps = {
   setValue: (value: ReferenceValue | null | undefined) => void;
   allContentTypes: ContentType[];
   renderCustomCard?: (props: CustomEntryCardProps) => React.ReactElement | false;
+  hasCardEditActions: boolean;
 };
 
 type EditorProps = ReferenceEditorProps &
@@ -128,3 +129,7 @@ export function SingleReferenceEditor(
     </ReferenceEditor>
   );
 }
+
+SingleReferenceEditor.defaultProps = {
+  hasCardEditActions: true,
+};

--- a/packages/reference/src/entries/SingleEntryReferenceEditor.tsx
+++ b/packages/reference/src/entries/SingleEntryReferenceEditor.tsx
@@ -6,7 +6,14 @@ import { FetchingWrappedEntryCard } from './WrappedEntryCard/FetchingWrappedEntr
 export function SingleEntryReferenceEditor(props: ReferenceEditorProps) {
   return (
     <SingleReferenceEditor {...props} entityType="Entry">
-      {({ allContentTypes, isDisabled, entityId, setValue, renderCustomCard }) => {
+      {({
+        allContentTypes,
+        isDisabled,
+        entityId,
+        setValue,
+        renderCustomCard,
+        hasCardEditActions,
+      }) => {
         return (
           <FetchingWrappedEntryCard
             {...props}
@@ -14,6 +21,7 @@ export function SingleEntryReferenceEditor(props: ReferenceEditorProps) {
             isDisabled={isDisabled}
             entryId={entityId}
             renderCustomCard={renderCustomCard}
+            hasCardEditActions={hasCardEditActions}
             onRemove={() => {
               setValue(null);
             }}

--- a/packages/reference/src/entries/WrappedEntryCard/FetchingWrappedEntryCard.tsx
+++ b/packages/reference/src/entries/WrappedEntryCard/FetchingWrappedEntryCard.tsx
@@ -16,6 +16,7 @@ export type EntryCardReferenceEditorProps = ReferenceEditorProps & {
   onRemove: () => void;
   cardDragHandle?: React.ReactElement;
   renderCustomCard?: (props: CustomEntryCardProps) => React.ReactElement | false;
+  hasCardEditActions: boolean;
 };
 
 async function openEntry(
@@ -78,6 +79,7 @@ export function FetchingWrappedEntryCard(props: EntryCardReferenceEditorProps) {
         slide,
       });
   };
+
   const onRemove = () => {
     props.onRemove();
     props.onAction &&
@@ -132,6 +134,7 @@ export function FetchingWrappedEntryCard(props: EntryCardReferenceEditorProps) {
     const builtinCardProps: WrappedEntryCardProps = {
       ...sharedCardProps,
       isClickable: false,
+      hasCardEditActions: props.hasCardEditActions,
       getAsset: props.sdk.space.getAsset,
       getEntityScheduledActions: props.sdk.space.getEntityScheduledActions,
     };

--- a/packages/reference/src/entries/WrappedEntryCard/WrappedEntryCard.tsx
+++ b/packages/reference/src/entries/WrappedEntryCard/WrappedEntryCard.tsx
@@ -36,10 +36,12 @@ export interface WrappedEntryCardProps {
   entry: Entry;
   cardDragHandle?: React.ReactElement;
   isClickable: boolean;
+  hasCardEditActions: boolean;
 }
 
 const defaultProps = {
   isClickable: true,
+  hasCardEditActions: true,
 };
 
 export function WrappedEntryCard(props: WrappedEntryCardProps) {
@@ -132,7 +134,7 @@ export function WrappedEntryCard(props: WrappedEntryCardProps) {
               onClick={(e) => {
                 e.stopPropagation();
               }}>
-              {props.onEdit && (
+              {props.hasCardEditActions && props.onEdit && (
                 <DropdownListItem
                   onClick={() => {
                     props.onEdit && props.onEdit();


### PR DESCRIPTION
This PR adds an `hasCardEditActions ` prop to the Reference Editor. This prop defaults to true but when set to false it will hide the edit option from the CardActionMenu.