### PR TITLE
feat(reference): adjust permissions

### DIFF
--- a/packages/reference/src/common/useEditorPermissions.spec.ts
+++ b/packages/reference/src/common/useEditorPermissions.spec.ts
@@ -63,11 +63,10 @@ describe('useEditorPermissions', () => {
       expect(sdk.access.can).not.toHaveBeenCalledWith();
     });
 
-    it(`checks basic access`, async () => {
-      const { sdk } = await renderEditorPermissions({ entityType: 'Asset' });
+    it(`defaults link entity action visibility to true`, async () => {
+      const { result } = await renderEditorPermissions({ entityType: 'Asset' });
 
-      expect(sdk.access.can).toHaveBeenCalledWith('create', 'Asset');
-      expect(sdk.access.can).toHaveBeenCalledWith('read', 'Asset');
+      expect(result.current.canLinkEntity).toBeTruthy();
     });
 
     it(`returns empty contentTypes`, async () => {

--- a/packages/reference/src/common/useEditorPermissions.spec.ts
+++ b/packages/reference/src/common/useEditorPermissions.spec.ts
@@ -63,7 +63,13 @@ describe('useEditorPermissions', () => {
       expect(sdk.access.can).not.toHaveBeenCalledWith();
     });
 
-    it(`defaults link entity action visibility to true`, async () => {
+    it(`defaults link entry action visibility to true`, async () => {
+      const { result } = await renderEditorPermissions({ entityType: 'Entry' });
+
+      expect(result.current.canLinkEntity).toBeTruthy();
+    });
+
+    it(`defaults link asset action visibility to true`, async () => {
       const { result } = await renderEditorPermissions({ entityType: 'Asset' });
 
       expect(result.current.canLinkEntity).toBeTruthy();

--- a/packages/reference/src/common/useEditorPermissions.ts
+++ b/packages/reference/src/common/useEditorPermissions.ts
@@ -20,7 +20,7 @@ export function useEditorPermissions(props: EditorPermissionsProps) {
   const {
     creatableContentTypes,
     readableContentTypes,
-    availableContentTypes,
+    availableContentTypes
   } = useContentTypePermissions({ ...props, validations });
   const { canOnEntity } = useAccessApi(sdk.access);
 
@@ -50,17 +50,21 @@ export function useEditorPermissions(props: EditorPermissionsProps) {
     }
 
     async function checkLinkAccess() {
-      if (entityType === 'Asset') {
-        const canRead = await canOnEntity('read', 'Asset');
-        setCanLinkEntity(canRead);
-      }
-      if (entityType === 'Entry') {
-        setCanLinkEntity(readableContentTypes.length > 0);
+      if (props.allContentTypes?.length) {
+        if (entityType === 'Asset') {
+          const canRead = await canOnEntity('read', 'Asset');
+          setCanLinkEntity(canRead);
+        }
+        if (entityType === 'Entry') {
+          setCanLinkEntity(readableContentTypes.length > 0);
+        }
+      } else {
+        setCanCreateEntity(true)
       }
     }
 
     void checkLinkAccess();
-  }, [entityType, parameters.instance, readableContentTypes]);
+  }, [entityType, parameters.instance, readableContentTypes, props.allContentTypes]);
 
   return {
     canCreateEntity,
@@ -68,7 +72,7 @@ export function useEditorPermissions(props: EditorPermissionsProps) {
     creatableContentTypes,
     readableContentTypes,
     availableContentTypes,
-    validations,
+    validations
   };
 }
 

--- a/packages/reference/src/common/useEditorPermissions.ts
+++ b/packages/reference/src/common/useEditorPermissions.ts
@@ -59,7 +59,7 @@ export function useEditorPermissions(props: EditorPermissionsProps) {
           setCanLinkEntity(readableContentTypes.length > 0);
         }
       } else {
-        setCanCreateEntity(true)
+        setCanLinkEntity(true)
       }
     }
 


### PR DESCRIPTION
The check for permissions on read entity are too pessimistic.
There are situation where we can have enitites to reference, but we don't offer the "select content to link" button.