### PR TITLE
fix: 🐛 isInitiallyDisabled being null in examples

### DIFF
--- a/packages/date/src/DateEditor.mdx
+++ b/packages/date/src/DateEditor.mdx
@@ -17,7 +17,7 @@ import { createFakeFieldAPI, ActionsPlayground } from '@contentful/field-editor-
 <Playground>
   {() => {
     const initialValue = window.localStorage.getItem('initialValue');
-    const isInitiallyDisabled = window.localStorage.getItem('initialDisabled');
+    const isInitiallyDisabled = !!window.localStorage.getItem('initialDisabled');
     const instanceParams = window.localStorage.getItem('instanceParams');
     const [field, mitt] = createFakeFieldAPI(field => field, initialValue);
     return (

--- a/packages/location/src/LocationEditor.mdx
+++ b/packages/location/src/LocationEditor.mdx
@@ -19,7 +19,7 @@ import { createFakeFieldAPI, ActionsPlayground } from '@contentful/field-editor-
 <Playground>
   {() => {
     const initialValue = window.localStorage.getItem('initialValue');
-    const isInitiallyDisabled = window.localStorage.getItem('initialDisabled');
+    const isInitiallyDisabled = !!window.localStorage.getItem('initialDisabled');
     const [field, mitt] = createFakeFieldAPI(field => field, initialValue ? JSON.parse(initialValue) : undefined);
     return (
       <div data-test-id="location-editor-integration-test">

--- a/packages/markdown/src/MarkdownEditor.mdx
+++ b/packages/markdown/src/MarkdownEditor.mdx
@@ -20,7 +20,7 @@ import { createFakeFieldAPI, ActionsPlayground } from '@contentful/field-editor-
 <Playground>
   {() => {
     const initialValue = window.localStorage.getItem('initialValue');
-    const isInitiallyDisabled = window.localStorage.getItem('initialDisabled');
+    const isInitiallyDisabled = !!window.localStorage.getItem('initialDisabled');
     const [field, mitt] = createFakeFieldAPI(field => field, initialValue);
 
     let sdk = {

--- a/packages/reference/src/assets/MultipleMediaEditor.mdx
+++ b/packages/reference/src/assets/MultipleMediaEditor.mdx
@@ -26,7 +26,7 @@ import changedAsset from '../__fixtures__/changed_asset.json';
 <Playground>
   {() => {
     const initialValue = window.localStorage.getItem('initialValue');
-    const isInitiallyDisabled = window.localStorage.getItem('initialDisabled');
+    const isInitiallyDisabled = !!window.localStorage.getItem('initialDisabled');
     const instanceParams = window.localStorage.getItem('instanceParams');
     const [field, mitt] = createFakeFieldAPI(field => field, initialValue);
     const space = createFakeSpaceAPI();
@@ -117,7 +117,7 @@ import changedAsset from '../__fixtures__/changed_asset.json';
 <Playground>
   {() => {
     const initialValue = window.localStorage.getItem('initialValue');
-    const isInitiallyDisabled = window.localStorage.getItem('initialDisabled');
+    const isInitiallyDisabled = !!window.localStorage.getItem('initialDisabled');
     const instanceParams = window.localStorage.getItem('instanceParams');
     const [field, mitt] = createFakeFieldAPI(field => field, initialValue);
     const space = createFakeSpaceAPI();

--- a/packages/reference/src/assets/SingleMediaEditor.mdx
+++ b/packages/reference/src/assets/SingleMediaEditor.mdx
@@ -25,7 +25,7 @@ import publishedAsset from '../__fixtures__/published_asset.json';
 <Playground>
   {() => {
     const initialValue = window.localStorage.getItem('initialValue');
-    const isInitiallyDisabled = window.localStorage.getItem('initialDisabled');
+    const isInitiallyDisabled = !!window.localStorage.getItem('initialDisabled');
     const instanceParams = window.localStorage.getItem('instanceParams');
     const [field, mitt] = createFakeFieldAPI(field => field, initialValue);
     const space = createFakeSpaceAPI();
@@ -106,7 +106,7 @@ import publishedAsset from '../__fixtures__/published_asset.json';
 <Playground>
   {() => {
     const initialValue = window.localStorage.getItem('initialValue');
-    const isInitiallyDisabled = window.localStorage.getItem('initialDisabled');
+    const isInitiallyDisabled = !!window.localStorage.getItem('initialDisabled');
     const instanceParams = window.localStorage.getItem('instanceParams');
     const [field, mitt] = createFakeFieldAPI(field => field, initialValue);
     const space = createFakeSpaceAPI();

--- a/packages/reference/src/entries/MultipleEntryReferenceEditor.mdx
+++ b/packages/reference/src/entries/MultipleEntryReferenceEditor.mdx
@@ -29,7 +29,7 @@ import { newReferenceEditorFakeSdk } from '../__fixtures__/FakeSdk'
 
 <Playground>
   {() => {
-    const isInitiallyDisabled = window.localStorage.getItem('initialDisabled');
+    const isInitiallyDisabled = !!window.localStorage.getItem('initialDisabled');
     const instanceParams = window.localStorage.getItem('instanceParams');
     const [sdk, mitt] = newReferenceEditorFakeSdk();
     return (
@@ -59,7 +59,7 @@ another reference rendered by the stardard card renderer.
 
 <Playground>
   {() => {
-    const isInitiallyDisabled = window.localStorage.getItem('initialDisabled');
+    const isInitiallyDisabled = !!window.localStorage.getItem('initialDisabled');
     const instanceParams = window.localStorage.getItem('instanceParams');
     const [sdk, mitt] = newReferenceEditorFakeSdk();
     return (

--- a/packages/reference/src/entries/SingleEntryReferenceEditor.mdx
+++ b/packages/reference/src/entries/SingleEntryReferenceEditor.mdx
@@ -29,7 +29,7 @@ import { newReferenceEditorFakeSdk } from '../__fixtures__/FakeSdk'
 
 <Playground>
   {() => {
-    const isInitiallyDisabled = window.localStorage.getItem('initialDisabled');
+    const isInitiallyDisabled = !!window.localStorage.getItem('initialDisabled');
     const instanceParams = window.localStorage.getItem('instanceParams');
     const [sdk, mitt] = newReferenceEditorFakeSdk();
     return (
@@ -58,7 +58,7 @@ again to showcase inserting another reference rendered by the stardard card rend
 
 <Playground>
   {() => {
-    const isInitiallyDisabled = window.localStorage.getItem('initialDisabled');
+    const isInitiallyDisabled = !!window.localStorage.getItem('initialDisabled');
     const instanceParams = window.localStorage.getItem('instanceParams');
     const [sdk, mitt] = newReferenceEditorFakeSdk();
     return (


### PR DESCRIPTION
Avoid `isInitiallyDisabled` being `null` due to getting it from `localStorage` where it may not be defined. This prevents annoying console warning stating that a boolean is expected in some components.