### PR TITLE
chore: fix types imports to unblock docz production build

### DIFF
--- a/packages/reference/src/components/index.ts
+++ b/packages/reference/src/components/index.ts
@@ -1,4 +1,4 @@
-export { LinkActionsProps } from './LinkActions/LinkActions';
+export type { LinkActionsProps } from './LinkActions/LinkActions';
 export { CombinedLinkActions } from './LinkActions/CombinedLinkActions';
 export { MissingEntityCard } from './MissingEntityCard/MissingEntityCard';
 export { LinkEntityActions } from './LinkActions/LinkEntityActions';

--- a/packages/reference/src/entries/WrappedEntryCard/FetchingWrappedEntryCard.tsx
+++ b/packages/reference/src/entries/WrappedEntryCard/FetchingWrappedEntryCard.tsx
@@ -2,7 +2,8 @@ import * as React from 'react';
 import { EntryCard } from '@contentful/forma-36-react-components';
 import { ContentType, FieldExtensionSDK, NavigatorSlideInfo } from '../../types';
 import { WrappedEntryCard } from './WrappedEntryCard';
-import { LinkActionsProps, MissingEntityCard } from '../../components';
+import { MissingEntityCard } from '../../components';
+import type { LinkActionsProps } from '../../components';
 import { useEntities } from '../../common/EntityStore';
 import {
   CustomActionProps,

--- a/packages/reference/src/index.tsx
+++ b/packages/reference/src/index.tsx
@@ -14,7 +14,7 @@ export {
 } from './entries';
 export { SingleMediaEditor, MultipleMediaEditor, WrappedAssetCard } from './assets';
 export { EntityProvider, useEntities } from './common/EntityStore';
-export {
+export type {
   CustomEntryCardProps,
   CustomActionProps,
   DefaultCardRenderer,


### PR DESCRIPTION
Production build of docz is blocked because of warnings which are considered errors in CI. This PR unblocks it.