### PR TITLE
feat: 🎸 pass link actions props to a custom card renderer

### DIFF
--- a/packages/reference/src/common/ReferenceEditor.tsx
+++ b/packages/reference/src/common/ReferenceEditor.tsx
@@ -16,7 +16,10 @@ export interface ReferenceEditorProps {
   hasCardEditActions: boolean;
   sdk: FieldExtensionSDK;
   viewType: ViewType;
-  renderCustomCard?: (props: CustomEntryCardProps) => React.ReactElement | false;
+  renderCustomCard?: (
+    props: CustomEntryCardProps,
+    linkActionsProps: CustomActionProps
+  ) => React.ReactElement | false;
   renderCustomActions?: (props: CustomActionProps) => React.ReactElement;
   getEntityUrl?: (entryId: string) => string;
   onAction?: (action: Action) => void;

--- a/packages/reference/src/common/ReferenceEditor.tsx
+++ b/packages/reference/src/common/ReferenceEditor.tsx
@@ -38,6 +38,7 @@ export type CustomActionProps = LinkActionsProps;
 // TODO: When making this available to media editor, consider introducing a
 //  separate interface vs. making this more generic  using `entity` over `entry`
 export type CustomEntryCardProps = {
+  index?: number;
   entry: Entry;
   entryUrl?: string;
   contentType?: ContentType;

--- a/packages/reference/src/common/useEntityPermissions.ts
+++ b/packages/reference/src/common/useEntityPermissions.ts
@@ -1,0 +1,38 @@
+import { useEffect, useState } from 'react';
+import { FieldExtensionSDK, EntityType } from '../types';
+import { ReferenceEditorProps } from './ReferenceEditor';
+
+export function useEntityPermissions({
+  sdk,
+  entityType,
+  parameters,
+}: {
+  sdk: FieldExtensionSDK;
+  entityType: EntityType;
+  parameters: ReferenceEditorProps['parameters'];
+}) {
+  const [canCreate, setCanCreate] = useState(true);
+
+  useEffect(() => {
+    if (entityType === 'Asset') {
+      sdk.access.can('create', 'Asset').then((value) => {
+        setCanCreate(value);
+      });
+    }
+  }, []);
+
+  const canCreateEntity = () => {
+    if (parameters.instance.showCreateEntityAction === false) {
+      return false;
+    }
+    return canCreate;
+  };
+  const canLinkEntity = () => {
+    if (parameters.instance.showLinkEntityAction !== undefined) {
+      return parameters.instance.showLinkEntityAction;
+    }
+    return true;
+  };
+
+  return { canCreateEntity: canCreateEntity(), canLinkEntity: canLinkEntity() };
+}

--- a/packages/reference/src/components/LinkActions/helpers.ts
+++ b/packages/reference/src/components/LinkActions/helpers.ts
@@ -1,0 +1,75 @@
+import { Asset, EntityType, Entry, FieldExtensionSDK } from '../../types';
+import { ReferenceValidations } from '../../utils/fromFieldValidations';
+
+export async function createEntity(props: {
+  sdk: FieldExtensionSDK;
+  entityType: EntityType;
+  contentTypeId?: string;
+}) {
+  if (props.entityType === 'Entry') {
+    if (!props.contentTypeId) {
+      return {};
+    }
+    const { entity, slide } = await props.sdk.navigator.openNewEntry<Entry>(props.contentTypeId, {
+      slideIn: true,
+    });
+    return { entity, slide };
+  } else {
+    const { entity, slide } = await props.sdk.navigator.openNewAsset<Asset>({
+      slideIn: true,
+    });
+    return { entity, slide };
+  }
+}
+
+export async function selectSingleEntity(props: {
+  sdk: FieldExtensionSDK;
+  entityType: EntityType;
+  validations: ReferenceValidations;
+}) {
+  if (props.entityType === 'Entry') {
+    return await props.sdk.dialogs.selectSingleEntry<Entry>({
+      locale: props.sdk.field.locale,
+      contentTypes: props.validations.contentTypes,
+    });
+  } else {
+    return props.sdk.dialogs.selectSingleAsset<Asset>({
+      locale: props.sdk.field.locale,
+      mimetypeGroups: props.validations.mimetypeGroups,
+    });
+  }
+}
+
+export async function selectMultipleEntities(props: {
+  sdk: FieldExtensionSDK;
+  entityType: EntityType;
+  validations: ReferenceValidations;
+}) {
+  const value = props.sdk.field.getValue();
+
+  const linkCount = Array.isArray(value) ? value.length : value ? 1 : 0;
+
+  // TODO: Why not always set `min: 1` by default? Does it make sense to enforce
+  //  user to select as many entities as the field's "min" requires? What if e.g.
+  // "min" is 4 and the user wants to insert 2 entities first, then create 2 new ones?
+  const min = Math.max((props.validations.numberOfLinks?.min || 1) - linkCount, 1);
+  // TODO: Consider same for max. If e.g. "max" is 4, we disable the button if the
+  //  user wants to select 5 but we show no information why the button is disabled.
+  const max = (props.validations.numberOfLinks?.max || +Infinity) - linkCount;
+
+  if (props.entityType === 'Entry') {
+    return await props.sdk.dialogs.selectMultipleEntries<Entry>({
+      locale: props.sdk.field.locale,
+      contentTypes: props.validations.contentTypes,
+      min,
+      max,
+    });
+  } else {
+    return props.sdk.dialogs.selectMultipleAssets<Asset>({
+      locale: props.sdk.field.locale,
+      mimetypeGroups: props.validations.mimetypeGroups,
+      min,
+      max,
+    });
+  }
+}

--- a/packages/reference/src/entries/WrappedEntryCard/FetchingWrappedEntryCard.tsx
+++ b/packages/reference/src/entries/WrappedEntryCard/FetchingWrappedEntryCard.tsx
@@ -2,9 +2,13 @@ import * as React from 'react';
 import { EntryCard } from '@contentful/forma-36-react-components';
 import { ContentType, FieldExtensionSDK, NavigatorSlideInfo } from '../../types';
 import { WrappedEntryCard } from './WrappedEntryCard';
-import { MissingEntityCard } from '../../components';
+import { LinkActionsProps, MissingEntityCard } from '../../components';
 import { useEntities } from '../../common/EntityStore';
-import { CustomEntryCardProps, ReferenceEditorProps } from '../../common/ReferenceEditor';
+import {
+  CustomActionProps,
+  CustomEntryCardProps,
+  ReferenceEditorProps,
+} from '../../common/ReferenceEditor';
 import get from 'lodash/get';
 import { WrappedEntryCardProps } from './WrappedEntryCard';
 
@@ -15,7 +19,10 @@ export type EntryCardReferenceEditorProps = ReferenceEditorProps & {
   isDisabled: boolean;
   onRemove: () => void;
   cardDragHandle?: React.ReactElement;
-  renderCustomCard?: (props: CustomEntryCardProps) => React.ReactElement | false;
+  renderCustomCard?: (
+    props: CustomEntryCardProps,
+    linkActionsProps: CustomActionProps
+  ) => React.ReactElement | false;
   hasCardEditActions: boolean;
 };
 
@@ -125,7 +132,8 @@ export function FetchingWrappedEntryCard(props: EntryCardReferenceEditorProps) {
       onRemove,
     };
     if (props.renderCustomCard) {
-      const renderedCustomCard = props.renderCustomCard(sharedCardProps);
+      // LinkActionsProps are injected higher SingleReferenceEditor/MultipleReferenceEditor
+      const renderedCustomCard = props.renderCustomCard(sharedCardProps, {} as LinkActionsProps);
       // Only `false` indicates to render the original card. E.g. `null` would result in no card.
       if (renderedCustomCard !== false) {
         return renderedCustomCard;

--- a/packages/reference/src/entries/WrappedEntryCard/FetchingWrappedEntryCard.tsx
+++ b/packages/reference/src/entries/WrappedEntryCard/FetchingWrappedEntryCard.tsx
@@ -118,6 +118,7 @@ export function FetchingWrappedEntryCard(props: EntryCardReferenceEditorProps) {
       return <EntryCard size={size} loading />;
     }
     const sharedCardProps: CustomEntryCardProps = {
+      index: props.index,
       entry,
       entryUrl: props.getEntityUrl && props.getEntityUrl(entry.sys.id),
       contentType: props.allContentTypes.find(


### PR DESCRIPTION
Extracts props of `LinkEntityActions` to a hook `useLinkActionsProps`, so the same props can be passed to `renderCustomCard`.

Would allow to rendered custom card actions utilising `onCreate`, `onLinkExisting`, `availableContentTypes`.