### PR TITLE
fix: clear button should respect disabled state

### DIFF
--- a/packages/boolean/src/Boolean.spec.tsx
+++ b/packages/boolean/src/Boolean.spec.tsx
@@ -65,4 +65,19 @@ describe('BooleanEditor', () => {
     fireEvent.click(getByText('Clear'));
     expect(field.removeValue).toHaveBeenCalledTimes(1);
   });
+
+  it('all interactive elements are disabled if field is disabled', () => {
+    const [field] = createFakeFieldAPI((field) => {
+      return field;
+    }, true);
+
+    const { getByTestId, getByLabelText } = render(
+      <BooleanEditor field={field} isInitiallyDisabled={true} />
+    );
+
+    expect(getByLabelText('Yes')).toBeDisabled();
+    expect(getByLabelText('No')).toBeDisabled();
+
+    expect(getByTestId('boolean-editor-clear')).toBeDisabled();
+  });
 });

--- a/packages/boolean/src/BooleanEditor.tsx
+++ b/packages/boolean/src/BooleanEditor.tsx
@@ -74,7 +74,11 @@ export function BooleanEditor(props: BooleanEditorProps) {
                 </React.Fragment>
               );
             })}
-            {value !== undefined && <TextLink onClick={clearOption}>Clear</TextLink>}
+            {value !== undefined && (
+              <TextLink testId="boolean-editor-clear" disabled={disabled} onClick={clearOption}>
+                Clear
+              </TextLink>
+            )}
           </div>
         );
       }}


### PR DESCRIPTION
"Clear" button shouldn't be clickable if the field is disabled