### PR TITLE
feat: 🎸 refined editor focusing when using toolbar actions

### DIFF
--- a/packages/rich-text/src/Toolbar/index.js
+++ b/packages/rich-text/src/Toolbar/index.js
@@ -60,6 +60,8 @@ export default class Toolbar extends React.Component {
     onChange: PropTypes.func.isRequired,
   };
 
+  isReadyToSetFocusProgrammatically = false;
+
   state = {
     headingMenuOpen: false,
     canAccessAssets: false,
@@ -146,12 +148,18 @@ export default class Toolbar extends React.Component {
 
   render() {
     const { editor, isDisabled, richTextAPI } = this.props;
+    if (editor.value.selection.isFocused) {
+      // If the Slate input has ever been focused by the user, we can now also
+      // programmatically use `editor.setFocus()` without undesired side-effects.
+      this.isReadyToSetFocusProgrammatically = true;
+    }
     const props = {
       editor,
       onToggle: this.onChange,
       onCloseEmbedMenu: this.toggleEmbedDropdown,
       disabled: isDisabled,
       richTextAPI,
+      canAutoFocus: this.isReadyToSetFocusProgrammatically,
     };
     const { field } = richTextAPI.sdk;
     const { isAnyHyperlinkEnabled, isAnyListEnabled, isAnyMarkEnabled } = this.state;

--- a/packages/rich-text/src/plugins/EmbeddedEntityBlock/ToolbarIcon.js
+++ b/packages/rich-text/src/plugins/EmbeddedEntityBlock/ToolbarIcon.js
@@ -4,28 +4,32 @@ import { DropdownListItem, Button, Icon } from '@contentful/forma-36-react-compo
 
 import { selectEntityAndInsert } from './Util';
 import { TOOLBAR_PLUGIN_PROP_TYPES } from '../shared/PluginApi';
+import { toolbarActionHandlerWithSafeAutoFocus } from '../shared/Util';
 
 export default class EntityLinkToolbarIcon extends Component {
   static propTypes = {
     ...TOOLBAR_PLUGIN_PROP_TYPES,
-    isButton: PropTypes.bool
+    isButton: PropTypes.bool,
   };
 
   static defaultProps = {
-    isButton: false
+    isButton: false,
   };
 
-  handleClick = async event => {
+  handleClick = (e) => {
     this.props.onCloseEmbedMenu();
-    event.preventDefault();
+    this.handleAction(e);
+  };
+
+  handleAction = toolbarActionHandlerWithSafeAutoFocus(this, async () => {
     const {
       editor,
       nodeType,
-      richTextAPI: { sdk, logToolbarAction }
+      richTextAPI: { sdk, logToolbarAction },
     } = this.props;
     await selectEntityAndInsert(nodeType, sdk, editor, logToolbarAction);
     this.props.onToggle(editor);
-  };
+  });
 
   render() {
     const { nodeType } = this.props;
@@ -36,7 +40,7 @@ export default class EntityLinkToolbarIcon extends Component {
         disabled={this.props.disabled}
         className={`${baseClass}-button`}
         size="small"
-        onClick={event => this.handleClick(event)}
+        onClick={this.handleClick}
         icon={type === 'Asset' ? 'Asset' : 'EmbeddedEntryBlock'}
         buttonType="muted"
         testId={`toolbar-toggle-${nodeType}`}>
@@ -47,7 +51,7 @@ export default class EntityLinkToolbarIcon extends Component {
         isDisabled={this.props.disabled}
         className={`${baseClass}-list-item`}
         size="small"
-        onClick={event => this.handleClick(event)}
+        onClick={this.handleClick}
         testId={`toolbar-toggle-${nodeType}`}>
         <div className="cf-flex-grid">
           <Icon

--- a/packages/rich-text/src/plugins/EmbeddedEntryInline/ToolbarIcon.js
+++ b/packages/rich-text/src/plugins/EmbeddedEntryInline/ToolbarIcon.js
@@ -4,30 +4,36 @@ import { INLINES } from '@contentful/rich-text-types';
 
 import { selectEntryAndInsert, canInsertInline } from './Utils';
 import { TOOLBAR_PLUGIN_PROP_TYPES } from '../shared/PluginApi';
+import { toolbarActionHandlerWithSafeAutoFocus } from '../shared/Util';
 
 export default class EntryLinkToolbarIcon extends Component {
   static propTypes = TOOLBAR_PLUGIN_PROP_TYPES;
 
   static defaultProps = {
-    isButton: false
+    isButton: false,
   };
-  handleClick = async event => {
+
+  handleClick = (e) => {
     this.props.onCloseEmbedMenu();
-    event.preventDefault();
+    this.handleAction(e);
+  };
+
+  handleAction = toolbarActionHandlerWithSafeAutoFocus(this, async () => {
     const {
       editor,
-      richTextAPI: { sdk, logToolbarAction }
+      richTextAPI: { sdk, logToolbarAction },
     } = this.props;
     await selectEntryAndInsert(sdk, editor, logToolbarAction);
     this.props.onToggle(editor);
-  };
+  });
+
   render() {
     return this.props.isButton ? (
       <Button
         disabled={this.props.disabled}
         className={`${INLINES.EMBEDDED_ENTRY}-button`}
         size="small"
-        onClick={event => this.handleClick(event)}
+        onClick={(event) => this.handleClick(event)}
         icon="EmbeddedEntryInline"
         buttonType="muted"
         testId={`toolbar-toggle-${INLINES.EMBEDDED_ENTRY}`}>
@@ -40,7 +46,7 @@ export default class EntryLinkToolbarIcon extends Component {
         size="small"
         icon="Entry"
         testId={`toolbar-toggle-${INLINES.EMBEDDED_ENTRY}`}
-        onClick={event => this.handleClick(event)}>
+        onClick={this.handleClick}>
         <div className="cf-flex-grid">
           <Icon
             icon="EmbeddedEntryInline"

--- a/packages/rich-text/src/plugins/Hyperlink/ToolbarIcon.js
+++ b/packages/rich-text/src/plugins/Hyperlink/ToolbarIcon.js
@@ -2,21 +2,21 @@ import React, { Component } from 'react';
 import { INLINES } from '@contentful/rich-text-types';
 import ToolbarIcon from '../shared/ToolbarIcon';
 import { TOOLBAR_PLUGIN_PROP_TYPES } from '../shared/PluginApi';
+import { toolbarActionHandlerWithSafeAutoFocus } from '../shared/Util';
 import { hasHyperlink, toggleLink, hasOnlyHyperlinkInlines } from './Util';
 
 export default class HyperlinkToolbarIcon extends Component {
   static propTypes = TOOLBAR_PLUGIN_PROP_TYPES;
 
-  handleClick = async event => {
-    event.preventDefault();
+  handleClick = toolbarActionHandlerWithSafeAutoFocus(this, async () => {
     const {
       onToggle,
       editor,
-      richTextAPI: { sdk, logToolbarAction }
+      richTextAPI: { sdk, logToolbarAction },
     } = this.props;
     await toggleLink(editor, sdk, logToolbarAction);
     onToggle(editor);
-  };
+  });
 
   render() {
     const { disabled, editor } = this.props;
@@ -27,7 +27,7 @@ export default class HyperlinkToolbarIcon extends Component {
         type={INLINES.HYPERLINK}
         icon="Link"
         title="Hyperlink"
-        onToggle={event => this.handleClick(event)}
+        onToggle={this.handleClick}
         isActive={hasHyperlink(editor.value)}
       />
     );

--- a/packages/rich-text/src/plugins/List/ToolbarDecorator.js
+++ b/packages/rich-text/src/plugins/List/ToolbarDecorator.js
@@ -1,11 +1,12 @@
 import * as React from 'react';
 import { TOOLBAR_PLUGIN_PROP_TYPES } from '../shared/PluginApi';
+import { toolbarActionHandlerWithSafeAutoFocus } from '../shared/Util';
 import EditList from './EditListWrapper';
 
 const applyChange = (editor, type, logAction) => {
   const {
     utils,
-    changes: { unwrapList, wrapInList }
+    changes: { unwrapList, wrapInList },
   } = EditList();
 
   if (utils.isSelectionInList(editor.value)) {
@@ -34,20 +35,19 @@ const isActive = (editor, type) => {
   return false;
 };
 
-export default ({ type, title, icon }) => Block => {
+export default ({ type, title, icon }) => (Block) => {
   return class ToolbarDecorator extends React.Component {
     static propTypes = TOOLBAR_PLUGIN_PROP_TYPES;
 
-    handleToggle = e => {
+    handleToggle = toolbarActionHandlerWithSafeAutoFocus(this, () => {
       const {
         editor,
         onToggle,
-        richTextAPI: { logToolbarAction }
+        richTextAPI: { logToolbarAction },
       } = this.props;
-      e.preventDefault();
       applyChange(editor, type, logToolbarAction);
       onToggle(editor);
-    };
+    });
 
     render() {
       const { editor } = this.props;

--- a/packages/rich-text/src/plugins/shared/BlockSelectDecorator.js
+++ b/packages/rich-text/src/plugins/shared/BlockSelectDecorator.js
@@ -1,28 +1,24 @@
 import * as React from 'react';
 import { haveBlocks } from './UtilHave';
+import { toolbarActionHandlerWithSafeAutoFocus } from './Util';
 import { TOOLBAR_PLUGIN_PROP_TYPES } from './PluginApi';
 
-export default ({
-  type,
-  title,
-  icon,
-  applyChange = (editor, type) => editor.setBlocks(type)
-}) => Block => {
+export default ({ type, title, icon, applyChange = (editor, type) => editor.setBlocks(type) }) => (
+  Block
+) => {
   return class BlockSelectDecorator extends React.Component {
     static propTypes = TOOLBAR_PLUGIN_PROP_TYPES;
 
-    handleSelect = e => {
+    handleSelect = toolbarActionHandlerWithSafeAutoFocus(this, () => {
       const {
         editor,
         onToggle,
-        richTextAPI: { logToolbarAction }
+        richTextAPI: { logToolbarAction },
       } = this.props;
-      e.preventDefault();
-
       applyChange(editor, type);
       onToggle(editor);
       logToolbarAction('insert', { nodeType: type });
-    };
+    });
 
     render() {
       const { editor, disabled } = this.props;

--- a/packages/rich-text/src/plugins/shared/BlockToggleDecorator.js
+++ b/packages/rich-text/src/plugins/shared/BlockToggleDecorator.js
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { BLOCKS } from '@contentful/rich-text-types';
 import { haveBlocks } from './UtilHave';
+import { toolbarActionHandlerWithSafeAutoFocus } from './Util';
 import { TOOLBAR_PLUGIN_PROP_TYPES } from './PluginApi';
 
 /**
@@ -18,29 +19,23 @@ export const toggleChange = (editor, type) => {
 
 const isBlockActive = (editor, type) => haveBlocks(editor, type);
 
-export default ({
-  type,
-  title,
-  icon,
-  applyChange = toggleChange,
-  isActive = isBlockActive
-}) => Block => {
+export default ({ type, title, icon, applyChange = toggleChange, isActive = isBlockActive }) => (
+  Block
+) => {
   return class BlockToggleDecorator extends React.Component {
     static propTypes = TOOLBAR_PLUGIN_PROP_TYPES;
 
-    handleToggle = e => {
+    handleToggle = toolbarActionHandlerWithSafeAutoFocus(this, () => {
       const {
         editor,
         onToggle,
-        richTextAPI: { logToolbarAction }
+        richTextAPI: { logToolbarAction },
       } = this.props;
-      e.preventDefault();
-
       const isActive = applyChange(editor, type);
       onToggle(editor);
       const actionName = isActive ? 'insert' : 'remove';
       logToolbarAction(actionName, { nodeType: type });
-    };
+    });
 
     render() {
       const { editor, disabled, richTextAPI } = this.props;

--- a/packages/rich-text/src/plugins/shared/MarkToggleDecorator.js
+++ b/packages/rich-text/src/plugins/shared/MarkToggleDecorator.js
@@ -1,22 +1,22 @@
 import * as React from 'react';
 import { haveMarks } from './UtilHave';
+import { toolbarActionHandlerWithSafeAutoFocus } from './Util';
 import { TOOLBAR_PLUGIN_PROP_TYPES } from './PluginApi';
 
-export default ({ type, title, icon }) => Mark => {
+export default ({ type, title, icon }) => (Mark) => {
   return class CommonToggleMark extends React.Component {
     static propTypes = TOOLBAR_PLUGIN_PROP_TYPES;
 
-    handleToggle = e => {
+    handleToggle = toolbarActionHandlerWithSafeAutoFocus(this, () => {
       const {
         editor,
         onToggle,
-        richTextAPI: { logToolbarAction }
+        richTextAPI: { logToolbarAction },
       } = this.props;
-      e.preventDefault();
       onToggle(editor.toggleMark(type));
       const action = haveMarks(editor, type) ? 'mark' : 'unmark';
       logToolbarAction(action, { markType: type });
-    };
+    });
 
     render() {
       const { editor, disabled } = this.props;

--- a/packages/rich-text/src/plugins/shared/PluginApi.js
+++ b/packages/rich-text/src/plugins/shared/PluginApi.js
@@ -8,7 +8,7 @@ export const actionOrigin = {
   TOOLBAR: 'toolbar-icon',
   SHORTCUT: 'shortcut',
   VIEWPORT: 'viewport-interaction',
-  COMMAND_PALETTE: 'command-palette'
+  COMMAND_PALETTE: 'command-palette',
 };
 
 const createActionLogger = (onAction, origin) => (name, data) => {
@@ -28,7 +28,7 @@ export const createRichTextAPI = ({ sdk, onAction }) => {
     logViewportAction: createActionLogger(onAction, actionOrigin.VIEWPORT),
     logShortcutAction: createActionLogger(onAction, actionOrigin.SHORTCUT),
     logToolbarAction: createActionLogger(onAction, actionOrigin.TOOLBAR),
-    logCommandPaletteAction: createActionLogger(onAction, actionOrigin.COMMAND_PALETTE)
+    logCommandPaletteAction: createActionLogger(onAction, actionOrigin.COMMAND_PALETTE),
   };
   return richTextAPI;
 };
@@ -42,8 +42,8 @@ export const EDITOR_PLUGIN_PROP_TYPES = {
     sdk: PropTypes.object.isRequired,
     logViewportAction: PropTypes.func.isRequired,
     logShortcutAction: PropTypes.func.isRequired,
-    logToolbarAction: PropTypes.func.isRequired
-  })
+    logToolbarAction: PropTypes.func.isRequired,
+  }),
 };
 
 /**
@@ -55,5 +55,8 @@ export const TOOLBAR_PLUGIN_PROP_TYPES = {
   editor: PropTypes.object.isRequired,
   onToggle: PropTypes.func.isRequired,
   disabled: PropTypes.bool.isRequired,
-  isButton: PropTypes.bool
+  isButton: PropTypes.bool,
+  // TODO: Should get rid of this as it's just necessary as a hack to prevent
+  //  crashes before the user manually set the focus to the Slate input.
+  canAutoFocus: PropTypes.bool,
 };

--- a/packages/rich-text/src/plugins/shared/Util.js
+++ b/packages/rich-text/src/plugins/shared/Util.js
@@ -1,0 +1,27 @@
+/**
+ * Handles setting the focus in the Slate editor (if possible due to Slate restrictions)
+ * when clicking on a toolbar acton while the editor got no focus.
+ *
+ * Ideally we would always focus the editor in his case, but this might result
+ * in a Slate crash if the editor hasn't been manually focused by the user at
+ * that point.
+ */
+export const toolbarActionHandlerWithSafeAutoFocus = (component, customHandler) => (event) => {
+  event.preventDefault();
+
+  const { editor, canAutoFocus } = component.props;
+
+  if (!editor.value.selection.isFocused) {
+    if (canAutoFocus) {
+      editor.focus();
+    } else {
+      // Note: This is only necessary as Slate in 0.4x in our case crashes when
+      //  working on the document before the user manually focuses. Attempts at
+      //  programmatically setting focus and a proper value.selection were in vain.
+      // TODO: Upgrade Slate or figure out how to editor.setFocus when clicking
+      //  a toolbar icon without the editor crashing when starting to type.
+      return;
+    }
+  }
+  return customHandler(event);
+};


### PR DESCRIPTION
When the user clicks on a Rich Text editor toolbar action while the
editor is not focused, this should ideally result in focusing the editor
and applying the clicked action.

This handling has been implemented for some actions and it has been
breaking in some cases. This change introduces consistent handling and
dealing with Slate related limitations.

The main limitaton would be after initializing Rich Text, before the
user has manually focused the rich text field, we can not set the focus
programmatically as the Slate internal value seems to lack some
properties that can result in a crash at this point. We circumvent bugs
by preventing any action when clicking on a toolbar action. Instead, the
user has to focus the input first. This is pretty much consistent with
the previous behavior but implemented in a way that is able to prevent
any crashes. Ideally we would improve the behaivor once we figure out
how to prevent Slate from having these missing properties or after
upgrading to a newer Slate 0.5x version.