### PR TITLE
chore: default field editors docs

### DIFF
--- a/doczrc.js
+++ b/doczrc.js
@@ -21,24 +21,24 @@ export default {
     colors: {
       primary: tokens.colorBlueBase,
       secondary: tokens.colorIceMid,
-      gray: tokens.colorElementMid
-    }
+      gray: tokens.colorElementMid,
+    },
   },
   htmlContext: {
     head: {
-      raw: `<style>${forma36Styles}</style><style>${pikadayStyles}</style>`
-    }
+      raw: `<style>${forma36Styles}</style><style>${pikadayStyles}</style>`,
+    },
   },
   menu: ['Introduction', 'Editors', 'Shared'],
-  modifyBabelRc: babelrc => {
+  modifyBabelRc: (babelrc) => {
     const newBabelRc = {
       ...babelrc,
       plugins: [
         ...babelrc.plugins,
         '@babel/plugin-proposal-optional-chaining',
-        '@babel/plugin-proposal-nullish-coalescing-operator'
-      ]
+        '@babel/plugin-proposal-nullish-coalescing-operator',
+      ],
     };
     return newBabelRc;
-  }
+  },
 };

--- a/extensions/entry-extension-collapsible/src/Field.tsx
+++ b/extensions/entry-extension-collapsible/src/Field.tsx
@@ -6,8 +6,8 @@ import {
   FieldWrapper,
 } from '../../../packages/default-field-editors/src/index';
 import { SDKContext, getEntryURL } from './shared';
-import '../../../packages/date/styles/styles';
-import '../../../packages/json/src/codemirrorImports';
+import 'codemirror/lib/codemirror.css';
+import '@contentful/field-editor-date/styles/styles.css';
 
 interface FieldProps {
   field: EntryFieldAPI;

--- a/packages/default-field-editors/README.md
+++ b/packages/default-field-editors/README.md
@@ -7,10 +7,13 @@ npm install @contentful/default-field-editors
 This package provides React components for rendering all supported field editors with the same structure and style as in Contentful web app.
 
 ```js
+import 'codemirror/lib/codemirror.css';
+import '@contentful/forma-36-react-components/dist/styles.css';
+import '@contentful/field-editor-date/styles/styles.css';
 import { Field, FieldWrapper } from 'packages/default-field-editors';
 
 const fieldEditor = (
-  <FieldWrapper sdk={fieldExtensionSdk} name={fieldName}>
+  <FieldWrapper sdk={fieldExtensionSdk} name={fieldName} getEntryURL={(entry) => ''}>
     <Field sdk={fieldExtensionSdk} widgetId={widgetId} />
   </FieldWrapper>
 );

--- a/packages/default-field-editors/src/DefaultFieldEditors.mdx
+++ b/packages/default-field-editors/src/DefaultFieldEditors.mdx
@@ -1,0 +1,54 @@
+---
+name: default-field-editors
+route: /shared/default-field-editors
+menu: Shared
+---
+
+import Readme from '../README.md';
+
+<Readme />
+
+import { Playground, Props } from 'docz';
+import { createFakeFieldAPI, createFakeSpaceAPI, createFakeLocalesAPI, ActionsPlayground } from '@contentful/field-editor-test-utils';
+import { Field } from './Field.tsx';
+import { FieldWrapper } from './FieldWrapper.tsx';
+
+
+## In Action
+
+<Playground>
+  {() => {
+    const [field, mitt] = createFakeFieldAPI();
+    const space = createFakeSpaceAPI();
+    const locales = createFakeLocalesAPI();
+    const sdk = {
+      field,
+      space,
+      locales,
+    };
+
+    return (
+      <div data-test-id="default-field-editors-test">
+        <FieldWrapper
+          sdk={sdk}
+          name="field"
+          getEntryURL={(entry) => `/${entry.sys.id}`}
+        >
+          <Field sdk={sdk} widgetId="singleLine" />
+        </FieldWrapper>
+
+        <ActionsPlayground mitt={mitt} />
+      </div>
+    );
+}}
+</Playground>
+
+
+## FieldWrapper props
+
+<Props of={FieldWrapper} />
+
+## Field props
+
+<Props of={Field} />
+

--- a/packages/default-field-editors/src/Field.tsx
+++ b/packages/default-field-editors/src/Field.tsx
@@ -23,7 +23,6 @@ import {
 import { RichTextEditor } from '@contentful/field-editor-rich-text';
 import { MarkdownEditor } from '@contentful/field-editor-markdown';
 import type { FieldExtensionSDK } from '@contentful/field-editor-shared';
-import '@contentful/field-editor-date/styles/styles.css';
 import type { EditorOptions, WidgetType } from './types';
 
 type FieldProps = {
@@ -38,13 +37,8 @@ type FieldProps = {
   getOptions?: (widgetId: WidgetType, sdk: FieldExtensionSDK) => EditorOptions;
 };
 
-export const Field: React.FC<FieldProps> = ({
-  sdk,
-  widgetId,
-  isInitiallyDisabled = false,
-  renderFieldEditor,
-  getOptions,
-}: FieldProps) => {
+export const Field: React.FC<FieldProps> = (props: FieldProps) => {
+  const { sdk, widgetId, isInitiallyDisabled = false, renderFieldEditor, getOptions } = props;
   const field = sdk.field;
   const locales = sdk.locales;
 

--- a/packages/default-field-editors/src/FieldWrapper.tsx
+++ b/packages/default-field-editors/src/FieldWrapper.tsx
@@ -16,16 +16,17 @@ type FieldWrapperProps = {
   renderHelpText?: (helpText: string) => JSX.Element | null;
 };
 
-export const FieldWrapper: React.FC<FieldWrapperProps> = function ({
-  name,
-  sdk,
-  getEntryURL,
-  className,
-  children,
-  renderHeading,
-  renderHelpText,
-  showFocusBar = true,
-}: FieldWrapperProps) {
+export const FieldWrapper: React.FC<FieldWrapperProps> = function (props: FieldWrapperProps) {
+  const {
+    name,
+    sdk,
+    getEntryURL,
+    className,
+    children,
+    renderHeading,
+    renderHelpText,
+    showFocusBar = true,
+  } = props;
   const { field } = sdk;
   const helpText = (sdk.parameters?.instance as any)?.helpText ?? '';
   const required = field.required;

--- a/packages/json/src/codemirrorImports.ts
+++ b/packages/json/src/codemirrorImports.ts
@@ -1,3 +1,2 @@
 import 'codemirror/addon/edit/closebrackets';
 import 'codemirror/mode/javascript/javascript';
-import 'codemirror/lib/codemirror.css';


### PR DESCRIPTION
Added documentation for `default-field-editors`. Fixed the styles import in `json`, so they are not imported by default breaking `docz`.