### PR TITLE
fix: 🐛 handle lack of proper acccess checks in the webapp

### DIFF
--- a/packages/reference/src/common/useAccessApi.ts
+++ b/packages/reference/src/common/useAccessApi.ts
@@ -4,31 +4,20 @@ import type {
   CrudAction,
   PublishableAction,
 } from '@contentful/app-sdk';
-import type { Entry } from '@contentful/field-editor-shared';
-
-function makeEntryFromType(contentTypeId: string) {
-  return {
-    sys: {
-      type: 'Entry',
-      contentType: {
-        sys: { id: contentTypeId },
-      },
-    },
-    metadata: {
-      tags: [],
-    },
-    fields: {},
-  } as Entry;
-}
 
 type EntryAction = CrudAction | PublishableAction | ArchiveableAction;
 
-export function useAccessApi(accessApi: AccessAPI) {
-  const canOnEntity = accessApi.can;
-  const canOnEntryOfType = (action: EntryAction, contentTypeId: string) => {
-    // @ts-expect-error
-    return canOnEntity(action, makeEntryFromType(contentTypeId));
-  };
+type ExtendedAccessAPI = {
+  canPerformActionOnEntryOfType: (action: EntryAction, contentTypeId: string) => Promise<boolean>;
+};
 
-  return { canOnEntity, canOnEntryOfType };
+const AllowActionsOnContentType: ExtendedAccessAPI['canPerformActionOnEntryOfType'] = () =>
+  Promise.resolve(true);
+
+export function useAccessApi(accessApi: AccessAPI & Partial<ExtendedAccessAPI>) {
+  const canPerformAction = accessApi.can;
+  const canPerformActionOnEntryOfType =
+    accessApi.canPerformActionOnEntryOfType ?? AllowActionsOnContentType;
+
+  return { canPerformAction, canPerformActionOnEntryOfType };
 }

--- a/packages/reference/src/common/useContentTypePermissions.ts
+++ b/packages/reference/src/common/useContentTypePermissions.ts
@@ -46,11 +46,13 @@ export function useContentTypePermissions(
   }, [props.allContentTypes, props.validations.contentTypes, props.entityType]);
   const [creatableContentTypes, setCreatableContentTypes] = useState(availableContentTypes);
   const [readableContentTypes, setReadableContentTypes] = useState(availableContentTypes);
-  const { canOnEntryOfType } = useAccessApi(props.sdk.access);
+  const { canPerformActionOnEntryOfType } = useAccessApi(props.sdk.access);
 
   useEffect(() => {
     function getContentTypes(action: 'create' | 'read') {
-      return filter(availableContentTypes, (ct) => canOnEntryOfType(action, ct.sys.id));
+      return filter(availableContentTypes, (ct) =>
+        canPerformActionOnEntryOfType(action, ct.sys.id)
+      );
     }
 
     async function checkContentTypeAccess() {

--- a/packages/reference/src/common/useEditorPermissions.ts
+++ b/packages/reference/src/common/useEditorPermissions.ts
@@ -22,7 +22,7 @@ export function useEditorPermissions(props: EditorPermissionsProps) {
     readableContentTypes,
     availableContentTypes,
   } = useContentTypePermissions({ ...props, validations });
-  const { canOnEntity } = useAccessApi(sdk.access);
+  const { canPerformAction } = useAccessApi(sdk.access);
 
   useEffect(() => {
     if (parameters.instance.showCreateEntityAction === false) {
@@ -32,7 +32,7 @@ export function useEditorPermissions(props: EditorPermissionsProps) {
 
     async function checkCreateAccess() {
       if (entityType === 'Asset') {
-        const canCreate = await canOnEntity('create', 'Asset');
+        const canCreate = await canPerformAction('create', 'Asset');
         setCanCreateEntity(canCreate);
       }
       if (entityType === 'Entry') {
@@ -51,7 +51,7 @@ export function useEditorPermissions(props: EditorPermissionsProps) {
 
     async function checkLinkAccess() {
       if (entityType === 'Asset') {
-        const canRead = await canOnEntity('read', 'Asset');
+        const canRead = await canPerformAction('read', 'Asset');
         setCanLinkEntity(canRead);
       }
       if (entityType === 'Entry') {


### PR DESCRIPTION
The access check on content-types is slightly buggy in the web app and needs to be addressed separately.