### PR TITLE
feat: allow custom plugins for slate

### DIFF
--- a/packages/rich-text/src/RichTextEditor.jsx
+++ b/packages/rich-text/src/RichTextEditor.jsx
@@ -136,7 +136,7 @@ export class ConnectedRichTextEditor extends React.Component {
     onAction: this.props.onAction,
   });
 
-  slatePlugins = buildPlugins(this.richTextAPI);
+  slatePlugins = buildPlugins(this.richTextAPI, this.props.customPlugins);
 
   onChange = (editor) => {
     const { value, operations } = editor;

--- a/packages/rich-text/src/plugins/index.js
+++ b/packages/rich-text/src/plugins/index.js
@@ -33,9 +33,10 @@ import { InsertBeforeFirstVoidBlockPlugin } from './InsertBeforeFirstVoidBlock';
 
 import schema from '../constants/Schema';
 
-export function buildPlugins(richTextAPI) {
+export function buildPlugins(richTextAPI, customPlugins = []) {
   return [
     { schema },
+    ...customPlugins.map(plugin => plugin({ richTextAPI })),
     InsertBeforeFirstVoidBlockPlugin({ richTextAPI }),
     BoldPlugin({ richTextAPI }),
     ItalicPlugin({ richTextAPI }),


### PR DESCRIPTION
## Description

Adds a `customPlugins` prop to the `RichTextEditor` component. This allows the user to override existing node renderers or and/or add their own node renderers used by Slate.