### PR TITLE
feat(reference): performance optimizations

### DIFF
--- a/packages/reference/src/assets/WrappedAssetCard/FetchingWrappedAssetCard.tsx
+++ b/packages/reference/src/assets/WrappedAssetCard/FetchingWrappedAssetCard.tsx
@@ -25,10 +25,10 @@ type FetchingWrappedAssetCardProps = {
 };
 
 export function FetchingWrappedAssetCard(props: FetchingWrappedAssetCardProps) {
-  const { loadAsset, assets } = useEntities();
+  const { getOrLoadAsset, assets } = useEntities();
 
   React.useEffect(() => {
-    loadAsset(props.assetId);
+    getOrLoadAsset(props.assetId);
   }, [props.assetId]);
 
   const asset = assets[props.assetId];

--- a/packages/reference/src/common/EntityStore.ts
+++ b/packages/reference/src/common/EntityStore.ts
@@ -108,6 +108,16 @@ function useEntitiesStore(props: { sdk: BaseExtensionSDK }) {
     [state.assets, loadAsset]
   );
 
+  const getOrLoadEntry = React.useCallback(
+    (id: string) => {
+      if (state.entries[id]) {
+        return Promise.resolve(state.entries[id]);
+      }
+      return loadEntry(id);
+    },
+    [state.entries, loadEntry]
+  );
+
   React.useEffect(() => {
     // @ts-expect-error
     if (typeof props.sdk.space.onEntityChanged !== 'undefined') {
@@ -152,7 +162,7 @@ function useEntitiesStore(props: { sdk: BaseExtensionSDK }) {
     }) as { (): void };
   }, [props.sdk, state.assets, state.entries]);
 
-  return { loadEntry, loadAsset, getOrLoadAsset, ...state };
+  return { getOrLoadEntry, getOrLoadAsset, ...state };
 }
 
 const [EntityProvider, useEntities] = constate(useEntitiesStore);

--- a/packages/reference/src/common/EntityStore.ts
+++ b/packages/reference/src/common/EntityStore.ts
@@ -68,27 +68,45 @@ const initialState: State = {
 function useEntitiesStore(props: { sdk: BaseExtensionSDK }) {
   const [state, dispatch] = React.useReducer(reducer, initialState);
 
-  const loadEntry = (id: string) => {
-    props.sdk.space
-      .getEntry<Entry>(id)
-      .then((entry) => {
-        dispatch({ type: 'set_entry', id, entry });
-      })
-      .catch(() => {
-        dispatch({ type: 'set_entry_failed', id });
-      });
-  };
+  const loadEntry = React.useCallback(
+    (id: string) => {
+      return props.sdk.space
+        .getEntry<Entry>(id)
+        .then((entry) => {
+          dispatch({ type: 'set_entry', id, entry });
+          return entry;
+        })
+        .catch(() => {
+          dispatch({ type: 'set_entry_failed', id });
+        });
+    },
+    [props.sdk.space]
+  );
 
-  const loadAsset = (id: string) => {
-    props.sdk.space
-      .getAsset<Asset>(id)
-      .then((asset) => {
-        dispatch({ type: 'set_asset', id, asset });
-      })
-      .catch(() => {
-        dispatch({ type: 'set_asset_failed', id });
-      });
-  };
+  const loadAsset = React.useCallback(
+    (id: string) => {
+      return props.sdk.space
+        .getAsset<Asset>(id)
+        .then((asset) => {
+          dispatch({ type: 'set_asset', id, asset });
+          return asset;
+        })
+        .catch(() => {
+          dispatch({ type: 'set_asset_failed', id });
+        });
+    },
+    [props.sdk.space]
+  );
+
+  const getOrLoadAsset = React.useCallback(
+    (id: string) => {
+      if (state.assets[id]) {
+        return Promise.resolve(state.assets[id]);
+      }
+      return loadAsset(id);
+    },
+    [state.assets, loadAsset]
+  );
 
   React.useEffect(() => {
     // @ts-expect-error
@@ -134,7 +152,7 @@ function useEntitiesStore(props: { sdk: BaseExtensionSDK }) {
     }) as { (): void };
   }, [props.sdk, state.assets, state.entries]);
 
-  return { loadEntry, loadAsset, ...state };
+  return { loadEntry, loadAsset, getOrLoadAsset, ...state };
 }
 
 const [EntityProvider, useEntities] = constate(useEntitiesStore);

--- a/packages/reference/src/common/MultipleReferenceEditor.tsx
+++ b/packages/reference/src/common/MultipleReferenceEditor.tsx
@@ -40,9 +40,23 @@ function onLinkOrCreate(
   setValue(newItems);
 }
 
+const emptyArray: ReferenceValue[] = [];
+const nullableValue = { sys: { id: 'null-value' } };
+
 function Editor(props: EditorProps) {
-  const { items, setValue, entityType } = props;
+  const { setValue, entityType } = props;
   const editorPermissions = useEditorPermissions(props);
+
+  const items = React.useMemo(() => {
+    return (
+      (props.items || [])
+        // If null values have found their way into the persisted
+        // value for the multiref field, replace them with an object
+        // that has the shape of a Link to make the missing entry/asset
+        // card render
+        .map((link) => link || nullableValue)
+    );
+  }, [props.items]);
 
   const onSortStart: SortStartHandler = useCallback((_, event) => event.preventDefault(), []);
   const onSortEnd: SortEndHandler = useCallback(
@@ -110,17 +124,10 @@ export function MultipleReferenceEditor(
   return (
     <ReferenceEditor<ReferenceValue[]> {...props}>
       {({ value, disabled, setValue, externalReset }) => {
-        const items = (value || [])
-          // If null values have found their way into the persisted
-          // value for the multiref field, replace them with an object
-          // that has the shape of a Link to make the missing entry/asset
-          // card render
-          .map((link) => link || { sys: { id: 'null-value' } });
-
         return (
           <Editor
             {...props}
-            items={items}
+            items={value || emptyArray}
             isDisabled={disabled}
             setValue={setValue}
             key={`${externalReset}-list`}

--- a/packages/reference/src/entries/WrappedEntryCard/FetchingWrappedEntryCard.tsx
+++ b/packages/reference/src/entries/WrappedEntryCard/FetchingWrappedEntryCard.tsx
@@ -53,7 +53,7 @@ async function openEntry(
 }
 
 export function FetchingWrappedEntryCard(props: EntryCardReferenceEditorProps) {
-  const { loadEntry, entries } = useEntities();
+  const { loadEntry, getOrLoadAsset, entries } = useEntities();
 
   React.useEffect(() => {
     loadEntry(props.entryId);
@@ -148,7 +148,7 @@ export function FetchingWrappedEntryCard(props: EntryCardReferenceEditorProps) {
         ...sharedCardProps,
         ...props,
         hasCardEditActions: hasCardEditActions,
-        getAsset: sdk.space.getAsset,
+        getAsset: getOrLoadAsset,
         getEntityScheduledActions: sdk.space.getEntityScheduledActions,
         entry: props?.entity || sharedCardProps.entity,
         entryUrl: props?.entityUrl || sharedCardProps.entityUrl,

--- a/packages/reference/src/entries/WrappedEntryCard/FetchingWrappedEntryCard.tsx
+++ b/packages/reference/src/entries/WrappedEntryCard/FetchingWrappedEntryCard.tsx
@@ -53,10 +53,10 @@ async function openEntry(
 }
 
 export function FetchingWrappedEntryCard(props: EntryCardReferenceEditorProps) {
-  const { loadEntry, getOrLoadAsset, entries } = useEntities();
+  const { getOrLoadEntry, getOrLoadAsset, entries } = useEntities();
 
   React.useEffect(() => {
-    loadEntry(props.entryId);
+    getOrLoadEntry(props.entryId);
   }, [props.entryId]);
 
   const size = props.viewType === 'link' ? 'small' : 'default';


### PR DESCRIPTION
* Don't fetch new entries and assets when re-ordering elements (don't fetch if there's an item in the store already)
* Fix a few memorization problems by using statically defined variables (outside of react components)
* Loading thumbnail for entry preview also set an image to the store