### PR TITLE
chore: 🤖 use proper testId for validation errors components

### DIFF
--- a/packages/validation-errors/src/ValidationErrors.tsx
+++ b/packages/validation-errors/src/ValidationErrors.tsx
@@ -89,7 +89,7 @@ function UniquenessError(props: UniquenessErrorProps) {
   }, [getTitle, state.entries, props.error.conflicting, props.space.getEntries, props.getEntryURL]);
 
   return (
-    <List className={styles.errorList} data-test-id="uniqueness-conflicts-list">
+    <List className={styles.errorList} testId="validation-errors-uniqueness">
       <ListItem className={styles.entryLink}>
         {state.loading ? (
           <div>Loading title for conflicting entry…</div>
@@ -135,7 +135,7 @@ export function ValidationErrors(props: ValidationErrorsProps) {
   }
 
   return (
-    <List className={styles.errorList}>
+    <List className={styles.errorList} testId="validation-errors">
       {errors.map((error, index) => {
         return (
           <li


### PR DESCRIPTION
To be able to consume in downstream dependencies.