### PR TITLE
feat: 🎸 introduce experimental CombinedAssetLinkActions

### DIFF
--- a/cypress/integration/MultipleMediaEditor.spec.ts
+++ b/cypress/integration/MultipleMediaEditor.spec.ts
@@ -3,25 +3,49 @@ describe('Multiple Media Editor', () => {
     cy.visit('/media-multiple');
   });
 
-  const getDefaultWrapper = () => cy.findByTestId('multiple-media-editor-integration-test');
-  const getCustomActionsWrapper = () =>
-    cy.findByTestId('multiple-media-editor-custom-actions-integration-test');
-  const findCreateAndLinkBtn = () => getDefaultWrapper().findByTestId('linkEditor.createAndLink');
-  const findLinkExistingBtn = () => getDefaultWrapper().findByTestId('linkEditor.linkExisting');
-  const findCustomLinkActions = () => getCustomActionsWrapper().findAllByTestId('custom-link');
-  const findCards = () => getCustomActionsWrapper().findAllByTestId('cf-ui-asset-card');
+  const findCreateAndLinkBtn = (parent: Cypress.Chainable) =>
+    parent.findByTestId('linkEditor.createAndLink');
+  const findLinkExistingBtn = (parent: Cypress.Chainable) =>
+    parent.findByTestId('linkEditor.linkExisting');
+  const findCustomActionsDropdownTrigger = (parent: Cypress.Chainable) =>
+    parent.findAllByTestId('link-actions-menu-trigger');
+  const findCustomActionsDropdown = () => cy.findAllByTestId('cf-ui-dropdown-container');
+  const findCards = (parent: Cypress.Chainable) => parent.findAllByTestId('cf-ui-asset-card');
 
-  it('renders default actions', () => {
-    findCreateAndLinkBtn().should('exist');
-    findLinkExistingBtn().should('exist');
+  describe('default editor', () => {
+    beforeEach(() => {
+      cy.findByTestId('multiple-media-editor-integration-test').as('wrapper');
+    });
+
+    it('renders default actions', () => {
+      findCreateAndLinkBtn(cy.get('@wrapper')).should('exist');
+      findLinkExistingBtn(cy.get('@wrapper')).should('exist');
+    });
+
+    it('can insert existing links', () => {
+      findLinkExistingBtn(cy.get('@wrapper')).click();
+      findCards(cy.get('body')).should('have.length', 2);
+    });
+
+    it('can insert new links', () => {
+      findCreateAndLinkBtn(cy.get('@wrapper')).click();
+      findCards(cy.get('body')).should('have.length', 1);
+    });
   });
 
-  it('renders custom actions', () => {
-    findCustomLinkActions().should('exist');
-  });
+  describe('custom actions injected actions dropdown', () => {
+    beforeEach(() => {
+      cy.findByTestId('multiple-media-editor-custom-actions-integration-test').as('wrapper');
+    });
 
-  it('is able to interact through props', () => {
-    findCustomLinkActions().click();
-    findCards().should('have.length', 2);
+    it('is rendered', () => {
+      findCustomActionsDropdownTrigger(cy.get('@wrapper')).should('exist');
+    });
+
+    it('is able to interact through props', () => {
+      findCustomActionsDropdownTrigger(cy.get('@wrapper')).click();
+      findLinkExistingBtn(findCustomActionsDropdown()).click();
+      findCards(cy.get('body')).should('have.length', 2);
+    });
   });
 });

--- a/packages/reference/src/assets/MultipleMediaEditor.mdx
+++ b/packages/reference/src/assets/MultipleMediaEditor.mdx
@@ -15,6 +15,7 @@ import { MultipleMediaEditor } from '@contentful/field-editor-reference';
 
 import { Playground, Props } from 'docz';
 import { MultipleMediaEditor } from './MultipleMediaEditor.tsx'
+import { CombinedLinkActions } from '../../src';
 import { createFakeFieldAPI, createFakeSpaceAPI, createFakeLocalesAPI, ActionsPlayground } from '@contentful/field-editor-test-utils';
 import { TextLink } from '@contentful/forma-36-react-components';
 import emptyAsset from '../__fixtures__/empty_asset.json';
@@ -114,6 +115,8 @@ import changedAsset from '../__fixtures__/changed_asset.json';
 
 ## With custom actions
 
+Note the alternative link actions injected via the `renderCustomActions` prop.
+
 <Playground>
   {() => {
     const initialValue = window.localStorage.getItem('initialValue');
@@ -159,6 +162,15 @@ import changedAsset from '../__fixtures__/changed_asset.json';
           alert('open Asset in slide in');
           return Promise.resolve({});
         },
+        openNewAsset: async () => {
+          return {
+            entity: {
+              sys: {
+                id: 'changed_asset',
+              },
+            },
+          };
+        },
         onSlideInNavigation: () => () => {}
       },
       access: {
@@ -171,14 +183,7 @@ import changedAsset from '../__fixtures__/changed_asset.json';
           viewType="card"
           sdk={sdk}
           isInitiallyDisabled={false}
-          renderCustomActions={(props) => <TextLink disabled={props.isDisabled} testId='custom-link'
-              onClick={props.onLinkExisting}
-              linkType="primary"
-              icon="ThumbUp"
-              iconPosition="right">
-            Re-use something
-            </TextLink>
-          }
+          renderCustomActions={(props) => (<CombinedLinkActions {...props}/>)}
           parameters={{
             instance: {
               canCreateEntity: true,

--- a/packages/reference/src/assets/SingleMediaEditor.mdx
+++ b/packages/reference/src/assets/SingleMediaEditor.mdx
@@ -103,6 +103,8 @@ import publishedAsset from '../__fixtures__/published_asset.json';
 
 ## With custom actions
 
+Note the alternative link actions injected via the `renderCustomActions` prop.
+
 <Playground>
   {() => {
     const initialValue = window.localStorage.getItem('initialValue');

--- a/packages/reference/src/common/ReferenceEditor.tsx
+++ b/packages/reference/src/common/ReferenceEditor.tsx
@@ -3,7 +3,7 @@ import deepEqual from 'deep-equal';
 import { FieldConnector } from '@contentful/field-editor-shared';
 import { EntityProvider } from './EntityStore';
 import { ViewType, FieldExtensionSDK, Action, Entry, ContentType, ActionLabels } from '../types';
-import type { LinkActionsProps } from '../components/LinkActions/LinkActions';
+import type { LinkActionsProps } from '../components';
 
 // TODO: Rename common base for reference/media editors to something neutral,
 //  e.g. `LinkEditor<T>`.

--- a/packages/reference/src/components/CreateEntryLinkButton/CreateEntryLinkButton.tsx
+++ b/packages/reference/src/components/CreateEntryLinkButton/CreateEntryLinkButton.tsx
@@ -4,7 +4,7 @@ import { css } from 'emotion';
 import { ContentType } from '../../types';
 import { Icon, TextLink, Spinner } from '@contentful/forma-36-react-components';
 import tokens from '@contentful/forma-36-tokens';
-import { CreateEntryMenuTrigger } from './CreateEntryMenuTrigger';
+import { CreateEntryMenuTrigger, CreateCustomEntryMenuItems } from './CreateEntryMenuTrigger';
 
 const styles = {
   chevronIcon: css({
@@ -21,6 +21,7 @@ interface CreateEntryLinkButtonProps {
   contentTypes: ContentType[];
   suggestedContentTypeId?: string;
   onSelect: (contentTypeId: string) => Promise<unknown>;
+  renderCustomDropdownItems?: CreateCustomEntryMenuItems;
   disabled?: boolean;
   hasPlusIcon: boolean;
   text?: string;
@@ -34,6 +35,7 @@ interface CreateEntryLinkButtonProps {
 export const CreateEntryLinkButton = ({
   contentTypes,
   onSelect,
+  renderCustomDropdownItems,
   text,
   testId,
   hasPlusIcon,
@@ -49,14 +51,21 @@ export const CreateEntryLinkButton = ({
       'name',
       'entry'
     )}`;
+  // TODO: Introduce `icon: string` and remove `hasPlusIcon` or remove "Plus" if we keep new layout.
+  const plusIcon = !hasPlusIcon ? undefined : renderCustomDropdownItems ? 'PlusCircle' : 'Plus';
+  // TODO: Always use "New content" here if we fully switch to new layout.
+  const contentTypesLabel = renderCustomDropdownItems ? 'New content' : undefined;
+  const hasDropdown = contentTypes.length > 1 || renderCustomDropdownItems;
 
   return (
     <CreateEntryMenuTrigger
       contentTypes={contentTypes}
       suggestedContentTypeId={suggestedContentTypeId}
+      contentTypesLabel={contentTypesLabel}
       onSelect={onSelect}
       testId={testId}
-      dropdownSettings={dropdownSettings}>
+      dropdownSettings={dropdownSettings}
+      renderCustomDropdownItems={renderCustomDropdownItems}>
       {({ openMenu, isSelecting }) => (
         <>
           {isSelecting && <Spinner size="small" key="spinner" className={styles.spinnerMargin} />}
@@ -66,10 +75,10 @@ export const CreateEntryLinkButton = ({
               openMenu();
             }}
             disabled={disabled || isSelecting || (contentTypes && contentTypes.length === 0)}
-            icon={isSelecting || !hasPlusIcon ? undefined : 'Plus'}
+            icon={isSelecting ? undefined : plusIcon}
             testId="create-entry-link-button">
             {buttonText}
-            {contentTypes.length > 1 && (
+            {hasDropdown && (
               <Icon
                 data-test-id="dropdown-icon"
                 icon="ChevronDown"

--- a/packages/reference/src/components/LinkActions/CombinedLinkActions.tsx
+++ b/packages/reference/src/components/LinkActions/CombinedLinkActions.tsx
@@ -1,0 +1,107 @@
+import * as React from 'react';
+import { Dropdown, DropdownListItem, Icon, TextLink } from '@contentful/forma-36-react-components';
+import * as styles from './styles';
+import { CreateEntryLinkButton } from '../CreateEntryLinkButton/CreateEntryLinkButton';
+import { testIds as sharedTextIds, LinkActionsProps } from './LinkActions';
+
+const testIds = {
+  ...sharedTextIds,
+  actionsWrapper: 'link-actions-menu-trigger',
+};
+
+/**
+ * Alternative, experimental alternative to <LinkActions /> that is planned to
+ * replace the current default LinkActions in reference and media editors.
+ *
+ * Places both actions to create and link new, as well as link existing, behind
+ * one action dropdown and introduces new copy for action labels.
+ */
+export function CombinedLinkActions(props: LinkActionsProps) {
+  // TODO: We don't want to render a spacious container in case there are
+  //  are already assets linked (in case of entries, always show it) as the
+  //  border wouldn't be nicely aligned with asset cards.
+  return (
+    <div className={styles.spaciousContainer}>
+      {props.canCreateEntity && (
+        <>
+          {props.entityType === 'Entry' && <CombinedEntryLinkActions {...props} />}
+          {props.entityType === 'Asset' && <CombinedAssetLinkActions {...props} />}
+        </>
+      )}
+    </div>
+  );
+}
+
+function CombinedEntryLinkActions(props: LinkActionsProps) {
+  return (
+    <CreateEntryLinkButton
+      testId={testIds.actionsWrapper}
+      disabled={props.isDisabled}
+      text="Add content"
+      contentTypes={props.contentTypes}
+      hasPlusIcon={true}
+      onSelect={(contentTypeId) => {
+        return contentTypeId ? props.onCreate(contentTypeId) : Promise.resolve();
+      }}
+      renderCustomDropdownItems={({ closeMenu }) => (
+        <DropdownListItem
+          testId={testIds.linkExisting}
+          onClick={() => {
+            closeMenu();
+            props.onLinkExisting();
+          }}>
+          Add existing content
+        </DropdownListItem>
+      )}
+    />
+  );
+}
+
+function CombinedAssetLinkActions(props: LinkActionsProps) {
+  const [isOpen, setOpen] = React.useState(false);
+
+  // TODO: If we fully switch to this new layout, make a more generic `CreateEntityLinkButton`
+  //  that works without content types to cover asset use-case.
+  return (
+    <Dropdown
+      isOpen={isOpen}
+      onClose={() => setOpen(false)}
+      toggleElement={
+        <>
+          <TextLink
+            disabled={props.isDisabled}
+            testId={testIds.actionsWrapper}
+            onClick={() => {
+              setOpen(!isOpen);
+            }}
+            linkType="primary"
+            icon="PlusCircle">
+            Add media
+            <Icon
+              data-test-id="dropdown-icon"
+              icon="ChevronDown"
+              color="secondary"
+              className={styles.chevronIcon}
+            />
+          </TextLink>
+        </>
+      }>
+      <DropdownListItem
+        testId={testIds.createAndLink}
+        onClick={() => {
+          setOpen(false);
+          props.onCreate();
+        }}>
+        Add new media
+      </DropdownListItem>
+      <DropdownListItem
+        testId={testIds.linkExisting}
+        onClick={() => {
+          setOpen(false);
+          props.onLinkExisting();
+        }}>
+        Add existing media
+      </DropdownListItem>
+    </Dropdown>
+  );
+}

--- a/packages/reference/src/components/LinkActions/CombinedLinkActions.tsx
+++ b/packages/reference/src/components/LinkActions/CombinedLinkActions.tsx
@@ -22,43 +22,91 @@ export function CombinedLinkActions(props: LinkActionsProps) {
   //  border wouldn't be nicely aligned with asset cards.
   return (
     <div className={styles.spaciousContainer}>
-      {props.canCreateEntity && (
-        <>
-          {props.entityType === 'Entry' && <CombinedEntryLinkActions {...props} />}
-          {props.entityType === 'Asset' && <CombinedAssetLinkActions {...props} />}
-        </>
-      )}
+      {props.entityType === 'Entry' && <CombinedEntryLinkActions {...props} />}
+      {props.entityType === 'Asset' && <CombinedAssetLinkActions {...props} />}
     </div>
   );
 }
 
 function CombinedEntryLinkActions(props: LinkActionsProps) {
-  return (
-    <CreateEntryLinkButton
-      testId={testIds.actionsWrapper}
-      disabled={props.isDisabled}
-      text="Add content"
-      contentTypes={props.contentTypes}
-      hasPlusIcon={true}
-      onSelect={(contentTypeId) => {
-        return contentTypeId ? props.onCreate(contentTypeId) : Promise.resolve();
-      }}
-      renderCustomDropdownItems={({ closeMenu }) => (
-        <DropdownListItem
-          testId={testIds.linkExisting}
-          onClick={() => {
-            closeMenu();
-            props.onLinkExisting();
-          }}>
-          Add existing content
-        </DropdownListItem>
-      )}
-    />
-  );
+  if (props.canCreateEntity) {
+    return (
+      <CreateEntryLinkButton
+        testId={testIds.actionsWrapper}
+        disabled={props.isDisabled}
+        text="Add content"
+        contentTypes={props.contentTypes}
+        hasPlusIcon={true}
+        onSelect={(contentTypeId) => {
+          return contentTypeId ? props.onCreate(contentTypeId) : Promise.resolve();
+        }}
+        renderCustomDropdownItems={
+          props.canLinkEntity
+            ? ({ closeMenu }) => (
+                <DropdownListItem
+                  testId={testIds.linkExisting}
+                  onClick={() => {
+                    closeMenu();
+                    props.onLinkExisting();
+                  }}>
+                  Add existing content
+                </DropdownListItem>
+              )
+            : undefined
+        }
+      />
+    );
+  } else if (props.canLinkEntity) {
+    return (
+      <TextLink
+        disabled={props.isDisabled}
+        testId={testIds.linkExisting}
+        onClick={() => {
+          props.onLinkExisting();
+        }}
+        linkType="primary"
+        icon="Link">
+        Add existing content
+      </TextLink>
+    );
+  }
+  return null;
 }
 
 function CombinedAssetLinkActions(props: LinkActionsProps) {
   const [isOpen, setOpen] = React.useState(false);
+
+  if (!props.canLinkEntity || !props.canCreateEntity) {
+    if (props.canLinkEntity) {
+      return (
+        <TextLink
+          disabled={props.isDisabled}
+          testId={testIds.linkExisting}
+          onClick={() => {
+            props.onLinkExisting();
+          }}
+          linkType="primary"
+          icon="Link">
+          Add existing media
+        </TextLink>
+      );
+    }
+    if (props.canCreateEntity) {
+      return (
+        <TextLink
+          disabled={props.isDisabled}
+          testId={testIds.createAndLink}
+          onClick={() => {
+            props.onCreate();
+          }}
+          linkType="primary"
+          icon="PlusCircle">
+          Add new media
+        </TextLink>
+      );
+    }
+    return null;
+  }
 
   // TODO: If we fully switch to this new layout, make a more generic `CreateEntityLinkButton`
   //  that works without content types to cover asset use-case.

--- a/packages/reference/src/components/LinkActions/LinkActions.tsx
+++ b/packages/reference/src/components/LinkActions/LinkActions.tsx
@@ -17,28 +17,16 @@ export interface LinkActionsProps {
 }
 
 const defaultEntryLabels: ActionLabels = {
-  createNew: (props) => {
-    if (props?.contentType) {
-      return `Create new ${props.contentType} and link`;
-    }
-    return 'Create new entry and link';
-  },
-  linkExisting: (props) => {
-    if (props?.canLinkMultiple) {
-      return 'Link existing entries';
-    }
-    return 'Link existing entry';
-  },
+  createNew: (props) =>
+    props?.contentType ? `Create new ${props.contentType} and link` : 'Create new entry and link',
+  linkExisting: (props) =>
+    props?.canLinkMultiple ? 'Link existing entries' : 'Link existing entry',
 };
 
 const defaultAssetLabels: ActionLabels = {
   createNew: () => `Create new asset and link`,
-  linkExisting: (props) => {
-    if (props?.canLinkMultiple) {
-      return 'Link existing assets';
-    }
-    return 'Link existing asset';
-  },
+  linkExisting: (props) =>
+    props?.canLinkMultiple ? 'Link existing assets' : 'Link existing asset',
 };
 
 export const testIds = {
@@ -48,11 +36,11 @@ export const testIds = {
 };
 
 export function LinkActions(props: LinkActionsProps) {
-  const labels = Object.assign(
-    {},
-    props.entityType === 'Entry' ? defaultEntryLabels : defaultAssetLabels,
-    props.actionLabels
-  );
+  const defaultLabels = props.entityType === 'Entry' ? defaultEntryLabels : defaultAssetLabels;
+  const labels = {
+    ...defaultLabels,
+    ...props.actionLabels,
+  };
 
   return (
     <div className={styles.container}>
@@ -69,10 +57,7 @@ export function LinkActions(props: LinkActionsProps) {
               contentTypes={props.contentTypes}
               hasPlusIcon={true}
               onSelect={(contentTypeId) => {
-                if (contentTypeId) {
-                  return props.onCreate(contentTypeId);
-                }
-                return Promise.resolve();
+                return contentTypeId ? props.onCreate(contentTypeId) : Promise.resolve();
               }}
             />
           )}
@@ -100,10 +85,7 @@ export function LinkActions(props: LinkActionsProps) {
           }}
           linkType="primary"
           icon="Link">
-          {props.entityType === 'Entry' &&
-            labels.linkExisting({ canLinkMultiple: props.canLinkMultiple })}
-          {props.entityType === 'Asset' &&
-            labels.linkExisting({ canLinkMultiple: props.canLinkMultiple })}
+          {labels.linkExisting({ canLinkMultiple: props.canLinkMultiple })}
         </TextLink>
       )}
     </div>

--- a/packages/reference/src/components/LinkActions/LinkEntityActions.tsx
+++ b/packages/reference/src/components/LinkActions/LinkEntityActions.tsx
@@ -162,7 +162,7 @@ export function LinkEntityActions(props: LinkEntityActionsProps) {
     });
   }, []);
 
-  const linkActionProps = {
+  const linkActionProps: LinkActionsProps = {
     entityType: props.entityType,
     canLinkMultiple: props.canLinkMultiple,
     isDisabled: props.isDisabled,
@@ -173,10 +173,9 @@ export function LinkEntityActions(props: LinkEntityActionsProps) {
     onLinkExisting: props.canLinkMultiple ? onLinkSeveralExisting : onLinkExisting,
     actionLabels: props.actionLabels,
   };
+  const renderLinkActions = props.renderCustomActions
+    ? props.renderCustomActions
+    : (props: LinkActionsProps) => <LinkActions {...props} />;
 
-  return props.renderCustomActions ? (
-    props.renderCustomActions(linkActionProps)
-  ) : (
-    <LinkActions {...linkActionProps} />
-  );
+  return renderLinkActions(linkActionProps);
 }

--- a/packages/reference/src/components/LinkActions/styles.ts
+++ b/packages/reference/src/components/LinkActions/styles.ts
@@ -4,9 +4,26 @@ import tokens from '@contentful/forma-36-tokens';
 export const container = css({
   display: 'flex',
   width: '100%',
-  marginTop: tokens.spacingS
+  marginTop: tokens.spacingS,
+});
+
+// TODO: Should height match card depending on
+//  "link" vs. "card" layout appearance?
+export const spaciousContainer = css({
+  display: 'flex',
+  backgroundColor: tokens.colorWhite,
+  border: `1px dashed ${tokens.colorElementMid}`,
+  borderRadius: '3px',
+  justifyContent: 'center',
+  padding: tokens.spacing3Xl,
 });
 
 export const separator = css({
-  marginRight: tokens.spacingXl
+  marginRight: tokens.spacingXl,
+});
+
+export const chevronIcon = css({
+  float: 'right',
+  marginLeft: tokens.spacingXs,
+  marginRight: -tokens.spacing2Xs,
 });

--- a/packages/reference/src/components/index.ts
+++ b/packages/reference/src/components/index.ts
@@ -1,3 +1,5 @@
+export { LinkActionsProps } from './LinkActions/LinkActions';
+export { CombinedLinkActions } from './LinkActions/CombinedLinkActions';
 export { MissingEntityCard } from './MissingEntityCard/MissingEntityCard';
 export { LinkEntityActions } from './LinkActions/LinkEntityActions';
 export { CreateEntryLinkButton } from './CreateEntryLinkButton/CreateEntryLinkButton';

--- a/packages/reference/src/entries/MultipleEntryReferenceEditor.mdx
+++ b/packages/reference/src/entries/MultipleEntryReferenceEditor.mdx
@@ -15,6 +15,7 @@ import { MultipleEntryReferenceEditor } from '@contentful/field-editor-reference
 
 import { Playground, Props } from 'docz';
 import { MultipleEntryReferenceEditor } from './MultipleEntryReferenceEditor.tsx';
+import { CombinedLinkActions } from '../../src';
 import { ActionsPlayground } from '@contentful/field-editor-test-utils';
 import {
   Card,
@@ -54,7 +55,7 @@ import { newReferenceEditorFakeSdk } from '../__fixtures__/FakeSdk'
 
 ## With custom card
 
-Insert some references via _Link existing entries_. Click again to showcase inserting
+Click _Link existing entries_ to insert some references with custom layout rendered via `renderCustomCard` prop. Click again to showcase inserting
 another reference rendered by the stardard card renderer.
 
 <Playground>
@@ -74,6 +75,35 @@ another reference rendered by the stardard card renderer.
               <Button onClick={props.onRemove}>Remove</Button>
             </Card> : false
           }
+          viewType="link"
+          sdk={sdk}
+          isInitiallyDisabled={isInitiallyDisabled}
+          parameters={{
+            instance: instanceParams || {
+              canCreateEntity: true,
+              canLinkEntity: true
+            }
+          }}
+        />
+        <ActionsPlayground mitt={mitt} />
+      </div>
+    );
+  }}
+</Playground>
+
+## With custom actions
+
+Note the alternative link actions injected via the `renderCustomActions` prop.
+
+<Playground>
+  {() => {
+    const isInitiallyDisabled = window.localStorage.getItem('initialDisabled');
+    const instanceParams = window.localStorage.getItem('instanceParams');
+    const [sdk, mitt] = newReferenceEditorFakeSdk();
+    return (
+      <div>
+        <MultipleEntryReferenceEditor
+          renderCustomActions={(props) => (<CombinedLinkActions {...props}/>)}
           viewType="link"
           sdk={sdk}
           isInitiallyDisabled={isInitiallyDisabled}

--- a/packages/reference/src/index.tsx
+++ b/packages/reference/src/index.tsx
@@ -5,6 +5,7 @@ export {
   ScheduledIconWithTooltip,
   AssetThumbnail,
   MissingEntityCard,
+  CombinedLinkActions,
 } from './components';
 export {
   SingleEntryReferenceEditor,


### PR DESCRIPTION
Introduces a new component `CombinedAssetLinkActions` that can be used in conjunction with reference and media editor `renderCustomCard` props. It introduces a new link actions layout which is planned to replace the current link actions in some future version of these editors.

**For references:**
![new-entries](https://user-images.githubusercontent.com/101926/94142465-9ea9b080-fe6e-11ea-879c-74d1d3a6b9ac.png)

**For assets:**
![media](https://user-images.githubusercontent.com/101926/94142489-a79a8200-fe6e-11ea-94a8-121d8dd2c2a9.png)
