### PR TITLE
fix: 🐛 allow heigh overflow for hyperlink dialog [PEN-1218]

### DIFF
--- a/packages/rich-text/src/dialogs/HypelinkDialog/HyperlinkDialog.jsx
+++ b/packages/rich-text/src/dialogs/HypelinkDialog/HyperlinkDialog.jsx
@@ -301,6 +301,7 @@ export const openHyperlinkDialog = (
     width: 'large',
     shouldCloseOnEscapePress: true,
     shouldCloseOnOverlayClick: true,
+    allowHeightOverflow: true,
     parameters: {
       type: 'rich-text-hyperlink-dialog',
       ...props,


### PR DESCRIPTION
A small visual improvement for hyperlink modal dialog