### PR TITLE
chore: 🤖 enable autoalignment for default create reference button

### DIFF
--- a/packages/reference/src/components/CreateEntryLinkButton/CreateEntryMenuTrigger.tsx
+++ b/packages/reference/src/components/CreateEntryLinkButton/CreateEntryMenuTrigger.tsx
@@ -80,7 +80,7 @@ export const CreateEntryMenuTrigger = ({
   onSelect,
   testId,
   dropdownSettings = {
-    isAutoalignmentEnabled: false,
+    isAutoalignmentEnabled: true,
     position: 'bottom-left',
   },
   renderCustomDropdownItems,


### PR DESCRIPTION
Now we have a stable behavior of the dropdown position and we can allow `create reference` dropdown to auto position itself.