### PR TITLE
feat(reference-editor): insert at index

### DIFF
--- a/packages/reference/package.json
+++ b/packages/reference/package.json
@@ -25,6 +25,7 @@
     "@contentful/forma-36-react-components": "^3.57.1",
     "@contentful/forma-36-tokens": "^0.8.0",
     "@contentful/mimetype": "^1.4.0",
+    "@types/deep-equal": "^1.0.1",
     "array-move": "^3.0.0",
     "constate": "2.0.0",
     "contentful-ui-extensions-sdk": "^3.18.0",

--- a/packages/reference/src/common/MultipleReferenceEditor.tsx
+++ b/packages/reference/src/common/MultipleReferenceEditor.tsx
@@ -24,6 +24,21 @@ type EditorProps = ReferenceEditorProps &
     children: (props: ReferenceEditorProps & ChildProps) => React.ReactElement;
   };
 
+function onLinkOrCreate(
+  setValue: ChildProps['setValue'],
+  entityType: ChildProps['entityType'],
+  items: ChildProps['items'],
+  ids: string[],
+  index?: number
+): void {
+  const links: ReferenceValue[] = ids.map((id) => ({
+    sys: { type: 'Link', linkType: entityType, id },
+  }));
+  const newItems = Array.from(items);
+  newItems.splice(index !== undefined ? index : items.length, 0, ...links);
+  setValue(newItems);
+}
+
 function Editor(props: EditorProps) {
   const { items, setValue, entityType } = props;
   const { canCreateEntity, canLinkEntity } = useEntityPermissions(props);
@@ -38,19 +53,12 @@ function Editor(props: EditorProps) {
   );
 
   const onCreate = useCallback(
-    (id: string) => {
-      setValue([...items, { sys: { type: 'Link', linkType: entityType, id } }]);
-    },
+    (id: string, index?: number) => onLinkOrCreate(setValue, entityType, items, [id], index),
     [setValue, items, entityType]
   );
 
   const onLink = useCallback(
-    (ids: string[]) => {
-      setValue([
-        ...items,
-        ...ids.map((id) => ({ sys: { type: 'Link', linkType: entityType, id } as const })),
-      ]);
-    },
+    (ids: string[], index?: number) => onLinkOrCreate(setValue, entityType, items, ids, index),
     [setValue, items, entityType]
   );
 
@@ -64,8 +72,8 @@ function Editor(props: EditorProps) {
     validations,
     canCreateEntity,
     canLinkEntity,
-    onCreate: onCreate,
-    onLink: onLink,
+    onCreate,
+    onLink,
   });
   const customCardRenderer = useCallback(
     (cardProps: CustomEntryCardProps, _, renderDefaultCard) =>

--- a/packages/reference/src/components/LinkActions/LinkActions.tsx
+++ b/packages/reference/src/components/LinkActions/LinkActions.tsx
@@ -13,8 +13,8 @@ export interface LinkActionsProps {
   isDisabled: boolean;
   isFull: boolean;
   isEmpty: boolean;
-  onCreate: (contentType?: string) => Promise<unknown>;
-  onLinkExisting: () => void;
+  onCreate: (contentType?: string, index?: number) => Promise<unknown>;
+  onLinkExisting: (index?: number) => void;
   actionLabels?: Partial<ActionLabels>;
 }
 


### PR DESCRIPTION
Adds support for inserting a new created or linked entity or entities at a given index in the `MultipleReferencesEditor`.

By default we're currently adding such entities to the end of the list. This PR allows the options for clients to insert wherever they'd like, e.g., immediately after the element in a list, depending on how the card's rendered.

Note this is non-breaking as the default behavior remains the same.

Also adds `@types/deep-equal` as my compiler was complaining about that.