### PR TITLE
fix: trim empty lines in markdown editor

### DIFF
--- a/packages/markdown/src/MarkdownEditor.tsx
+++ b/packages/markdown/src/MarkdownEditor.tsx
@@ -104,7 +104,9 @@ export function MarkdownEditor(
           editor.setReadOnly(props.disabled);
           setEditor(editor);
           editor.events.onChange((value: string) => {
-            props.saveValueToSDK(value);
+            // Trim empty lines
+            const trimmedValue = value.replace(/^\s+$/gm, '');
+            props.saveValueToSDK(trimmedValue);
             setCurrentValue(value);
           });
         }}


### PR DESCRIPTION
## The issue:

Writing MDX (and MD with html tags) in the markdown editor can lead to a bad experience for editors, ultimately breaking their (Gatsby) website while the developer is absent.

This is due to limitations of MDX (and maybe some other MD renderers as well).

MDX (v1) requires you to have an empty line between MDX and MD sections.

Unfortunately, it is very easy to accidentally add whitespace to empty lines when using MDX. It happens unintentional when writing tags with child tags.

## How does it happen?

CodeMirror indents the HTML tag automatically, but does not un-indent when you write the closing tag.

If you are not careful when writing MDX, you leave a empty line with a few white spaces.


### Current value:

Check the white space within the `<div/>` and the line after. This breaks the MDX renderer.

```
# Some headline

with a paragraph below

<div>
  <center>Cus we can</center>
  
</div>
  
Text after div
```

# Solution

Remove all whitespace from empty lines, to allow less fault-tolerant MD(X) renderers to work with Contentful output.

```
# Some headline

with a paragraph below

<div>
  <center>Cus we can</center>

</div>

Text after div
```