### PR TITLE
fix: center vertical align of error items

### DIFF
--- a/packages/validation-errors/src/styles.ts
+++ b/packages/validation-errors/src/styles.ts
@@ -17,6 +17,7 @@ export const errorMessage = css({
 
 export const errorItem = css({
   display: 'flex',
+  alignItems: 'center',
 });
 
 export const entryLink = css({


### PR DESCRIPTION
Vertically align the error message with the svg icon