### PR TITLE
fix: 🐛 use onAction for all remove actions (including missing)

### DIFF
--- a/packages/reference/src/assets/WrappedAssetCard/FetchingWrappedAssetCard.tsx
+++ b/packages/reference/src/assets/WrappedAssetCard/FetchingWrappedAssetCard.tsx
@@ -38,6 +38,12 @@ export function FetchingWrappedAssetCard(props: FetchingWrappedAssetCardProps) {
     }
   }, [asset]);
 
+  const onRemoveAsset = () => {
+    props.onRemove();
+    props.onAction &&
+      props.onAction({ entity: 'Asset', type: 'delete', id: props.assetId, contentTypeId: '' });
+  };
+
   return React.useMemo(() => {
     if (asset === 'failed') {
       return (
@@ -45,7 +51,7 @@ export function FetchingWrappedAssetCard(props: FetchingWrappedAssetCardProps) {
           entityType="Asset"
           asSquare={props.viewType !== 'link'}
           isDisabled={props.isDisabled}
-          onRemove={props.onRemove}
+          onRemove={onRemoveAsset}
         />
       );
     }
@@ -68,11 +74,7 @@ export function FetchingWrappedAssetCard(props: FetchingWrappedAssetCardProps) {
           });
       },
       cardDragHandle: props.cardDragHandle,
-      onRemove: () => {
-        props.onRemove();
-        props.onAction &&
-          props.onAction({ entity: 'Asset', type: 'delete', id: props.assetId, contentTypeId: '' });
-      },
+      onRemove: onRemoveAsset,
     };
 
     if (props.viewType === 'link') {

--- a/packages/reference/src/entries/WrappedEntryCard/FetchingWrappedEntryCard.tsx
+++ b/packages/reference/src/entries/WrappedEntryCard/FetchingWrappedEntryCard.tsx
@@ -89,7 +89,7 @@ export function FetchingWrappedEntryCard(props: EntryCardReferenceEditorProps) {
       });
   };
 
-  const onRemove = () => {
+  const onRemoveEntry = () => {
     props.onRemove();
     props.onAction &&
       props.onAction({
@@ -112,7 +112,7 @@ export function FetchingWrappedEntryCard(props: EntryCardReferenceEditorProps) {
         <MissingEntityCard
           entityType="Entry"
           isDisabled={props.isDisabled}
-          onRemove={props.onRemove}
+          onRemove={onRemoveEntry}
         />
       );
     }
@@ -132,7 +132,7 @@ export function FetchingWrappedEntryCard(props: EntryCardReferenceEditorProps) {
       defaultLocaleCode: props.sdk.locales.default,
       cardDragHandle: props.cardDragHandle,
       onEdit,
-      onRemove,
+      onRemove: onRemoveEntry,
     };
 
     const { hasCardEditActions, sdk } = props;


### PR DESCRIPTION
Closes  https://github.com/contentful/field-editors/issues/470