### PR TITLE
feat: reference editor onCreated onLinkedExisting callbacks

### DIFF
--- a/packages/reference/src/__fixtures__/FakeSdk.ts
+++ b/packages/reference/src/__fixtures__/FakeSdk.ts
@@ -74,19 +74,19 @@ export function newReferenceEditorFakeSdk() {
       },
     },
     dialogs: {
-      selectSingleAsset: () => {
+      selectSingleAsset: async () => {
         selectorCounter++;
         return assetLinks[selectorCounter % assetLinks.length];
       },
-      selectMultipleAssets: () => {
+      selectMultipleAssets: async () => {
         selectorCounter++;
         return selectorCounter % 2 ? assetLinks.slice(0, 2) : [assetLinks[2]];
       },
-      selectSingleEntry: () => {
+      selectSingleEntry: async () => {
         selectorCounter++;
         return entryLinks[selectorCounter % entryLinks.length];
       },
-      selectMultipleEntries: () => {
+      selectMultipleEntries: async () => {
         selectorCounter++;
         return selectorCounter % 2 ? entryLinks.slice(0, 2) : [entryLinks[2]];
       },

--- a/packages/reference/src/components/LinkActions/LinkActions.tsx
+++ b/packages/reference/src/components/LinkActions/LinkActions.tsx
@@ -24,7 +24,7 @@ export interface LinkActionsProps {
   onCreate: (contentType?: string, index?: number) => Promise<unknown>;
   onCreated: (entity: Entry | Asset, index?: number, slide?: NavigatorSlideInfo) => void;
   onLinkExisting: (index?: number) => void;
-  onLinked: (entities: Array<Entry | Asset>, index?: number) => void;
+  onLinkedExisting: (entities: Array<Entry | Asset>, index?: number) => void;
   actionLabels?: Partial<ActionLabels>;
   combinedActionsLabel?: string | React.ReactElement;
 }

--- a/packages/reference/src/components/LinkActions/LinkActions.tsx
+++ b/packages/reference/src/components/LinkActions/LinkActions.tsx
@@ -1,7 +1,14 @@
 import * as React from 'react';
 import { Button } from '@contentful/forma-36-react-components';
 import * as styles from './styles';
-import { EntityType, ContentType, ActionLabels } from '../../types';
+import {
+  EntityType,
+  ContentType,
+  ActionLabels,
+  Entry,
+  Asset,
+  NavigatorSlideInfo,
+} from '../../types';
 import { CreateEntryLinkButton } from '../CreateEntryLinkButton/CreateEntryLinkButton';
 import { NoLinkPermissionsInfo } from './NoLinkPermissionsInfo';
 
@@ -15,7 +22,9 @@ export interface LinkActionsProps {
   isFull: boolean;
   isEmpty: boolean;
   onCreate: (contentType?: string, index?: number) => Promise<unknown>;
+  onCreated: (entity: Entry | Asset, index?: number, slide?: NavigatorSlideInfo) => void;
   onLinkExisting: (index?: number) => void;
+  onLinked: (entities: Array<Entry | Asset>, index?: number) => void;
   actionLabels?: Partial<ActionLabels>;
   combinedActionsLabel?: string | React.ReactElement;
 }

--- a/packages/reference/src/components/LinkActions/LinkEntityActions.tsx
+++ b/packages/reference/src/components/LinkActions/LinkEntityActions.tsx
@@ -48,7 +48,7 @@ export function useLinkActionsProps(props: LinkEntityActionsProps): LinkActionsP
     },
     [entityType, props.onCreate, props.onAction]
   );
-  const onLinked = React.useCallback(
+  const onLinkedExisting = React.useCallback(
     (entities: Array<Entry | Asset>, index?: number) => {
       props.onLink(
         entities.map((item) => item.sys.id),
@@ -90,9 +90,9 @@ export function useLinkActionsProps(props: LinkEntityActionsProps): LinkActionsP
         return;
       }
 
-      onLinked([entity], index);
+      onLinkedExisting([entity], index);
     },
-    [sdk, entityType, onLinked]
+    [sdk, entityType, onLinkedExisting]
   );
 
   const onLinkSeveralExisting = React.useCallback(
@@ -106,9 +106,9 @@ export function useLinkActionsProps(props: LinkEntityActionsProps): LinkActionsP
       if (!entities || entities.length === 0) {
         return;
       }
-      onLinked(entities, index);
+      onLinkedExisting(entities, index);
     },
-    [sdk, entityType, onLinked]
+    [sdk, entityType, onLinkedExisting]
   );
 
   return useMemo(
@@ -125,7 +125,7 @@ export function useLinkActionsProps(props: LinkEntityActionsProps): LinkActionsP
       onLinkExisting: canLinkMultiple ? onLinkSeveralExisting : onLinkExisting,
       actionLabels,
       onCreated,
-      onLinked,
+      onLinkedExisting,
     }),
     [
       entityType,
@@ -141,7 +141,7 @@ export function useLinkActionsProps(props: LinkEntityActionsProps): LinkActionsP
       onLinkExisting,
       onLinkSeveralExisting,
       onCreated,
-      onLinked,
+      onLinkedExisting,
     ]
   );
 }

--- a/packages/reference/src/components/LinkActions/LinkEntityActions.tsx
+++ b/packages/reference/src/components/LinkActions/LinkEntityActions.tsx
@@ -1,6 +1,14 @@
 import * as React from 'react';
 import { useMemo } from 'react';
-import { Action, ActionLabels, EntityType, FieldExtensionSDK } from '../../types';
+import {
+  Action,
+  ActionLabels,
+  EntityType,
+  FieldExtensionSDK,
+  Entry,
+  Asset,
+  NavigatorSlideInfo,
+} from '../../types';
 import { LinkActions, LinkActionsProps } from './LinkActions';
 import { createEntity, selectMultipleEntities, selectSingleEntity } from './helpers';
 import { EditorPermissions } from '../../common/useEditorPermissions';
@@ -26,12 +34,8 @@ export function useLinkActionsProps(props: LinkEntityActionsProps): LinkActionsP
   const isFull = !!maxLinksCount && maxLinksCount <= linkCount;
   const isEmpty = linkCount === 0;
 
-  const onCreate = React.useCallback(
-    async (contentTypeId?: string, index?: number) => {
-      const { entity, slide } = await createEntity({ sdk, entityType, contentTypeId });
-      if (!entity) {
-        return;
-      }
+  const onCreated = React.useCallback(
+    (entity: Entry | Asset, index?: number, slide?: NavigatorSlideInfo) => {
       props.onCreate(entity.sys.id, index);
       props.onAction &&
         props.onAction({
@@ -42,7 +46,37 @@ export function useLinkActionsProps(props: LinkEntityActionsProps): LinkActionsP
           index,
         });
     },
-    [sdk, entityType, props.onCreate, props.onAction]
+    [entityType, props.onCreate, props.onAction]
+  );
+  const onLinked = React.useCallback(
+    (entities: Array<Entry | Asset>, index?: number) => {
+      props.onLink(
+        entities.map((item) => item.sys.id),
+        index
+      );
+      entities.forEach((entity) => {
+        props.onAction &&
+          props.onAction({
+            type: 'select_and_link',
+            entity: entityType,
+            entityData: entity,
+            index,
+          });
+      });
+    },
+    [entityType, props.onLink, props.onAction]
+  );
+
+  const onCreate = React.useCallback(
+    async (contentTypeId?: string, index?: number) => {
+      const { entity, slide } = await createEntity({ sdk, entityType, contentTypeId });
+      if (!entity) {
+        return;
+      }
+
+      onCreated(entity, index, slide);
+    },
+    [sdk, entityType, onCreated]
   );
 
   const onLinkExisting = React.useCallback(
@@ -55,11 +89,10 @@ export function useLinkActionsProps(props: LinkEntityActionsProps): LinkActionsP
       if (!entity) {
         return;
       }
-      props.onLink([entity.sys.id], index);
-      props.onAction &&
-        props.onAction({ type: 'select_and_link', entity: entityType, entityData: entity, index });
+
+      onLinked([entity], index);
     },
-    [sdk, entityType, props.onLink, props.onAction]
+    [sdk, entityType, onLinked]
   );
 
   const onLinkSeveralExisting = React.useCallback(
@@ -73,22 +106,9 @@ export function useLinkActionsProps(props: LinkEntityActionsProps): LinkActionsP
       if (!entities || entities.length === 0) {
         return;
       }
-      props.onLink(
-        entities.map((item) => item.sys.id),
-        index
-      );
-
-      entities.forEach((entity) => {
-        props.onAction &&
-          props.onAction({
-            type: 'select_and_link',
-            entity: entityType,
-            entityData: entity,
-            index,
-          });
-      });
+      onLinked(entities, index);
     },
-    [sdk, entityType, props.onLink, props.onAction]
+    [sdk, entityType, onLinked]
   );
 
   return useMemo(
@@ -104,6 +124,8 @@ export function useLinkActionsProps(props: LinkEntityActionsProps): LinkActionsP
       onCreate,
       onLinkExisting: canLinkMultiple ? onLinkSeveralExisting : onLinkExisting,
       actionLabels,
+      onCreated,
+      onLinked,
     }),
     [
       entityType,
@@ -118,6 +140,8 @@ export function useLinkActionsProps(props: LinkEntityActionsProps): LinkActionsP
       onCreate,
       onLinkExisting,
       onLinkSeveralExisting,
+      onCreated,
+      onLinked,
     ]
   );
 }

--- a/packages/reference/src/entries/MultipleEntryReferenceEditor.mdx
+++ b/packages/reference/src/entries/MultipleEntryReferenceEditor.mdx
@@ -139,11 +139,72 @@ Note the alternative link actions injected via the `renderCustomActions` prop.
       <div>
         <MultipleEntryReferenceEditor
           renderCustomActions={(props) => (
-            <CombinedLinkActions {...props} combinedActionsLabel="My custom label" onCreate={(ct) => window.alert('clicked' + ct)} />
+            <CombinedLinkActions
+              {...props}
+              combinedActionsLabel="My custom label"
+              onCreate={(ct) => window.alert('clicked' + ct)}
+            />
           )}
           viewType="link"
           sdk={sdk}
           isInitiallyDisabled={isInitiallyDisabled}
+          parameters={{
+            instance: instanceParams || {
+              canCreateEntity: true,
+              canLinkEntity: true,
+            },
+          }}
+        />
+        <ActionsPlayground mitt={mitt} />
+      </div>
+    );
+  }}
+</Playground>
+
+## With custom onCreate, onLinkExisting actions
+
+In this case we override standard `onCreate` to create a custom entry, then tell the field editor about it using `onCreated` and then open it.
+
+Same applies to `onLinkExisting` property that can be overriden to customize the linking process, at the end the `onLinkedExisting` callback should be called.
+
+<Playground>
+  {() => {
+    const instanceParams = window.localStorage.getItem('instanceParams');
+    const [sdk, mitt] = newReferenceEditorFakeSdk();
+    return (
+      <div data-test-id="custom-card-using-default">
+        <MultipleEntryReferenceEditor
+          renderCustomActions={(props) => (
+            <CombinedLinkActions
+              {...props}
+              onCreate={(ct) => {
+                sdk.space
+                  .createEntry(ct, {
+                    fields: { exField: { en: 'Custom initial value' } },
+                  })
+                  .then((entry) => {
+                    props.onCreated(entry);
+                    sdk.navigator.openEntry(entry.sys.id);
+                  });
+              }}
+              onLinkExisting={(index) => {
+                sdk.dialogs
+                  .selectMultipleEntries({
+                    locale: sdk.field.locale,
+                    contentTypes: ['exampleCT'],
+                  })
+                  .then((entries) => {
+                    if (entries.length) {
+                      window.alert(`Custom linking of ${entries.length} entries`);
+                      props.onLinkedExisting(entries, index);
+                    }
+                  });
+              }}
+            />
+          )}
+          viewType="card"
+          sdk={sdk}
+          isInitiallyDisabled={false}
           parameters={{
             instance: instanceParams || {
               canCreateEntity: true,


### PR DESCRIPTION
This PR addresses https://github.com/contentful/field-editors/issues/586 by adding two callbacks to `LinkActionsProps`:
- `onCreated(entity: Entity, index?: number, slide?: NavigatorSlideInfo) => void`
- `onLinkedExisting(entities: Entity[], index?: number) => void`

These callbacks add a created/linked entry/entries to the reference field and can be used to implement custom creation/linking processes, for example duplicating an entry instead of creating a new empty one.

It can be achieved by rendering custom actions `renderCustomActions` and overriding `onCreate` and `onLinkExisting` properties of `CombinedLinkActions` (or creating completely new UI) and calling `onCreated` or `onLinkedExisting` to show the new items in the editor.

### Example

```js
<MultipleEntryReferenceEditor
  renderCustomActions={(props) => (
    <CombinedLinkActions
      {...props}
      onCreate={async (ct) => {
        const entry = await sdk.space
          .createEntry(ct, {
            fields: { exField: { en: "Custom initial value" } },
          });

          if (entry) {
            props.onCreated(entry);
            sdk.navigator.openEntry(entry.sys.id);
          }
      }}
      onLinkExisting={async (index) => {
        const entries = await sdk.dialogs
          .selectMultipleEntries({
            locale: sdk.field.locale,
            contentTypes: ["exampleCT"],
          })
      
          if (entries.length) {
            window.alert(`Custom linking of ${entries.length} entries`);
            props.onLinkedExisting(entries, index);
          }
      }}
    />
  )}
  viewType="card"
  sdk={sdk}
  isInitiallyDisabled={false}
  parameters={{
    instance: instanceParams || {
      canCreateEntity: true,
      canLinkEntity: true,
    },
  }}
/>;

```