### PR TITLE
chore(extensions): fix build errors [EXT-2496]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,7 @@ jobs:
       - run: yarn lint
       - run: yarn bootstrap 
       - run: yarn build
+      - run: yarn build:extensions
       - run: yarn tsc
   unit-tests:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,7 @@ jobs:
       - checkout
       - yarn_install
       - run: yarn lint
+      - run: yarn bootstrap 
       - run: yarn build
       - run: yarn tsc
   unit-tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,6 @@ jobs:
       - checkout
       - yarn_install
       - run: yarn lint
-      - run: yarn bootstrap 
       - run: yarn build
       - run: yarn build:extensions
       - run: yarn tsc

--- a/extensions/entry-extension-collapsible/.babelrc
+++ b/extensions/entry-extension-collapsible/.babelrc
@@ -15,12 +15,6 @@
   ],
   "plugins": [
     [
-      "@babel/plugin-proposal-class-properties",
-      {
-        "loose": true
-      }
-    ],
-    [
       "@babel/plugin-transform-runtime",
       {
         "corejs": false,

--- a/extensions/entry-extension-collapsible/package.json
+++ b/extensions/entry-extension-collapsible/package.json
@@ -4,10 +4,6 @@
   "private": true,
   "devDependencies": {
     "@babel/core": "7.3.4",
-    "@babel/plugin-proposal-class-properties": "7.13.0",
-    "@babel/plugin-transform-runtime": "7.12.15",
-    "@babel/preset-env": "7.12.11",
-    "@babel/preset-react": "7.12.10",
     "@contentful/contentful-extension-scripts": "0.15.1",
     "@contentful/eslint-config-extension": "0.4.2",
     "@testing-library/react": "11.2.5",
@@ -22,6 +18,7 @@
   },
   "scripts": {
     "start": "contentful-extension-scripts start",
+    "build": "contentful-extension-scripts build",
     "deploy": "contentful-extension-scripts build && contentful extension update --force",
     "configure": "contentful space use && contentful space environment use",
     "login": "contentful login",
@@ -29,11 +26,11 @@
     "help": "contentful-extension-scripts help"
   },
   "dependencies": {
+    "@contentful/app-sdk": "^3.29.2",
     "@contentful/field-editor-shared": "^0.14.0",
     "@contentful/forma-36-fcss": "^0.3.1",
     "@contentful/forma-36-react-components": "^3.79.5",
     "@contentful/forma-36-tokens": "^0.10.1",
-    "@contentful/app-sdk": "^3.29.2",
     "emotion": "^10.0.17",
     "prop-types": "^15.7.2",
     "react": "^16.8.6",

--- a/extensions/markdown-extension/.babelrc
+++ b/extensions/markdown-extension/.babelrc
@@ -15,12 +15,6 @@
   ],
   "plugins": [
     [
-      "@babel/plugin-proposal-class-properties",
-      {
-        "loose": true
-      }
-    ],
-    [
       "@babel/plugin-transform-runtime",
       {
         "corejs": false,

--- a/extensions/markdown-extension/package.json
+++ b/extensions/markdown-extension/package.json
@@ -4,10 +4,6 @@
   "private": true,
   "devDependencies": {
     "@babel/core": "7.3.4",
-    "@babel/plugin-proposal-class-properties": "7.13.0",
-    "@babel/plugin-transform-runtime": "7.12.15",
-    "@babel/preset-env": "7.12.11",
-    "@babel/preset-react": "7.12.10",
     "@contentful/contentful-extension-scripts": "0.15.1",
     "@contentful/eslint-config-extension": "0.4.2",
     "@testing-library/react": "11.2.5",
@@ -22,6 +18,7 @@
   },
   "scripts": {
     "start": "contentful-extension-scripts start",
+    "build": "contentful-extension-scripts build",
     "deploy": "npm run build && contentful extension update --force",
     "configure": "contentful space use && contentful space environment use",
     "login": "contentful login",
@@ -29,10 +26,10 @@
     "help": "contentful-extension-scripts help"
   },
   "dependencies": {
+    "@contentful/app-sdk": "^3.29.2",
     "@contentful/forma-36-fcss": "^0.3.1",
     "@contentful/forma-36-react-components": "^3.79.5",
     "@contentful/forma-36-tokens": "^0.10.1",
-    "@contentful/app-sdk": "^3.29.2",
     "prop-types": "^15.7.2",
     "react": "^16.8.6",
     "react-dom": "^16.8.6"

--- a/extensions/multiple-references-extension/.babelrc
+++ b/extensions/multiple-references-extension/.babelrc
@@ -15,12 +15,6 @@
   ],
   "plugins": [
     [
-      "@babel/plugin-proposal-class-properties",
-      {
-        "loose": true
-      }
-    ],
-    [
       "@babel/plugin-transform-runtime",
       {
         "corejs": false,

--- a/extensions/multiple-references-extension/package.json
+++ b/extensions/multiple-references-extension/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "scripts": {
     "start": "contentful-extension-scripts start",
+    "build": "contentful-extension-scripts build",
     "deploy": "contentful-extension-scripts build && contentful extension update --force",
     "configure": "contentful space use && contentful space environment use",
     "login": "contentful login",

--- a/extensions/rich-text-extension/.babelrc
+++ b/extensions/rich-text-extension/.babelrc
@@ -15,12 +15,6 @@
   ],
   "plugins": [
     [
-      "@babel/plugin-proposal-class-properties",
-      {
-        "loose": true
-      }
-    ],
-    [
       "@babel/plugin-transform-runtime",
       {
         "corejs": false,

--- a/extensions/rich-text-extension/package.json
+++ b/extensions/rich-text-extension/package.json
@@ -4,10 +4,6 @@
   "private": true,
   "devDependencies": {
     "@babel/core": "7.3.4",
-    "@babel/plugin-proposal-class-properties": "7.13.0",
-    "@babel/plugin-transform-runtime": "7.12.15",
-    "@babel/preset-env": "7.12.11",
-    "@babel/preset-react": "7.12.10",
     "@contentful/contentful-extension-scripts": "0.15.1",
     "@contentful/eslint-config-extension": "0.4.2",
     "@testing-library/react": "11.2.5",
@@ -22,6 +18,7 @@
   },
   "scripts": {
     "start": "contentful-extension-scripts start",
+    "build": "contentful-extension-scripts build",
     "deploy": "npm run build && contentful extension update --force",
     "configure": "contentful space use && contentful space environment use",
     "login": "contentful login",
@@ -29,10 +26,10 @@
     "help": "contentful-extension-scripts help"
   },
   "dependencies": {
+    "@contentful/app-sdk": "^3.29.2",
     "@contentful/forma-36-fcss": "^0.3.1",
     "@contentful/forma-36-react-components": "^3.79.5",
     "@contentful/forma-36-tokens": "^0.10.1",
-    "@contentful/app-sdk": "^3.29.2",
     "prop-types": "^15.7.2",
     "react": "^16.8.6",
     "react-dom": "^16.8.6"

--- a/extensions/singleline-extension/.babelrc
+++ b/extensions/singleline-extension/.babelrc
@@ -15,12 +15,6 @@
   ],
   "plugins": [
     [
-      "@babel/plugin-proposal-class-properties",
-      {
-        "loose": true
-      }
-    ],
-    [
       "@babel/plugin-transform-runtime",
       {
         "corejs": false,

--- a/extensions/singleline-extension/package.json
+++ b/extensions/singleline-extension/package.json
@@ -4,10 +4,6 @@
   "private": true,
   "devDependencies": {
     "@babel/core": "7.3.4",
-    "@babel/plugin-proposal-class-properties": "7.13.0",
-    "@babel/plugin-transform-runtime": "7.12.15",
-    "@babel/preset-env": "7.12.11",
-    "@babel/preset-react": "7.12.10",
     "@contentful/contentful-extension-scripts": "0.15.1",
     "@contentful/eslint-config-extension": "0.4.2",
     "@testing-library/react": "11.2.5",
@@ -22,6 +18,7 @@
   },
   "scripts": {
     "start": "contentful-extension-scripts start",
+    "build": "contentful-extension-scripts build",
     "deploy": "npm run build && contentful extension update --force",
     "configure": "contentful space use && contentful space environment use",
     "login": "contentful login",
@@ -29,10 +26,10 @@
     "help": "contentful-extension-scripts help"
   },
   "dependencies": {
+    "@contentful/app-sdk": "^3.29.2",
     "@contentful/forma-36-fcss": "^0.3.1",
     "@contentful/forma-36-react-components": "^3.79.5",
     "@contentful/forma-36-tokens": "^0.10.1",
-    "@contentful/app-sdk": "^3.29.2",
     "prop-types": "^15.7.2",
     "react": "^16.8.6",
     "react-dom": "^16.8.6"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "scripts": {
     "bootstrap": "lerna bootstrap",
     "clean": "lerna clean",
-    "build": "lerna run --concurrency 1 --stream build",
+    "build": "lerna run --concurrency 1 --stream --scope=@contentful/** build",
+    "build:extensions": "lerna run --concurrency 1 --stream --scope={'markdown-extension,entry-extension-collapsible,field-editor-example,rich-text-extension,singleline-extension'} build",
     "lint": "eslint ./ --ext .js,.jsx,.ts,.tsx",
     "lint:md": "remark --no-stdout --frail *.md */*.md",
     "watch": "lerna run --stream watch",

--- a/packages/rich-text/.babelrc
+++ b/packages/rich-text/.babelrc
@@ -1,4 +1,3 @@
 {
   "presets": ["@babel/preset-env", "@babel/preset-react"],
-  "plugins": ["@babel/plugin-proposal-class-properties"]
 }

--- a/packages/rich-text/.babelrc
+++ b/packages/rich-text/.babelrc
@@ -1,3 +1,21 @@
 {
-  "presets": ["@babel/preset-env", "@babel/preset-react"],
+  "env": {
+    "test": {
+      "plugins": ["@babel/plugin-proposal-class-properties"]
+    }
+  },
+  "presets": [
+    [
+      "@babel/preset-env",
+      {
+        "useBuiltIns": false
+      }
+    ],
+    [
+      "@babel/preset-react",
+      {
+        "useBuiltIns": true
+      }
+    ]
+  ]
 }

--- a/packages/rich-text/jest.config.js
+++ b/packages/rich-text/jest.config.js
@@ -1,4 +1,4 @@
 module.exports = {
   transformIgnorePatterns: ['/node_modules/(?!lodash-es).+\\.js$'],
-  setupFilesAfterEnv: ['<rootDir>src/setupTests.js']
+  setupFilesAfterEnv: ['<rootDir>src/setupTests.js'],
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -208,7 +208,7 @@
     browserslist "^4.14.5"
     semver "^5.5.0"
 
-"@babel/helper-create-class-features-plugin@^7.12.1", "@babel/helper-create-class-features-plugin@^7.13.0", "@babel/helper-create-class-features-plugin@^7.8.3":
+"@babel/helper-create-class-features-plugin@^7.12.1", "@babel/helper-create-class-features-plugin@^7.8.3":
   version "7.13.8"
   resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.13.8.tgz#0367bd0a7505156ce018ca464f7ac91ba58c1a04"
   integrity sha512-qioaRrKHQbn4hkRKDHbnuQ6kAxmmOF+kzKGnIfxPK4j2rckSJCpKzr/SSTlohSCiE3uAQpNDJ9FIh4baeE8W+w==
@@ -487,14 +487,6 @@
     "@babel/helper-remap-async-to-generator" "^7.12.1"
     "@babel/plugin-syntax-async-generators" "^7.8.0"
 
-"@babel/plugin-proposal-class-properties@7.13.0", "@babel/plugin-proposal-class-properties@^7.12.1", "@babel/plugin-proposal-class-properties@^7.4.4", "@babel/plugin-proposal-class-properties@^7.8.3":
-  version "7.13.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.13.0.tgz#146376000b94efd001e57a40a88a525afaab9f37"
-  integrity sha512-KnTDjFNC1g+45ka0myZNvSBFLhNCLN+GeGYLDEA8Oq7MZ6yMgfLoIRh86GRT0FjtJhZw8JyUskP9uvj5pHM9Zg==
-  dependencies:
-    "@babel/helper-create-class-features-plugin" "^7.13.0"
-    "@babel/helper-plugin-utils" "^7.13.0"
-
 "@babel/plugin-proposal-class-properties@7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.8.3.tgz#5e06654af5cd04b608915aada9b2a6788004464e"
@@ -502,6 +494,14 @@
   dependencies:
     "@babel/helper-create-class-features-plugin" "^7.8.3"
     "@babel/helper-plugin-utils" "^7.8.3"
+
+"@babel/plugin-proposal-class-properties@^7.12.1", "@babel/plugin-proposal-class-properties@^7.4.4", "@babel/plugin-proposal-class-properties@^7.8.3":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.12.1.tgz#a082ff541f2a29a4821065b8add9346c0c16e5de"
+  integrity sha512-cKp3dlQsFsEs5CWKnN7BnSHOd0EOW8EKpEjkoz1pO2E5KzIDNV9Ros1b0CnmbVgAGXJubOYVBOGCT1OmJwOI7w==
+  dependencies:
+    "@babel/helper-create-class-features-plugin" "^7.12.1"
+    "@babel/helper-plugin-utils" "^7.10.4"
 
 "@babel/plugin-proposal-decorators@7.8.3":
   version "7.8.3"
@@ -1036,15 +1036,6 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
 
-"@babel/plugin-transform-runtime@7.12.15", "@babel/plugin-transform-runtime@^7.9.6":
-  version "7.12.15"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.12.15.tgz#4337b2507288007c2b197059301aa0af8d90c085"
-  integrity sha512-OwptMSRnRWJo+tJ9v9wgAf72ydXWfYSXWhnQjZing8nGZSDFqU1MBleKM3+DriKkcbv7RagA8gVeB0A1PNlNow==
-  dependencies:
-    "@babel/helper-module-imports" "^7.12.13"
-    "@babel/helper-plugin-utils" "^7.12.13"
-    semver "^5.5.1"
-
 "@babel/plugin-transform-runtime@7.9.0":
   version "7.9.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.9.0.tgz#45468c0ae74cc13204e1d3b1f4ce6ee83258af0b"
@@ -1053,6 +1044,15 @@
     "@babel/helper-module-imports" "^7.8.3"
     "@babel/helper-plugin-utils" "^7.8.3"
     resolve "^1.8.1"
+    semver "^5.5.1"
+
+"@babel/plugin-transform-runtime@^7.9.6":
+  version "7.12.15"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.12.15.tgz#4337b2507288007c2b197059301aa0af8d90c085"
+  integrity sha512-OwptMSRnRWJo+tJ9v9wgAf72ydXWfYSXWhnQjZing8nGZSDFqU1MBleKM3+DriKkcbv7RagA8gVeB0A1PNlNow==
+  dependencies:
+    "@babel/helper-module-imports" "^7.12.13"
+    "@babel/helper-plugin-utils" "^7.12.13"
     semver "^5.5.1"
 
 "@babel/plugin-transform-shorthand-properties@^7.12.1", "@babel/plugin-transform-shorthand-properties@^7.8.3":


### PR DESCRIPTION
The build process for the extensions / examples was broken since November due to a dependency update that included a forma version bump (https://github.com/contentful/field-editors/pull/467).  

The error resulted in a `Error: Duplicate plugin/preset detected.`

My approach was to remove duplicated `babel` dependencies that we already have declared in the root `package.json` file. I also added a build step that checks if the extensions are able to build.