### PR TITLE
fix rich text command palette and embed dropdown icons

### DIFF
--- a/packages/rich-text/src/plugins/CommandPalette/CommandPanel/index.js
+++ b/packages/rich-text/src/plugins/CommandPalette/CommandPanel/index.js
@@ -11,6 +11,7 @@ import { fetchEntries, fetchAssets, CommandPaletteActionBuilder } from '../Comma
 import { removeCommand } from '../Util';
 import CommandPanelMenu from './CommandPanelMenu';
 import { InViewport } from '@contentful/forma-36-react-components';
+import tokens from '@contentful/forma-36-tokens';
 
 const DEFAULT_POSITION = {
   top: 0,
@@ -287,6 +288,7 @@ class CommandPalette extends React.PureComponent {
           minWidth: 200,
           top: this.state.anchorPosition.top,
           left: this.state.anchorPosition.left,
+          zIndex: tokens.zIndexDropdown,
         }}>
         <InViewport
           onOverflowBottom={() => {

--- a/packages/rich-text/src/plugins/EmbeddedEntityBlock/EmbeddedEntityBlock.styles.ts
+++ b/packages/rich-text/src/plugins/EmbeddedEntityBlock/EmbeddedEntityBlock.styles.ts
@@ -1,0 +1,7 @@
+import { css } from 'emotion';
+
+export const styles = {
+  icon: css({
+    marginRight: '10px',
+  }),
+};

--- a/packages/rich-text/src/plugins/EmbeddedEntityBlock/ToolbarIcon.js
+++ b/packages/rich-text/src/plugins/EmbeddedEntityBlock/ToolbarIcon.js
@@ -1,10 +1,11 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { DropdownListItem, Button, Icon } from '@contentful/forma-36-react-components';
+import { DropdownListItem, Button, Flex, Icon } from '@contentful/forma-36-react-components';
 
 import { selectEntityAndInsert } from './Util';
 import { TOOLBAR_PLUGIN_PROP_TYPES } from '../shared/PluginApi';
 import { toolbarActionHandlerWithSafeAutoFocus } from '../shared/Util';
+import { styles } from './EmbeddedEntityBlock.styles';
 
 export default class EntityLinkToolbarIcon extends Component {
   static propTypes = {
@@ -53,14 +54,14 @@ export default class EntityLinkToolbarIcon extends Component {
         size="small"
         onClick={this.handleClick}
         testId={`toolbar-toggle-${nodeType}`}>
-        <div className="cf-flex-grid">
+        <Flex alignItems="center" flexDirection="row">
           <Icon
             icon={type === 'Asset' ? 'Asset' : 'EmbeddedEntryBlock'}
-            className="rich-text__embedded-entry-list-icon"
+            className={`rich-text__embedded-entry-list-icon ${styles.icon}`}
             color="secondary"
           />
-          {type}
-        </div>
+          <span>{type}</span>
+        </Flex>
       </DropdownListItem>
     );
   }

--- a/packages/rich-text/src/plugins/EmbeddedEntryInline/EmbeddedEntryInline.js
+++ b/packages/rich-text/src/plugins/EmbeddedEntryInline/EmbeddedEntryInline.js
@@ -1,20 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { css } from 'emotion';
-import { FetchingWrappedInlineEntryCard } from './FetchingWrappedInlineEntryCard';
 
-const styles = {
-  root: css({
-    margin: '0px 5px',
-    fontSize: 'inherit',
-    span: {
-      webkitUserSelect: 'none',
-      mozUserSelect: 'none',
-      msUserSelect: 'none',
-      userSelect: 'none'
-    }
-  })
-};
+import { FetchingWrappedInlineEntryCard } from './FetchingWrappedInlineEntryCard';
+import { styles } from './EmbeddedEntryInline.styles';
 
 class EmbeddedEntryInline extends React.Component {
   static propTypes = {
@@ -23,14 +11,14 @@ class EmbeddedEntryInline extends React.Component {
     attributes: PropTypes.object.isRequired,
     editor: PropTypes.object.isRequired,
     node: PropTypes.object.isRequired,
-    onEntityFetchComplete: PropTypes.func.isRequired
+    onEntityFetchComplete: PropTypes.func.isRequired,
   };
 
   getEntitySys() {
     const data = this.props.node.data;
     return {
       id: data.get('target').sys.id,
-      type: data.get('target').sys.linkType
+      type: data.get('target').sys.linkType,
     };
   }
 

--- a/packages/rich-text/src/plugins/EmbeddedEntryInline/EmbeddedEntryInline.styles.ts
+++ b/packages/rich-text/src/plugins/EmbeddedEntryInline/EmbeddedEntryInline.styles.ts
@@ -1,0 +1,18 @@
+import { css } from 'emotion';
+
+export const styles = {
+  icon: css({
+    marginRight: '10px',
+  }),
+
+  root: css({
+    margin: '0px 5px',
+    fontSize: 'inherit',
+    span: {
+      webkitUserSelect: 'none',
+      mozUserSelect: 'none',
+      msUserSelect: 'none',
+      userSelect: 'none',
+    },
+  }),
+};

--- a/packages/rich-text/src/plugins/EmbeddedEntryInline/ToolbarIcon.js
+++ b/packages/rich-text/src/plugins/EmbeddedEntryInline/ToolbarIcon.js
@@ -1,10 +1,11 @@
 import React, { Component } from 'react';
-import { DropdownListItem, Icon, Button } from '@contentful/forma-36-react-components';
+import { DropdownListItem, Flex, Icon, Button } from '@contentful/forma-36-react-components';
 import { INLINES } from '@contentful/rich-text-types';
 
 import { selectEntryAndInsert, canInsertInline } from './Utils';
 import { TOOLBAR_PLUGIN_PROP_TYPES } from '../shared/PluginApi';
 import { toolbarActionHandlerWithSafeAutoFocus } from '../shared/Util';
+import { styles } from './EmbeddedEntryInline.styles';
 
 export default class EntryLinkToolbarIcon extends Component {
   static propTypes = TOOLBAR_PLUGIN_PROP_TYPES;
@@ -47,14 +48,14 @@ export default class EntryLinkToolbarIcon extends Component {
         icon="Entry"
         testId={`toolbar-toggle-${INLINES.EMBEDDED_ENTRY}`}
         onClick={this.handleClick}>
-        <div className="cf-flex-grid">
+        <Flex alignItems="center" flexDirection="row">
           <Icon
             icon="EmbeddedEntryInline"
             color="secondary"
-            className="rich-text__embedded-entry-list-icon"
+            className={`rich-text__embedded-entry-list-icon ${styles.icon}`}
           />
-          Inline entry
-        </div>
+          <span>Inline entry</span>
+        </Flex>
       </DropdownListItem>
     );
   }


### PR DESCRIPTION
* fix(rich-text): add z-index token to rich text command palette
* fix(embedded-entry-inline): use Flex component to align icons
* fix(embedded-entity-block): use Flex component to align icons