### PR TITLE
feat: default-field-editors doc improvements

### DIFF
--- a/packages/default-field-editors/README.md
+++ b/packages/default-field-editors/README.md
@@ -6,6 +6,8 @@ npm install @contentful/default-field-editors
 
 This package provides React components for rendering all supported field editors with the same structure and style as in Contentful web app.
 
+## Example
+
 ```js
 import 'codemirror/lib/codemirror.css';
 import '@contentful/forma-36-react-components/dist/styles.css';
@@ -13,8 +15,14 @@ import '@contentful/field-editor-date/styles/styles.css';
 import { Field, FieldWrapper } from 'packages/default-field-editors';
 
 const fieldEditor = (
-  <FieldWrapper sdk={fieldExtensionSdk} name={fieldName} getEntryURL={(entry) => ''}>
-    <Field sdk={fieldExtensionSdk} widgetId={widgetId} />
+  <FieldWrapper sdk={fieldExtensionSdk} name={fieldName}>
+    <Field sdk={fieldExtensionSdk} widgetId="singleLine" />
   </FieldWrapper>
 );
 ```
+
+It is optional to specify `widgetId`, and when not specified we'll try to determine a default editor type to render based on the field configuration.
+
+Otherwise, you can set it to one of many available editor types: `singleLine` for a single line text editor, `checkbox` for a checkbox input, etc.
+
+You can see [the full list of supported widgets in the `WidgetType` type definition](https://github.com/contentful/field-editors/blob/master/packages/default-field-editors/src/types.ts#L24).

--- a/packages/default-field-editors/src/DefaultFieldEditors.mdx
+++ b/packages/default-field-editors/src/DefaultFieldEditors.mdx
@@ -5,44 +5,95 @@ menu: Shared
 ---
 
 import Readme from '../README.md';
-
-<Readme />
-
 import { Playground, Props } from 'docz';
-import { createFakeFieldAPI, createFakeSpaceAPI, createFakeLocalesAPI, ActionsPlayground } from '@contentful/field-editor-test-utils';
+import {
+  ActionsPlayground,
+  createFakeFieldAPI,
+  createFakeLocalesAPI,
+  createFakeSpaceAPI,
+} from '@contentful/field-editor-test-utils';
+import { BooleanEditor } from '@contentful/field-editor-boolean';
+import { HelpText, Icon } from '@contentful/forma-36-react-components';
 import { Field } from './Field.tsx';
 import { FieldWrapper } from './FieldWrapper.tsx';
 
+<Readme />
 
 ## In Action
 
 <Playground>
   {() => {
-    const [field, mitt] = createFakeFieldAPI();
+    const [field, mitt] = createFakeFieldAPI((mock) => ({
+      ...mock,
+      items: {
+        validations: [{ in: ["test1", "test2"] }],
+      },
+    }), []);
     const space = createFakeSpaceAPI();
     const locales = createFakeLocalesAPI();
     const sdk = {
       field,
       space,
       locales,
+      contentType: { displayField: "name" },
+      parameters: {
+        instance: {
+          helpText: "Field help text",
+        },
+      },
     };
 
     return (
       <div data-test-id="default-field-editors-test">
+        <FieldWrapper sdk={sdk} name="field">
+          <Field sdk={sdk} widgetId="singleLine" />
+        </FieldWrapper>
+
+        <FieldWrapper sdk={sdk} name="anotherField">
+          <Field sdk={sdk} widgetId="rating" />
+        </FieldWrapper>
+
         <FieldWrapper
           sdk={sdk}
-          name="field"
-          getEntryURL={(entry) => `/${entry.sys.id}`}
+          name="customField"
+          renderHeading={(name) => (
+            <div>
+              <Icon icon="Edit" size="tiny" /> Custom {name} heading
+            </div>
+          )}
+          renderHelpText={(helpText) => (
+            <HelpText>
+              <Icon icon="HelpCircle" size="tiny" /> Custom help text:{" "}
+              {helpText}
+            </HelpText>
+          )}
         >
-          <Field sdk={sdk} widgetId="singleLine" />
+          <Field sdk={sdk} widgetId="datePicker" />
+        </FieldWrapper>
+
+        <FieldWrapper sdk={sdk} name="customEditor">
+          <Field
+            sdk={sdk}
+            renderFieldEditor={(widgetId, sdk, isInitiallyDisabled) => {
+              return (
+                <div>
+                  Custom editor with custom options.
+                  <BooleanEditor
+                    isInitiallyDisabled={isInitiallyDisabled}
+                    field={sdk.field}
+                    parameters={{instance: {trueLabel: 'Yay', falseLabel: 'Nope'}}}
+                  />
+                </div>
+              );
+            }}
+          />
         </FieldWrapper>
 
         <ActionsPlayground mitt={mitt} />
       </div>
     );
-}}
+  }}
 </Playground>
-
 
 ## FieldWrapper props
 
@@ -51,4 +102,3 @@ import { FieldWrapper } from './FieldWrapper.tsx';
 ## Field props
 
 <Props of={Field} />
-

--- a/packages/default-field-editors/src/FieldWrapper.tsx
+++ b/packages/default-field-editors/src/FieldWrapper.tsx
@@ -8,6 +8,9 @@ import { styles } from './FieldWrapper.styles';
 type FieldWrapperProps = {
   name: string;
   sdk: FieldExtensionSDK;
+  /**
+   * Generates a link to another entry with the same value when a "non unique" validation error occurs
+   */
   getEntryURL?: (entry: Entry) => string;
   className?: string;
   showFocusBar?: boolean;
@@ -16,9 +19,12 @@ type FieldWrapperProps = {
   renderHelpText?: (helpText: string) => JSX.Element | null;
 };
 
-const defaultGetEntryUrl = (entry: Entry) => `/${entry.sys.id}`;
-
 export const FieldWrapper: React.FC<FieldWrapperProps> = function (props: FieldWrapperProps) {
+  const { ids } = props.sdk;
+  const defaultGetEntryUrl = (entry: Entry) =>
+    `/spaces/${ids.space}/environments/${ids.environmentAlias || ids.environment}/entries/${
+      entry.sys.id
+    }`;
   const {
     name,
     sdk,
@@ -61,7 +67,7 @@ export const FieldWrapper: React.FC<FieldWrapperProps> = function (props: FieldW
         field={field}
         space={sdk.space}
         locales={sdk.locales}
-        getEntryURL={getEntryURL}
+        getEntryURL={getEntryURL || defaultGetEntryUrl}
       />
 
       {renderHelpText ? (

--- a/packages/default-field-editors/src/FieldWrapper.tsx
+++ b/packages/default-field-editors/src/FieldWrapper.tsx
@@ -8,7 +8,7 @@ import { styles } from './FieldWrapper.styles';
 type FieldWrapperProps = {
   name: string;
   sdk: FieldExtensionSDK;
-  getEntryURL: (entry: Entry) => string;
+  getEntryURL?: (entry: Entry) => string;
   className?: string;
   showFocusBar?: boolean;
   children: React.ReactNode;
@@ -16,16 +16,18 @@ type FieldWrapperProps = {
   renderHelpText?: (helpText: string) => JSX.Element | null;
 };
 
+const defaultGetEntryUrl = (entry: Entry) => `/${entry.sys.id}`;
+
 export const FieldWrapper: React.FC<FieldWrapperProps> = function (props: FieldWrapperProps) {
   const {
     name,
     sdk,
-    getEntryURL,
     className,
     children,
     renderHeading,
     renderHelpText,
     showFocusBar = true,
+    getEntryURL = defaultGetEntryUrl,
   } = props;
   const { field } = sdk;
   const helpText = (sdk.parameters?.instance as any)?.helpText ?? '';

--- a/packages/reference/src/entries/MultipleEntryReferenceEditor.mdx
+++ b/packages/reference/src/entries/MultipleEntryReferenceEditor.mdx
@@ -139,7 +139,7 @@ Note the alternative link actions injected via the `renderCustomActions` prop.
       <div>
         <MultipleEntryReferenceEditor
           renderCustomActions={(props) => (
-            <CombinedLinkActions {...props} combinedActionsLabel="My custom label" />
+            <CombinedLinkActions {...props} combinedActionsLabel="My custom label" onCreate={(ct) => window.alert('clicked' + ct)} />
           )}
           viewType="link"
           sdk={sdk}


### PR DESCRIPTION
Added few more examples, explained the `widgetId` and made the `getEntryURL` prop optional.