### PR TITLE
refactor(reference): resize combined link actions

### DIFF
--- a/packages/reference/src/components/LinkActions/redesignStyles.ts
+++ b/packages/reference/src/components/LinkActions/redesignStyles.ts
@@ -7,7 +7,7 @@ export const container = css({
   border: `1px dashed ${tokens.colorElementMid}`,
   borderRadius: '3px',
   justifyContent: 'center',
-  padding: tokens.spacing3Xl,
+  padding: tokens.spacingXl,
 });
 
 export const action = css({


### PR DESCRIPTION
This PR reduces the size of the combined link action empty state.

**Before**
<img width="578" alt="Screenshot 2020-10-23 at 14 32 05" src="https://user-images.githubusercontent.com/4446634/97004030-b2633800-153c-11eb-824f-98dee8e54daf.png">

**After**
<img width="578" alt="Screenshot 2020-10-23 at 14 31 59" src="https://user-images.githubusercontent.com/4446634/97004051-b8591900-153c-11eb-9da9-7bd81bcbe9eb.png">
