### PR TITLE
feat(link-actions): add reference index to action props

### DIFF
--- a/packages/reference/src/components/LinkActions/LinkEntityActions.tsx
+++ b/packages/reference/src/components/LinkActions/LinkEntityActions.tsx
@@ -59,6 +59,7 @@ export function useLinkActionsProps(props: LinkEntityActionsProps): LinkActionsP
           entity: entityType,
           entityData: entity,
           slide,
+          index,
         });
     },
     [sdk, entityType, props.onCreate, props.onAction]
@@ -72,7 +73,7 @@ export function useLinkActionsProps(props: LinkEntityActionsProps): LinkActionsP
       }
       props.onLink([entity.sys.id], index);
       props.onAction &&
-        props.onAction({ type: 'select_and_link', entity: entityType, entityData: entity });
+        props.onAction({ type: 'select_and_link', entity: entityType, entityData: entity, index });
     },
     [sdk, entityType, props.onLink, props.onAction]
   );
@@ -91,7 +92,12 @@ export function useLinkActionsProps(props: LinkEntityActionsProps): LinkActionsP
 
       entities.forEach((entity) => {
         props.onAction &&
-          props.onAction({ type: 'select_and_link', entity: entityType, entityData: entity });
+          props.onAction({
+            type: 'select_and_link',
+            entity: entityType,
+            entityData: entity,
+            index,
+          });
       });
     },
     [sdk, entityType, props.onLink, props.onAction]

--- a/packages/reference/src/types.ts
+++ b/packages/reference/src/types.ts
@@ -45,8 +45,9 @@ export type Action =
       entity: EntityType;
       entityData: Entry | Asset;
       slide?: NavigatorSlideInfo;
+      index?: number;
     }
-  | { type: 'select_and_link'; entity: EntityType; entityData: Entry | Asset }
+  | { type: 'select_and_link'; entity: EntityType; entityData: Entry | Asset; index?: number }
   | {
       type: 'edit';
       contentTypeId: string;


### PR DESCRIPTION
This PR adds an `index` prop to the `select_and_link` and `create_and_link` action types.