### PR TITLE
feat: allow rendering of custom missing entity card

### DIFF
--- a/packages/reference/src/assets/WrappedAssetCard/FetchingWrappedAssetCard.tsx
+++ b/packages/reference/src/assets/WrappedAssetCard/FetchingWrappedAssetCard.tsx
@@ -107,7 +107,6 @@ export function FetchingWrappedAssetCard(props: FetchingWrappedAssetCardProps) {
         <WrappedAssetLink
           {...commonProps}
           href={commonProps.entityUrl}
-          // @ts-expect-error
           getEntityScheduledActions={sdk.space.getEntityScheduledActions}
         />
       );

--- a/packages/reference/src/assets/WrappedAssetCard/FetchingWrappedAssetCard.tsx
+++ b/packages/reference/src/assets/WrappedAssetCard/FetchingWrappedAssetCard.tsx
@@ -5,7 +5,11 @@ import { LinkActionsProps, MissingEntityCard } from '../../components';
 import { WrappedAssetCard, WrappedAssetCardProps } from './WrappedAssetCard';
 import { WrappedAssetLink } from './WrappedAssetLink';
 import { useEntities } from '../../common/EntityStore';
-import { CustomEntityCardProps, CustomCardRenderer } from '../../common/customCardTypes';
+import {
+  CustomEntityCardProps,
+  CustomCardRenderer,
+  RenderCustomMissingEntityCard,
+} from '../../common/customCardTypes';
 
 type FetchingWrappedAssetCardProps = {
   assetId: string;
@@ -17,6 +21,7 @@ type FetchingWrappedAssetCardProps = {
   onAction?: (action: Action) => void;
   cardDragHandle?: React.ReactElement;
   renderCustomCard?: CustomCardRenderer;
+  renderCustomMissingEntityCard?: RenderCustomMissingEntityCard;
 };
 
 export function FetchingWrappedAssetCard(props: FetchingWrappedAssetCardProps) {
@@ -60,7 +65,7 @@ export function FetchingWrappedAssetCard(props: FetchingWrappedAssetCardProps) {
 
   return React.useMemo(() => {
     if (asset === 'failed') {
-      return (
+      const card = (
         <MissingEntityCard
           entityType="Asset"
           asSquare={props.viewType !== 'link'}
@@ -68,6 +73,16 @@ export function FetchingWrappedAssetCard(props: FetchingWrappedAssetCardProps) {
           onRemove={onRemove}
         />
       );
+      if (props.renderCustomMissingEntityCard) {
+        return props.renderCustomMissingEntityCard({
+          defaultCard: card,
+          entity: {
+            id: props.assetId,
+            type: 'Asset',
+          },
+        });
+      }
+      return card;
     }
 
     const { getEntityUrl, sdk } = props;
@@ -88,7 +103,14 @@ export function FetchingWrappedAssetCard(props: FetchingWrappedAssetCardProps) {
       if (asset === undefined) {
         return <EntryCard size="small" loading />;
       }
-      return <WrappedAssetLink {...commonProps} href={commonProps.entityUrl} getEntityScheduledActions={sdk.space.getEntityScheduledActions} />;
+      return (
+        <WrappedAssetLink
+          {...commonProps}
+          href={commonProps.entityUrl}
+          // @ts-expect-error
+          getEntityScheduledActions={sdk.space.getEntityScheduledActions}
+        />
+      );
     }
 
     if (asset === undefined) {

--- a/packages/reference/src/assets/WrappedAssetCard/WrappedAssetLink.tsx
+++ b/packages/reference/src/assets/WrappedAssetCard/WrappedAssetLink.tsx
@@ -62,6 +62,7 @@ export const WrappedAssetLink = (props: WrappedAssetLinkProps) => {
       status={status}
       statusIcon={
         <ScheduledIconWithTooltip
+          // @ts-expect-error
           getEntityScheduledActions={props.getEntityScheduledActions}
           entityType="Asset"
           entityId={props.asset.sys.id}>

--- a/packages/reference/src/assets/WrappedAssetCard/WrappedAssetLink.tsx
+++ b/packages/reference/src/assets/WrappedAssetCard/WrappedAssetLink.tsx
@@ -62,7 +62,6 @@ export const WrappedAssetLink = (props: WrappedAssetLinkProps) => {
       status={status}
       statusIcon={
         <ScheduledIconWithTooltip
-          // @ts-expect-error
           getEntityScheduledActions={props.getEntityScheduledActions}
           entityType="Asset"
           entityId={props.asset.sys.id}>

--- a/packages/reference/src/common/ReferenceEditor.tsx
+++ b/packages/reference/src/common/ReferenceEditor.tsx
@@ -4,7 +4,7 @@ import { FieldConnector } from '@contentful/field-editor-shared';
 import { EntityProvider } from './EntityStore';
 import { Action, ActionLabels, FieldExtensionSDK, ViewType } from '../types';
 import type { LinkActionsProps } from '../components';
-import { CustomCardRenderer } from './customCardTypes';
+import { CustomCardRenderer, RenderCustomMissingEntityCard } from './customCardTypes';
 
 // TODO: Rename common base for reference/media editors to something neutral,
 //  e.g. `LinkEditor<T>`.
@@ -19,6 +19,7 @@ export interface ReferenceEditorProps {
   viewType: ViewType;
   renderCustomCard?: CustomCardRenderer;
   renderCustomActions?: (props: CustomActionProps) => React.ReactElement;
+  renderCustomMissingEntityCard?: RenderCustomMissingEntityCard;
   getEntityUrl?: (entryId: string) => string;
   onAction?: (action: Action) => void;
   actionLabels?: Partial<ActionLabels>;

--- a/packages/reference/src/common/customCardTypes.ts
+++ b/packages/reference/src/common/customCardTypes.ts
@@ -2,6 +2,18 @@ import { Asset, ContentType, Entry } from '../types';
 import * as React from 'react';
 import { CustomActionProps } from './ReferenceEditor';
 
+export type MissingEntityCardProps = {
+  defaultCard: React.ReactElement;
+  entity: {
+    id: string;
+    type: 'Asset' | 'Entry';
+  };
+};
+
+export type RenderCustomMissingEntityCard = ({
+  defaultCard,
+}: MissingEntityCardProps) => React.ReactElement;
+
 export type DefaultCardRenderer = (props?: CustomEntityCardProps) => React.ReactElement;
 
 export type CustomCardRenderer = (

--- a/packages/reference/src/entries/WrappedEntryCard/FetchingWrappedEntryCard.tsx
+++ b/packages/reference/src/entries/WrappedEntryCard/FetchingWrappedEntryCard.tsx
@@ -7,7 +7,7 @@ import type { LinkActionsProps } from '../../components';
 import { useEntities } from '../../common/EntityStore';
 import { ReferenceEditorProps } from '../../common/ReferenceEditor';
 import get from 'lodash/get';
-import { CustomEntityCardProps } from '../../common/customCardTypes';
+import { CustomEntityCardProps, RenderCustomMissingEntityCard } from '../../common/customCardTypes';
 
 export type EntryCardReferenceEditorProps = ReferenceEditorProps & {
   entryId: string;
@@ -19,6 +19,7 @@ export type EntryCardReferenceEditorProps = ReferenceEditorProps & {
   hasCardEditActions: boolean;
   onMoveTop?: () => void;
   onMoveBottom?: () => void;
+  renderCustomMissingEntityCard?: RenderCustomMissingEntityCard;
 };
 
 async function openEntry(
@@ -101,13 +102,23 @@ export function FetchingWrappedEntryCard(props: EntryCardReferenceEditorProps) {
 
   return React.useMemo(() => {
     if (entry === 'failed') {
-      return (
+      const card = (
         <MissingEntityCard
           entityType="Entry"
           isDisabled={props.isDisabled}
           onRemove={onRemoveEntry}
         />
       );
+      if (props.renderCustomMissingEntityCard) {
+        return props.renderCustomMissingEntityCard({
+          defaultCard: card,
+          entity: {
+            id: props.entryId,
+            type: 'Entry',
+          },
+        });
+      }
+      return card;
     }
     if (entry === undefined) {
       return <EntryCard size={size} loading />;

--- a/packages/reference/src/index.tsx
+++ b/packages/reference/src/index.tsx
@@ -15,4 +15,9 @@ export {
 export { SingleMediaEditor, MultipleMediaEditor, WrappedAssetCard } from './assets';
 export { EntityProvider, useEntities } from './common/EntityStore';
 export type { CustomActionProps } from './common/ReferenceEditor';
-export type { CustomEntityCardProps, DefaultCardRenderer } from './common/customCardTypes';
+export type {
+  CustomEntityCardProps,
+  DefaultCardRenderer,
+  MissingEntityCardProps,
+  RenderCustomMissingEntityCard,
+} from './common/customCardTypes';


### PR DESCRIPTION
Allows the user to optionally render a custom missing entity reference card.