### PR TITLE
fix: users should be able to remove checkbox with invalid predefined values

### DIFF
--- a/packages/checkbox/src/CheckboxEditor.spec.tsx
+++ b/packages/checkbox/src/CheckboxEditor.spec.tsx
@@ -94,4 +94,32 @@ describe('CheckboxEditor', () => {
 
     expect(field.removeValue).toHaveBeenCalledTimes(1);
   });
+
+  it('it renders invalid text and remove link when value set is not in predefined values', () => {
+    const predefined = ['banana', 'orange', 'strawberry'];
+    const [field] = createFakeFieldAPI((mock) => {
+      jest.spyOn(mock, 'setValue');
+      jest.spyOn(mock, 'removeValue');
+      return {
+        ...mock,
+        items: {
+          type: '',
+          validations: [{ in: predefined }],
+        },
+      };
+    });
+
+    // value not included in predefined values
+    field.setValue(['mango']);
+
+    const { getByTestId } = render(
+      <CheckboxEditor field={field} locales={createFakeLocalesAPI()} isInitiallyDisabled={false} />
+    );
+
+    expect(getByTestId('invalid-text')).toBeInTheDocument();
+    expect(getByTestId('cf-ui-text-link')).toBeInTheDocument();
+
+    fireEvent.click(getByTestId('cf-ui-text-link'));
+    expect(field.removeValue).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/checkbox/src/CheckboxEditor.tsx
+++ b/packages/checkbox/src/CheckboxEditor.tsx
@@ -7,7 +7,7 @@ import {
   FieldConnector,
   PredefinedValuesError,
 } from '@contentful/field-editor-shared';
-import { CheckboxField, Form } from '@contentful/forma-36-react-components';
+import { CheckboxField, Form, TextLink } from '@contentful/forma-36-react-components';
 import * as styles from './styles';
 
 export interface CheckboxEditorProps {
@@ -55,6 +55,19 @@ export function getOptions(field: FieldAPI): CheckboxOption[] {
   }));
 }
 
+const getMergedOptions = (values: string[], options: CheckboxOption[]): CheckboxOption[] => {
+  const getValueFromOptions = (options as CheckboxOption[]).map((item) => item.value);
+  const invalidValues = values
+    .filter((value) => !getValueFromOptions.includes(value))
+    .map((value, index) => ({
+      id: `invalid-${index}`,
+      label: value,
+      value,
+    }));
+
+  return [...options, ...invalidValues];
+};
+
 export function CheckboxEditor(props: CheckboxEditorProps) {
   const { field, locales } = props;
 
@@ -86,29 +99,41 @@ export function CheckboxEditor(props: CheckboxEditorProps) {
           setValue(newValues);
         };
 
+        const mergedOptions = getMergedOptions(values, options);
+
         return (
           <Form
             testId="checkbox-editor"
             spacing="condensed"
             className={cx(styles.form, direction === 'rtl' ? styles.rightToLeft : '')}>
-            {options.map((item) => (
-              <CheckboxField
-                key={item.id}
-                labelIsLight
-                id={item.id}
-                checked={values.includes(item.value)}
-                labelText={item.label}
-                disabled={disabled}
-                value={item.value}
-                name={`${field.id}.${field.locale}`}
-                onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                  if (e.target.checked) {
-                    addValue(item.value);
-                  } else {
-                    removeValue(item.value);
-                  }
-                }}
-              />
+            {mergedOptions.map((item) => (
+              <div key={item.id}>
+                <CheckboxField
+                  key={item.id}
+                  labelIsLight
+                  id={item.id}
+                  checked={values.includes(item.value)}
+                  labelText={item.label}
+                  disabled={disabled}
+                  value={item.value}
+                  name={`${field.id}.${field.locale}`}
+                  onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                    if (e.target.checked) {
+                      addValue(item.value);
+                    } else {
+                      removeValue(item.value);
+                    }
+                  }}
+                />
+                {item.id.includes('invalid') && (
+                  <>
+                    <span className={styles.invalidText}>(invalid)</span>
+                    <TextLink className={styles.removeBtn} onClick={() => removeValue(item.value)}>
+                      Remove
+                    </TextLink>
+                  </>
+                )}
+              </div>
             ))}
           </Form>
         );

--- a/packages/checkbox/src/styles.ts
+++ b/packages/checkbox/src/styles.ts
@@ -2,9 +2,18 @@ import { css } from 'emotion';
 import tokens from '@contentful/forma-36-tokens';
 
 export const form = css({
-  marginTop: tokens.spacingS
+  marginTop: tokens.spacingS,
 });
 
 export const rightToLeft = css({
-  direction: 'rtl'
+  direction: 'rtl',
+});
+
+export const invalidText = css({
+  color: tokens.colorRedMid,
+  marginLeft: tokens.spacing2Xs,
+});
+
+export const removeBtn = css({
+  marginLeft: tokens.spacingL,
 });


### PR DESCRIPTION
When a predefined checked checkbox value is invalid and page is reloaded, the value disappears which makes it impossible for users to unselect or remove invalid value.

This PR makes it possible for the user to see the invalid value and be able to remove it.

![image](https://user-images.githubusercontent.com/30434146/90147042-a9eec400-dd79-11ea-972c-978104cb9ab0.png)
