### PR TITLE
feat(asset reference): add support for scheduled icon [PUL-1206]

### DIFF
--- a/packages/reference/src/assets/WrappedAssetCard/FetchingWrappedAssetCard.tsx
+++ b/packages/reference/src/assets/WrappedAssetCard/FetchingWrappedAssetCard.tsx
@@ -70,7 +70,7 @@ export function FetchingWrappedAssetCard(props: FetchingWrappedAssetCardProps) {
       );
     }
 
-    const { getEntityUrl } = props;
+    const { getEntityUrl, sdk } = props;
     const size = props.viewType === 'big_card' ? 'default' : 'small';
     const commonProps = {
       asset: asset as Asset,
@@ -88,7 +88,7 @@ export function FetchingWrappedAssetCard(props: FetchingWrappedAssetCardProps) {
       if (asset === undefined) {
         return <EntryCard size="small" loading />;
       }
-      return <WrappedAssetLink {...commonProps} href={commonProps.entityUrl} />;
+      return <WrappedAssetLink {...commonProps} href={commonProps.entityUrl} getEntityScheduledActions={sdk.space.getEntityScheduledActions} />;
     }
 
     if (asset === undefined) {
@@ -100,6 +100,7 @@ export function FetchingWrappedAssetCard(props: FetchingWrappedAssetCardProps) {
       const builtinCardProps: Omit<WrappedAssetCardProps, 'isClickable'> = {
         ...commonProps,
         ...props,
+        getEntityScheduledActions: sdk.space.getEntityScheduledActions,
         asset: (props?.entity as Asset) || commonProps.asset,
         getAssetUrl: getEntityUrl,
       };

--- a/packages/reference/src/assets/WrappedAssetCard/WrappedAssetCard.tsx
+++ b/packages/reference/src/assets/WrappedAssetCard/WrappedAssetCard.tsx
@@ -1,9 +1,12 @@
 import React from 'react';
-import { AssetCard } from '@contentful/forma-36-react-components';
+import { css } from 'emotion';
+import tokens from '@contentful/forma-36-tokens';
+import { SpaceAPI } from 'contentful-ui-extensions-sdk';
+import { AssetCard, Icon } from '@contentful/forma-36-react-components';
 import { renderActions, renderAssetInfo } from './AssetCardActions';
 import { File, Asset } from '../../types';
 import { entityHelpers } from '@contentful/field-editor-shared';
-import { MissingEntityCard } from '../../components';
+import { MissingEntityCard, ScheduledIconWithTooltip } from '../../components';
 
 // @ts-expect-error
 import mimetype from '@contentful/mimetype';
@@ -22,7 +25,14 @@ const groupToIconMap = {
   markup: 'markup',
 };
 
+const styles = {
+  scheduleIcon: css({
+    marginRight: tokens.spacing2Xs,
+  }),
+};
+
 export interface WrappedAssetCardProps {
+  getEntityScheduledActions: SpaceAPI['getEntityScheduledActions'];
   asset: Asset;
   localeCode: string;
   defaultLocaleCode: string;
@@ -99,6 +109,20 @@ export const WrappedAssetCard = (props: WrappedAssetCardProps) => {
       selected={isSelected}
       href={getAssetUrl ? getAssetUrl(props.asset.sys.id) : undefined}
       status={status}
+      statusIcon={
+        <ScheduledIconWithTooltip
+          getEntityScheduledActions={props.getEntityScheduledActions}
+          entityType="Asset"
+          entityId={props.asset.sys.id}>
+          <Icon
+            className={styles.scheduleIcon}
+            icon="Clock"
+            size="small"
+            color="muted"
+            testId="schedule-icon"
+          />
+        </ScheduledIconWithTooltip>
+      }
       src={
         entityFile && entityFile.url
           ? size === 'small'

--- a/packages/reference/src/assets/WrappedAssetCard/WrappedAssetLink.tsx
+++ b/packages/reference/src/assets/WrappedAssetCard/WrappedAssetLink.tsx
@@ -1,11 +1,20 @@
 import React from 'react';
-import { EntryCard } from '@contentful/forma-36-react-components';
+import { css } from 'emotion';
+import tokens from '@contentful/forma-36-tokens';
+import { EntryCard, Icon } from '@contentful/forma-36-react-components';
 import { renderActions, renderAssetInfo } from './AssetCardActions';
 import { Asset } from '../../types';
-import { entityHelpers } from '@contentful/field-editor-shared';
-import { MissingEntityCard } from '../../components';
+import { entityHelpers, SpaceAPI } from '@contentful/field-editor-shared';
+import { MissingEntityCard, ScheduledIconWithTooltip } from '../../components';
+
+const styles = {
+  scheduleIcon: css({
+    marginRight: tokens.spacing2Xs,
+  }),
+};
 
 export interface WrappedAssetLinkProps {
+  getEntityScheduledActions: SpaceAPI['getEntityScheduledActions'];
   asset: Asset;
   localeCode: string;
   defaultLocaleCode: string;
@@ -51,6 +60,20 @@ export const WrappedAssetLink = (props: WrappedAssetLinkProps) => {
       href={href}
       size="small"
       status={status}
+      statusIcon={
+        <ScheduledIconWithTooltip
+          getEntityScheduledActions={props.getEntityScheduledActions}
+          entityType="Asset"
+          entityId={props.asset.sys.id}>
+          <Icon
+            className={styles.scheduleIcon}
+            icon="Clock"
+            size="small"
+            color="muted"
+            testId="schedule-icon"
+          />
+        </ScheduledIconWithTooltip>
+      }
       onClick={(e) => {
         e.preventDefault();
         onEdit();


### PR DESCRIPTION
Next steps:
- bump the dependency in the web app
- bump the dependency in entity selector


Here I did the same thing we do already for entry references