### PR TITLE
feat: 🎸 hide CombinedLinkActions asset card on non‐empty field

### DIFF
--- a/packages/reference/src/components/LinkActions/CombinedLinkActions.tsx
+++ b/packages/reference/src/components/LinkActions/CombinedLinkActions.tsx
@@ -20,11 +20,12 @@ export function CombinedLinkActions(props: LinkActionsProps) {
   if (props.isFull) {
     return null; // Don't render link actions if we reached max allowed links.
   }
-  // TODO: We don't want to render a spacious container in case there are
-  //  are already assets linked (in case of entries, always show it) as the
-  //  border wouldn't be nicely aligned with asset cards.
+  // We don't want to render a spacious container in case there are are already
+  // assets linked (in case of entries, always show it) as the border wouldn't be
+  // nicely aligned with asset cards.
+  const hideEmptyCard = props.entityType === 'Asset' && !props.isEmpty;
   return (
-    <div className={styles.container}>
+    <div className={hideEmptyCard ? '' : styles.container}>
       {props.entityType === 'Entry' && <CombinedEntryLinkActions {...props} />}
       {props.entityType === 'Asset' && <CombinedAssetLinkActions {...props} />}
     </div>

--- a/packages/reference/src/components/LinkActions/LinkActions.tsx
+++ b/packages/reference/src/components/LinkActions/LinkActions.tsx
@@ -12,6 +12,7 @@ export interface LinkActionsProps {
   canLinkMultiple: boolean;
   isDisabled: boolean;
   isFull: boolean;
+  isEmpty: boolean;
   onCreate: (contentType?: string) => Promise<unknown>;
   onLinkExisting: () => void;
   actionLabels?: Partial<ActionLabels>;

--- a/packages/reference/src/components/LinkActions/LinkEntityActions.tsx
+++ b/packages/reference/src/components/LinkActions/LinkEntityActions.tsx
@@ -44,6 +44,7 @@ export function useLinkActionsProps(props: LinkEntityActionsProps): LinkActionsP
   const value = sdk.field.getValue();
   const linkCount = Array.isArray(value) ? value.length : value ? 1 : 0;
   const isFull = !!maxLinksCount && maxLinksCount <= linkCount;
+  const isEmpty = linkCount === 0;
 
   const onCreate = React.useCallback(
     async (contentTypeId?: string) => {
@@ -92,6 +93,7 @@ export function useLinkActionsProps(props: LinkEntityActionsProps): LinkActionsP
       entityType,
       canLinkMultiple,
       isDisabled,
+      isEmpty,
       isFull,
       canCreateEntity,
       canLinkEntity,
@@ -104,6 +106,7 @@ export function useLinkActionsProps(props: LinkEntityActionsProps): LinkActionsP
       entityType,
       canLinkMultiple,
       isDisabled,
+      isEmpty,
       isFull,
       canCreateEntity,
       canLinkEntity,


### PR DESCRIPTION
When  there  are  assets  linked  on  a  media  field  using `CombinedLinkActions`, the link actions won’t be wrapped by the cards placeholder as it doesn’t go well with the asset cards which do not cover the full available horizontal space like the card placeholder.

:exclamation: This PR is based on and requires #437 to be merged first.

**Empty field:**
![add-media](https://user-images.githubusercontent.com/101926/95372330-b277fc80-08db-11eb-830c-7d43792fd292.png)

**Non-empty field (NEW):**
![add-media-with-existing](https://user-images.githubusercontent.com/101926/95372358-bad03780-08db-11eb-8bda-e67834329e46.png)

After this we can use `CombinedLinkActions` in the new app.