### PR TITLE
feat: 🎸 fallback to a default inferred widget id

### DIFF
--- a/packages/default-field-editors/src/Field.tsx
+++ b/packages/default-field-editors/src/Field.tsx
@@ -24,10 +24,11 @@ import { RichTextEditor } from '@contentful/field-editor-rich-text';
 import { MarkdownEditor } from '@contentful/field-editor-markdown';
 import type { FieldExtensionSDK } from '@contentful/field-editor-shared';
 import type { EditorOptions, WidgetType } from './types';
+import { getDefaultWidgetId } from './getDefaultWidgetId';
 
 type FieldProps = {
   sdk: FieldExtensionSDK;
-  widgetId: WidgetType;
+  widgetId?: WidgetType;
   isInitiallyDisabled?: boolean;
   renderFieldEditor?: (
     widgetId: WidgetType,
@@ -38,9 +39,17 @@ type FieldProps = {
 };
 
 export const Field: React.FC<FieldProps> = (props: FieldProps) => {
-  const { sdk, widgetId, isInitiallyDisabled = false, renderFieldEditor, getOptions } = props;
+  const {
+    sdk,
+    widgetId: possiblyUndefinedWidgetId,
+    isInitiallyDisabled = false,
+    renderFieldEditor,
+    getOptions,
+  } = props;
   const field = sdk.field;
   const locales = sdk.locales;
+
+  const widgetId = possiblyUndefinedWidgetId ?? getDefaultWidgetId(sdk);
 
   if (renderFieldEditor) {
     const customEditor = renderFieldEditor(widgetId, sdk, isInitiallyDisabled);

--- a/packages/default-field-editors/src/getDefaultWidgetId.ts
+++ b/packages/default-field-editors/src/getDefaultWidgetId.ts
@@ -1,0 +1,45 @@
+import type { FieldExtensionSDK } from '@contentful/field-editor-shared';
+import type { WidgetType } from './types';
+
+const DROPDOWN_TYPES = ['Text', 'Symbol', 'Integer', 'Number', 'Boolean'];
+
+export const DEFAULTS: { [key: string]: WidgetType } = {
+  Text: 'markdown',
+  Symbol: 'singleLine',
+  Integer: 'numberEditor',
+  Number: 'numberEditor',
+  Boolean: 'boolean',
+  Date: 'datePicker',
+  Location: 'locationEditor',
+  Object: 'objectEditor',
+  RichText: 'richTextEditor',
+  Entry: 'entryLinkEditor',
+  Asset: 'assetLinkEditor',
+  Symbols: 'tagEditor',
+  Entries: 'entryLinksEditor',
+  Assets: 'assetLinksEditor',
+  File: 'fileEditor',
+};
+
+export function getDefaultWidgetId(
+  sdk: Pick<FieldExtensionSDK, 'field' | 'contentType'>
+): WidgetType {
+  const field = sdk.field;
+  const fieldType = field.type;
+  const hasInValidation = (field.validations || []).find((v) => 'in' in v);
+
+  if (hasInValidation && DROPDOWN_TYPES.includes(fieldType)) {
+    return 'dropdown';
+  }
+
+  const displayFieldId = sdk.contentType.displayField;
+
+  const isTextField = fieldType === 'Text';
+  const isDisplayField = field.id === displayFieldId;
+
+  if (isTextField && isDisplayField) {
+    return 'singleLine';
+  }
+
+  return DEFAULTS[fieldType];
+}

--- a/packages/default-field-editors/src/index.tsx
+++ b/packages/default-field-editors/src/index.tsx
@@ -1,3 +1,4 @@
 export { Field } from './Field';
 export { FieldWrapper } from './FieldWrapper';
 export type { WidgetType, EditorOptions } from './types';
+export { getDefaultWidgetId } from './getDefaultWidgetId';


### PR DESCRIPTION
`widgetId` can be undefined, so we need to fallback to a default widgetId based on the information in content type