### PR TITLE
feat: 🎸 auto position combined link actions dropdown

### DIFF
--- a/packages/reference/src/components/LinkActions/CombinedLinkActions.tsx
+++ b/packages/reference/src/components/LinkActions/CombinedLinkActions.tsx
@@ -42,6 +42,10 @@ function CombinedEntryLinkActions(props: LinkActionsProps) {
         contentTypes={props.contentTypes}
         hasPlusIcon={true}
         useExperimentalStyles={true}
+        dropdownSettings={{
+          isAutoalignmentEnabled: true,
+          position: 'bottom-left',
+        }}
         onSelect={(contentTypeId) => {
           return contentTypeId ? props.onCreate(contentTypeId) : Promise.resolve();
         }}


### PR DESCRIPTION
The new combined reference link action's dropdown will be positioned automatically, if necessary, above the trigger button (in most cases, if there's enough space, it will still be shown below). This should prevent the menu from being cut off when e.g. positioned at the end of a page.

<img src="https://user-images.githubusercontent.com/101926/96877804-6780ec00-147a-11eb-8146-c69742dc66f2.png" width="350px" />
