### PR TITLE
fix: 🐛 ensure correct style for code and italic marks

### DIFF
--- a/packages/rich-text/src/plugins/shared/MarkPlugin.js
+++ b/packages/rich-text/src/plugins/shared/MarkPlugin.js
@@ -7,23 +7,30 @@ import tokens from '@contentful/forma-36-tokens';
 const styles = {
   bold: css({
     color: 'inherit',
-    fontWeight: tokens.fontWeightDemiBold
+    fontWeight: tokens.fontWeightDemiBold,
   }),
   headingBold: css({
-    fontWeight: 900
-  })
+    fontWeight: 900, // Make headings which are already bold even bolder.
+  }),
+  italic: css({
+    fontStyle: 'italic',
+  }),
+  code: css({
+    fontFamily: tokens.fontStackMonospace,
+    fontSize: '.9em', // Can't use `rem` to account for code inside a heading.
+  }),
 };
 
-const isHeading = tagName => /^h[1-6]$/.test(tagName);
+const isHeading = (tagName) => /^h[1-6]$/.test(tagName);
 
-const getClassName = (type, tagName) =>
-  type === 'bold' ? cx(styles.bold, isHeading(tagName) && styles.headingBold) : '';
+const getMarkStyles = (type, tagName) =>
+  type === 'bold' ? cx(styles.bold, isHeading(tagName) && styles.headingBold) : styles[type];
 
-export default function({ type, tagName, hotkey, richTextAPI }) {
+export default function ({ type, tagName, hotkey, richTextAPI }) {
   return {
     renderMark: (props, _editor, next) => {
       if (props.mark.type === type) {
-        return markDecorator(tagName, { className: getClassName(type, tagName) })(props);
+        return markDecorator(tagName, { className: getMarkStyles(type, tagName) })(props);
       }
       return next();
     },
@@ -36,6 +43,6 @@ export default function({ type, tagName, hotkey, richTextAPI }) {
         return;
       }
       return next();
-    }
+    },
   };
 }


### PR DESCRIPTION
In an enviornment with reset css styles code and italic marks might have shown as normal text. This change ensures they are formatted explicitly.