### PR TITLE
fix(tags): Editor permissions handles entities with metadata

### DIFF
--- a/packages/_shared/src/typesEntity.ts
+++ b/packages/_shared/src/typesEntity.ts
@@ -16,6 +16,9 @@ export interface Entry {
       [localeKey: string]: any;
     };
   };
+  metadata: {
+    tags: [];
+  };
 }
 
 export type Asset = {
@@ -27,6 +30,9 @@ export type Asset = {
     file: {
       [locale: string]: File;
     };
+  };
+  metadata: {
+    tags: [];
   };
 };
 

--- a/packages/_test/src/fakesFactory.ts
+++ b/packages/_test/src/fakesFactory.ts
@@ -24,6 +24,9 @@ export const createEntry = (contentTypeId: string, fields: Fields): Entry => ({
     createdBy: { sys: { id: 'u123', type: 'Link', linkType: 'User' } },
     updatedBy: { sys: { id: 'u123', type: 'Link', linkType: 'User' } },
     publishedBy: { sys: { id: 'u123', type: 'Link', linkType: 'User' } },
-    contentType: { sys: { id: contentTypeId, type: 'Link', linkType: 'ContentType' } }
-  }
+    contentType: { sys: { id: contentTypeId, type: 'Link', linkType: 'ContentType' } },
+  },
+  metadata: {
+    tags: [],
+  },
 });

--- a/packages/reference/src/common/useAccessApi.ts
+++ b/packages/reference/src/common/useAccessApi.ts
@@ -14,6 +14,9 @@ function makeEntryFromType(contentTypeId: string) {
         sys: { id: contentTypeId },
       },
     },
+    metadata: {
+      tags: [],
+    },
     fields: {},
   } as Entry;
 }

--- a/packages/reference/src/common/useEditorPermissions.spec.ts
+++ b/packages/reference/src/common/useEditorPermissions.spec.ts
@@ -63,10 +63,11 @@ describe('useEditorPermissions', () => {
       expect(sdk.access.can).not.toHaveBeenCalledWith();
     });
 
-    it(`defaults link entry action visibility to true`, async () => {
-      const { result } = await renderEditorPermissions({ entityType: 'Entry' });
+    it(`checks basic access`, async () => {
+      const { sdk } = await renderEditorPermissions({ entityType: 'Asset' });
 
-      expect(result.current.canLinkEntity).toBeTruthy();
+      expect(sdk.access.can).toHaveBeenCalledWith('create', 'Asset');
+      expect(sdk.access.can).toHaveBeenCalledWith('read', 'Asset');
     });
 
     it(`defaults link asset action visibility to true`, async () => {

--- a/packages/reference/src/common/useEditorPermissions.ts
+++ b/packages/reference/src/common/useEditorPermissions.ts
@@ -20,7 +20,7 @@ export function useEditorPermissions(props: EditorPermissionsProps) {
   const {
     creatableContentTypes,
     readableContentTypes,
-    availableContentTypes
+    availableContentTypes,
   } = useContentTypePermissions({ ...props, validations });
   const { canOnEntity } = useAccessApi(sdk.access);
 
@@ -50,21 +50,17 @@ export function useEditorPermissions(props: EditorPermissionsProps) {
     }
 
     async function checkLinkAccess() {
-      if (props.allContentTypes?.length) {
-        if (entityType === 'Asset') {
-          const canRead = await canOnEntity('read', 'Asset');
-          setCanLinkEntity(canRead);
-        }
-        if (entityType === 'Entry') {
-          setCanLinkEntity(readableContentTypes.length > 0);
-        }
-      } else {
-        setCanLinkEntity(true)
+      if (entityType === 'Asset') {
+        const canRead = await canOnEntity('read', 'Asset');
+        setCanLinkEntity(canRead);
+      }
+      if (entityType === 'Entry') {
+        setCanLinkEntity(readableContentTypes.length > 0);
       }
     }
 
     void checkLinkAccess();
-  }, [entityType, parameters.instance, readableContentTypes, props.allContentTypes]);
+  }, [entityType, parameters.instance, readableContentTypes]);
 
   return {
     canCreateEntity,
@@ -72,7 +68,7 @@ export function useEditorPermissions(props: EditorPermissionsProps) {
     creatableContentTypes,
     readableContentTypes,
     availableContentTypes,
-    validations
+    validations,
   };
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1529,6 +1529,17 @@
     read-pkg-up "^7.0.1"
     semver "^7.3.2"
 
+"@contentful/field-editor-shared@^0.14.0":
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/@contentful/field-editor-shared/-/field-editor-shared-0.14.0.tgz#13e942e36ee5350c27978ce625ac74152495c270"
+  integrity sha512-z8PT7hkuUWHcgJNnxIA2VbC2DWEVu/6yhpSKIv4iaFRHsAZjyFQ1s/0QIVK8E0nm+qHZaV5RJKDm6wEkp3G+3A==
+  dependencies:
+    "@contentful/forma-36-tokens" "^0.10.0"
+    contentful-ui-extensions-sdk "^3.29.2"
+    emotion "^10.0.17"
+    lodash "^4.17.15"
+    lodash-es "^4.17.15"
+
 "@contentful/forma-36-fcss@^0.3.0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@contentful/forma-36-fcss/-/forma-36-fcss-0.3.0.tgz#f4883c7f06bff6c0bc728265475d32c5ee76ee1d"
@@ -6591,6 +6602,11 @@ contentful-sdk-core@^6.4.0, contentful-sdk-core@^6.7.0:
   dependencies:
     fast-copy "^2.1.0"
     qs "^6.9.4"
+
+contentful-ui-extensions-sdk@^3.29.2:
+  version "3.32.0"
+  resolved "https://registry.yarnpkg.com/contentful-ui-extensions-sdk/-/contentful-ui-extensions-sdk-3.32.0.tgz#1aee2ee98ed5a32873a78108412197bf41d79b7e"
+  integrity sha512-S36eeOV4a5IE1ZWpN60Sfl3USi5srXJ7QxH7EplTFIk57/lCTqPpdZZPiJMO3HNq9tBCAOTC+b8neql/+jtBQQ==
 
 contentful@^7.14.0:
   version "7.14.3"


### PR DESCRIPTION

The access API is not working properly when we have permissions that have tags in them, the issue seems to be solved by  adding property `metadata.tags` to the dump entry generated in **makeEntryFromType**