### PR TITLE
feat: 🎸 do not show link actions on full reference/media fields

### DIFF
--- a/cypress/integration/MultipleMediaEditor.spec.ts
+++ b/cypress/integration/MultipleMediaEditor.spec.ts
@@ -1,6 +1,8 @@
 describe('Multiple Media Editor', () => {
+  const openPage = () => cy.visit('/media-multiple');
+
   beforeEach(() => {
-    cy.visit('/media-multiple');
+    openPage();
   });
 
   const findCreateAndLinkBtn = (parent: Cypress.Chainable) =>
@@ -35,6 +37,8 @@ describe('Multiple Media Editor', () => {
 
   describe('custom actions injected actions dropdown', () => {
     beforeEach(() => {
+      cy.setFieldValidations([{ size: { max: 2 } }]);
+      openPage();
       cy.findByTestId('multiple-media-editor-custom-actions-integration-test').as('wrapper');
     });
 
@@ -46,6 +50,13 @@ describe('Multiple Media Editor', () => {
       findCustomActionsDropdownTrigger(cy.get('@wrapper')).click();
       findLinkExistingBtn(findCustomActionsDropdown()).click();
       findCards(cy.get('body')).should('have.length', 2);
+    });
+
+    it('hides actions when max number of allowed links is reached', () => {
+      findCustomActionsDropdownTrigger(cy.get('@wrapper')).click();
+      findLinkExistingBtn(findCustomActionsDropdown()).click();
+      findCards(cy.get('body')).should('have.length', 2);
+      findCustomActionsDropdownTrigger(cy.get('@wrapper')).should('not.be.visible');
     });
   });
 });

--- a/cypress/integration/MultipleReferenceEditor.spec.ts
+++ b/cypress/integration/MultipleReferenceEditor.spec.ts
@@ -1,6 +1,8 @@
 describe('Multiple Reference Editor', () => {
+  const openPage = () => cy.visit('/reference-multiple');
+
   beforeEach(() => {
-    cy.visit('/reference-multiple');
+    openPage();
   });
 
   const getWrapper = () =>
@@ -24,5 +26,13 @@ describe('Multiple Reference Editor', () => {
     findLinkExistingBtn().click(); // Inserts another card using standard card renderer.
     findDefaultCards().should('have.length', 1);
     findCustomCards().should('have.length', 2);
+  });
+
+  it('hides actions when max number of allowed links is reached', () => {
+    cy.setFieldValidations([{ size: { max: 3 } }]);
+    openPage();
+    findLinkExistingBtn().click();
+    findLinkExistingBtn().click(); // inserts 2 cards
+    findLinkExistingBtn().should('not.be.visible'); // limit reached, button hidden.
   });
 });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -35,7 +35,7 @@ Cypress.Commands.add('setGoogleMapsKey', () => {
 
 Cypress.Commands.add('setInitialValue', (initialValue) => {
   return cy.window().then((win) => {
-    win.localStorage.setItem('initialValue', initialValue);
+    win.localStorage.setItem('initialValue', JSON.stringify(initialValue));
     return win;
   });
 });
@@ -43,6 +43,13 @@ Cypress.Commands.add('setInitialValue', (initialValue) => {
 Cypress.Commands.add('setInitialDisabled', (initialDisabled) => {
   return cy.window().then((win) => {
     win.localStorage.setItem('initialDisabled', initialDisabled);
+    return win;
+  });
+});
+
+Cypress.Commands.add('setFieldValidations', (validations) => {
+  return cy.window().then((win) => {
+    win.localStorage.setItem('fieldValidations', JSON.stringify(validations));
     return win;
   });
 });

--- a/cypress/support/index.d.ts
+++ b/cypress/support/index.d.ts
@@ -5,6 +5,7 @@ declare namespace Cypress {
     setGoogleMapsKey(): Chainable<void>;
     setInitialValue(initialValue: any): void;
     setInitialDisabled(value: boolean | undefined): void;
+    setFieldValidations(value: Object[]): void;
     setInstanceParams(value: { [key: string]: any }): void;
     getMarkdownInstance(): Chainable<{
       getContent: () => string;

--- a/packages/date/src/DateEditor.mdx
+++ b/packages/date/src/DateEditor.mdx
@@ -16,7 +16,8 @@ import { createFakeFieldAPI, ActionsPlayground } from '@contentful/field-editor-
 
 <Playground>
   {() => {
-    const initialValue = window.localStorage.getItem('initialValue');
+    const rawInitialValue = window.localStorage.getItem('initialValue');
+    const initialValue = rawInitialValue ? JSON.parse(rawInitialValue) : undefined;
     const isInitiallyDisabled = !!window.localStorage.getItem('initialDisabled');
     const instanceParams = window.localStorage.getItem('instanceParams');
     const [field, mitt] = createFakeFieldAPI(field => field, initialValue);

--- a/packages/reference/src/assets/MultipleMediaEditor.mdx
+++ b/packages/reference/src/assets/MultipleMediaEditor.mdx
@@ -16,81 +16,14 @@ import { MultipleMediaEditor } from '@contentful/field-editor-reference';
 import { Playground, Props } from 'docz';
 import { MultipleMediaEditor } from './MultipleMediaEditor.tsx'
 import { CombinedLinkActions } from '../../src';
-import { createFakeFieldAPI, createFakeSpaceAPI, createFakeLocalesAPI, ActionsPlayground } from '@contentful/field-editor-test-utils';
-import { TextLink } from '@contentful/forma-36-react-components';
-import emptyAsset from '../__fixtures__/empty_asset.json';
-import publishedAsset from '../__fixtures__/published_asset.json';
-import changedAsset from '../__fixtures__/changed_asset.json';
+import { ActionsPlayground } from '@contentful/field-editor-test-utils';
+import { newReferenceEditorFakeSdk } from '../__fixtures__/FakeSdk';
 
 ## In Action
 
 <Playground>
   {() => {
-    const initialValue = window.localStorage.getItem('initialValue');
-    const isInitiallyDisabled = !!window.localStorage.getItem('initialDisabled');
-    const instanceParams = window.localStorage.getItem('instanceParams');
-    const [field, mitt] = createFakeFieldAPI(field => field, initialValue);
-    const space = createFakeSpaceAPI();
-    const locales = createFakeLocalesAPI();
-    const sdk = {
-      field,
-      locales,
-      space: {
-        ...space,
-        getAsset: (id) => {
-          if (id === 'empty_asset') {
-            return Promise.resolve(emptyAsset);
-          }
-          if (id === 'published_asset') {
-            return Promise.resolve(publishedAsset);
-          }
-          if (id === 'changed_asset') {
-            return Promise.resolve(changedAsset);
-          }
-          return Promise.reject();
-        },
-      },
-      dialogs: {
-        selectMultipleAssets: () => {
-          return [
-            {
-              sys: {
-                id: 'published_asset'
-              }
-            },
-            {
-              sys: {
-                id: 'changed_asset'
-              }
-            }
-          ]
-        }
-      },
-      navigator: {
-        openNewAsset: async () => {
-          return {
-            entity: {
-              sys: {
-                id: 'empty_asset'
-              }
-            }
-          }
-        },
-        openAsset: () => {
-          alert('open Asset in slide in');
-          return Promise.resolve({});
-        },
-        onSlideInNavigation: () => () => {}
-      },
-      access: {
-        can: (access, entityType) => {
-          if (access === 'create' && entityType === 'Asset') {
-            return Promise.resolve(true);
-          }
-          return Promise.resolve(false);
-        }
-      }
-    };
+    const [sdk, mitt] = newReferenceEditorFakeSdk();
     return (
       <div data-test-id="multiple-media-editor-integration-test">
         <MultipleMediaEditor
@@ -107,7 +40,6 @@ import changedAsset from '../__fixtures__/changed_asset.json';
         <ActionsPlayground mitt={mitt} />
       </div>
     );
-
 }}
 
 </Playground>
@@ -119,64 +51,7 @@ Note the alternative link actions injected via the `renderCustomActions` prop.
 
 <Playground>
   {() => {
-    const initialValue = window.localStorage.getItem('initialValue');
-    const isInitiallyDisabled = !!window.localStorage.getItem('initialDisabled');
-    const instanceParams = window.localStorage.getItem('instanceParams');
-    const [field, mitt] = createFakeFieldAPI(field => field, initialValue);
-    const space = createFakeSpaceAPI();
-    const locales = createFakeLocalesAPI();
-    const sdk = {
-      field,
-      locales,
-      space: {
-        ...space,
-        getAsset: (id) => {
-          if (id === 'published_asset') {
-            return Promise.resolve(publishedAsset);
-          }
-          if (id === 'changed_asset') {
-            return Promise.resolve(changedAsset);
-          }
-
-          return Promise.reject();
-        },
-      },
-      dialogs: {
-        selectMultipleAssets: () => {
-          return [
-            {
-              sys: {
-                id: 'published_asset'
-              }
-            },
-            {
-              sys: {
-                id: 'changed_asset'
-              }
-            }
-          ]
-        }
-      },
-      navigator: {
-        openAsset: () => {
-          alert('open Asset in slide in');
-          return Promise.resolve({});
-        },
-        openNewAsset: async () => {
-          return {
-            entity: {
-              sys: {
-                id: 'changed_asset',
-              },
-            },
-          };
-        },
-        onSlideInNavigation: () => () => {}
-      },
-      access: {
-        can: () => Promise.resolve(true)
-      }
-    };
+    const [sdk, mitt] = newReferenceEditorFakeSdk();
     return (
       <div data-test-id="multiple-media-editor-custom-actions-integration-test">
         <MultipleMediaEditor
@@ -194,7 +69,6 @@ Note the alternative link actions injected via the `renderCustomActions` prop.
         <ActionsPlayground mitt={mitt} />
       </div>
     );
-
 }}
 
 </Playground>

--- a/packages/reference/src/assets/SingleMediaEditor.mdx
+++ b/packages/reference/src/assets/SingleMediaEditor.mdx
@@ -15,70 +15,15 @@ import { SingleMediaEditor } from '@contentful/field-editor-reference';
 
 import { Playground, Props } from 'docz';
 import { SingleMediaEditor } from './SingleMediaEditor.tsx'
-import { createFakeFieldAPI, createFakeSpaceAPI, createFakeLocalesAPI, ActionsPlayground } from '@contentful/field-editor-test-utils';
 import { TextLink } from '@contentful/forma-36-react-components';
-import emptyAsset from '../__fixtures__/empty_asset.json';
-import publishedAsset from '../__fixtures__/published_asset.json';
+import { ActionsPlayground } from '@contentful/field-editor-test-utils';
+import { newReferenceEditorFakeSdk } from '../__fixtures__/FakeSdk';
 
 ## In Action
 
 <Playground>
   {() => {
-    const initialValue = window.localStorage.getItem('initialValue');
-    const isInitiallyDisabled = !!window.localStorage.getItem('initialDisabled');
-    const instanceParams = window.localStorage.getItem('instanceParams');
-    const [field, mitt] = createFakeFieldAPI(field => field, initialValue);
-    const space = createFakeSpaceAPI();
-    const locales = createFakeLocalesAPI();
-    const sdk = {
-      field,
-      locales,
-      space: {
-        ...space,
-        getAsset: (id) => {
-          if (id === 'empty_asset') {
-            return Promise.resolve(emptyAsset);
-          }
-          if (id === 'published_asset') {
-            return Promise.resolve(publishedAsset);
-          }
-          return Promise.reject();
-        },
-      },
-      dialogs: {
-        selectSingleAsset: () => {
-          return {
-            sys: {
-              id: 'published_asset'
-            }
-          }
-        }
-      },
-      navigator: {
-        openNewAsset: async () => {
-          return {
-            entity: {
-              sys: {
-                id: 'empty_asset'
-              }
-            }
-          }
-        },
-        openAsset: () => {
-          alert('open asset in slide in');
-          return Promise.resolve({});
-        },
-        onSlideInNavigation: () => () => {}
-      },
-      access: {
-        can: (access, entityType) => {
-          if (access === 'create' && entityType === 'Asset') {
-            return Promise.resolve(true);
-          }
-          return Promise.resolve(false);
-        }
-      }
-    };
+    const [sdk, mitt] = newReferenceEditorFakeSdk();
     return (
       <div>
         <SingleMediaEditor
@@ -95,7 +40,6 @@ import publishedAsset from '../__fixtures__/published_asset.json';
         <ActionsPlayground mitt={mitt} />
       </div>
     );
-
 }}
 
 </Playground>
@@ -107,43 +51,7 @@ Note the alternative link actions injected via the `renderCustomActions` prop.
 
 <Playground>
   {() => {
-    const initialValue = window.localStorage.getItem('initialValue');
-    const isInitiallyDisabled = !!window.localStorage.getItem('initialDisabled');
-    const instanceParams = window.localStorage.getItem('instanceParams');
-    const [field, mitt] = createFakeFieldAPI(field => field, initialValue);
-    const space = createFakeSpaceAPI();
-    const locales = createFakeLocalesAPI();
-    const sdk = {
-      field,
-      locales,
-      space: {
-        ...space,
-        getAsset: (id) => {
-          if (id === 'empty_asset') {
-            return Promise.resolve(emptyAsset);
-          }
-          if (id === 'published_asset') {
-            return Promise.resolve(publishedAsset);
-          }
-          return Promise.reject();
-        },
-      },
-      dialogs: {
-        selectSingleAsset: () => {
-          return {
-            sys: {
-              id: 'published_asset'
-            }
-          }
-        }
-      },
-      navigator: {
-        onSlideInNavigation: () => () => {}
-      },
-      access: {
-        can: () => Promise.resolve(true)
-      }
-    };
+    const [sdk, mitt] = newReferenceEditorFakeSdk();
     return (
       <div>
         <SingleMediaEditor
@@ -168,7 +76,6 @@ Note the alternative link actions injected via the `renderCustomActions` prop.
         <ActionsPlayground mitt={mitt} />
       </div>
     );
-
 }}
 
 </Playground>

--- a/packages/reference/src/components/LinkActions/CombinedLinkActions.tsx
+++ b/packages/reference/src/components/LinkActions/CombinedLinkActions.tsx
@@ -17,6 +17,9 @@ const testIds = {
  * one action dropdown and introduces new copy for action labels.
  */
 export function CombinedLinkActions(props: LinkActionsProps) {
+  if (props.isFull) {
+    return null; // Don't render link actions if we reached max allowed links.
+  }
   // TODO: We don't want to render a spacious container in case there are
   //  are already assets linked (in case of entries, always show it) as the
   //  border wouldn't be nicely aligned with asset cards.

--- a/packages/reference/src/components/LinkActions/LinkActions.tsx
+++ b/packages/reference/src/components/LinkActions/LinkActions.tsx
@@ -11,6 +11,7 @@ export interface LinkActionsProps {
   canLinkEntity: boolean;
   canLinkMultiple: boolean;
   isDisabled: boolean;
+  isFull: boolean;
   onCreate: (contentType?: string) => Promise<unknown>;
   onLinkExisting: () => void;
   actionLabels?: Partial<ActionLabels>;
@@ -36,6 +37,9 @@ export const testIds = {
 };
 
 export function LinkActions(props: LinkActionsProps) {
+  if (props.isFull) {
+    return null; // Don't render link actions if we reached max allowed links.
+  }
   const defaultLabels = props.entityType === 'Entry' ? defaultEntryLabels : defaultAssetLabels;
   const labels = {
     ...defaultLabels,

--- a/packages/reference/src/components/LinkActions/LinkEntityActions.tsx
+++ b/packages/reference/src/components/LinkActions/LinkEntityActions.tsx
@@ -40,6 +40,10 @@ export function useLinkActionsProps(props: LinkEntityActionsProps): LinkActionsP
         })
       : props.allContentTypes;
   }
+  const maxLinksCount = validations.numberOfLinks?.max;
+  const value = sdk.field.getValue();
+  const linkCount = Array.isArray(value) ? value.length : value ? 1 : 0;
+  const isFull = !!maxLinksCount && maxLinksCount <= linkCount;
 
   const onCreate = React.useCallback(
     async (contentTypeId?: string) => {
@@ -88,6 +92,7 @@ export function useLinkActionsProps(props: LinkEntityActionsProps): LinkActionsP
       entityType,
       canLinkMultiple,
       isDisabled,
+      isFull,
       canCreateEntity,
       canLinkEntity,
       contentTypes: availableContentTypes,
@@ -99,6 +104,7 @@ export function useLinkActionsProps(props: LinkEntityActionsProps): LinkActionsP
       entityType,
       canLinkMultiple,
       isDisabled,
+      isFull,
       canCreateEntity,
       canLinkEntity,
       actionLabels,

--- a/packages/reference/src/entries/MultipleEntryReferenceEditor.mdx
+++ b/packages/reference/src/entries/MultipleEntryReferenceEditor.mdx
@@ -120,13 +120,7 @@ Note the alternative link actions injected via the `renderCustomActions` prop.
   }}
 </Playground>
 
-## Props
-
-<Props of={MultipleEntryReferenceEditor} />
-
-
 ## With custom card relying on default card
-
 
 <Playground>
   {() => {
@@ -154,3 +148,7 @@ Note the alternative link actions injected via the `renderCustomActions` prop.
     );
   }}
 </Playground>
+
+## Props
+
+<Props of={MultipleEntryReferenceEditor} />


### PR DESCRIPTION
We do not want to show the link actions on a reference or media field which is already full (meaning the field has a max number of links validation and that number is met or exceeded). This is true for both the current editor link design as well as the experimental CombinedLinkActions design.

This is actually regarded as a regression, although one already in place for such a long while that we can probably treat it as a feature at this point (hence the `feat` commit).

This also removes a lot of redundant mocks used by the media field examples.