### PR TITLE
fix: 🐛 vertical jitter effect when applying rich text code mark

### DIFF
--- a/packages/rich-text/src/plugins/shared/MarkPlugin.js
+++ b/packages/rich-text/src/plugins/shared/MarkPlugin.js
@@ -13,6 +13,7 @@ const styles = {
   }),
   italic: css({
     fontStyle: 'italic',
+    lineHeight: 1, // Prevents vertical jitter effect when applying code mark.
   }),
   code: css({
     fontFamily: tokens.fontStackMonospace,


### PR DESCRIPTION
Fixes the following unpleasant effect whenever applying a code mark (also applies for normal text, not just headings)

![jitter](https://user-images.githubusercontent.com/101926/89577706-5f2cf380-d831-11ea-93dd-da94ae478e38.gif)
