### PR TITLE
fix(reference-editor): fix isclickable prop

### DIFF
--- a/packages/reference/src/entries/WrappedEntryCard/FetchingWrappedEntryCard.tsx
+++ b/packages/reference/src/entries/WrappedEntryCard/FetchingWrappedEntryCard.tsx
@@ -133,7 +133,6 @@ export function FetchingWrappedEntryCard(props: EntryCardReferenceEditorProps) {
     }
     const builtinCardProps: WrappedEntryCardProps = {
       ...sharedCardProps,
-      isClickable: false,
       hasCardEditActions: props.hasCardEditActions,
       getAsset: props.sdk.space.getAsset,
       getEntityScheduledActions: props.sdk.space.getEntityScheduledActions,

--- a/packages/reference/src/entries/WrappedEntryCard/WrappedEntryCard.tsx
+++ b/packages/reference/src/entries/WrappedEntryCard/WrappedEntryCard.tsx
@@ -35,7 +35,7 @@ export interface WrappedEntryCardProps {
   contentType?: ContentType;
   entry: Entry;
   cardDragHandle?: React.ReactElement;
-  isClickable: boolean;
+  isClickable?: boolean;
   hasCardEditActions: boolean;
 }
 


### PR DESCRIPTION
This PR fixes an issue where cards were rendered as not clickable (clicking the card did not perform the open slide-in editor action)