### PR TITLE
feat: {wip} use rich text adapter

### DIFF
--- a/packages/rich-text/package.json
+++ b/packages/rich-text/package.json
@@ -23,6 +23,7 @@
     "lint": "eslint ./src --ext .js,.jsx,.ts,.tsx"
   },
   "dependencies": {
+    "@contentful/contentful-slatejs-adapter": "^14.2.0",
     "@contentful/rich-text-types": "^14.1.2",
     "react": ">=16.8.0",
     "slate": "^0.62.0",

--- a/packages/rich-text/src/RichTextEditor.mdx
+++ b/packages/rich-text/src/RichTextEditor.mdx
@@ -15,5 +15,5 @@ import { css } from 'emotion';
 ## In Action
 
 <Playground>
-  <RichTextEditor />
+  <RichTextEditor onChange={console.log} />
 </Playground>

--- a/packages/rich-text/src/RichTextEditor.tsx
+++ b/packages/rich-text/src/RichTextEditor.tsx
@@ -1,11 +1,10 @@
-// Import React dependencies.
 import React, { useMemo, useState } from 'react'
-
-// Import the Slate editor factory.
 import { createEditor, BaseEditor } from 'slate'
-
-// Import the Slate components and React plugin.
 import { Slate, Editable, withReact, ReactEditor } from 'slate-react'
+import debounce from 'lodash-es/debounce'
+import { toContentfulDocument } from '@contentful/contentful-slatejs-adapter'
+import * as Contentful from '@contentful/rich-text-types';
+import schema from './constants/Schema';
 
 type CustomElement = {
   type: 'paragraph';
@@ -21,11 +20,18 @@ declare module 'slate' {
   }
 }
 
+const toContentfulDocumentDebounced = debounce((document, schema) => {
+  return toContentfulDocument({ document, schema });
+}, 500);
+
+type Props = {
+  onChange: (doc: Contentful.Document) => unknown;
+};
+
 // Define our app...
-const RichTextEditor = () => {
+const RichTextEditor = (props: Props) => {
   const editor = useMemo(() => withReact(createEditor()), [])
 
-  // Keep track of state for the value of the editor.
   const [value, setValue] = useState([
     {
       type: 'paragraph',
@@ -33,12 +39,15 @@ const RichTextEditor = () => {
     },
   ] as CustomElement[])
 
-  // Render the Slate context.
   return (
     <Slate
       editor={editor}
       value={value}
-      onChange={newValue => setValue(newValue as CustomElement[])}>
+      onChange={newValue => {
+        setValue(newValue as CustomElement[]);
+        const doc = toContentfulDocumentDebounced(newValue, schema);
+        props.onChange(doc);
+      }}>
       <Editable />
     </Slate>
   )

--- a/packages/rich-text/src/constants/Schema.ts
+++ b/packages/rich-text/src/constants/Schema.ts
@@ -1,0 +1,140 @@
+import {
+  BLOCKS,
+  INLINES,
+  TOP_LEVEL_BLOCKS,
+  VOID_BLOCKS,
+  CONTAINERS
+} from '@contentful/rich-text-types';
+
+const inlines = Object.values(INLINES).map((type) => ({ type }));
+
+export default {
+  document: {
+    nodes: [
+      {
+        types: TOP_LEVEL_BLOCKS.map((type) => ({ type }))
+      }
+    ]
+  },
+
+  blocks: {
+    [BLOCKS.PARAGRAPH]: {
+      nodes: [
+        {
+          match: [
+            ...inlines,
+            { object: 'text' }
+          ],
+        },
+      ]
+    },
+    [BLOCKS.HEADING_1]: {
+      nodes: [
+        {
+          match: [
+            ...inlines,
+            { object: 'text' }
+          ],
+        },
+      ]
+    },
+    [BLOCKS.HEADING_2]: {
+      nodes: [
+        {
+          match: [
+            ...inlines,
+            { object: 'text' }
+          ],
+        },
+      ]
+    },
+    [BLOCKS.HEADING_3]: {
+      nodes: [
+        {
+          match: [
+            ...inlines,
+            { object: 'text' }
+          ],
+        },
+      ]
+    },
+    [BLOCKS.HEADING_4]: {
+      nodes: [
+        {
+          match: [
+            ...inlines,
+            { object: 'text' }
+          ],
+        },
+      ]
+    },
+    [BLOCKS.HEADING_5]: {
+      nodes: [
+        {
+          match: [
+            ...inlines,
+            { object: 'text' }
+          ],
+        },
+      ]
+    },
+    [BLOCKS.HEADING_6]: {
+      nodes: [
+        {
+          match: [
+            ...inlines,
+            { object: 'text' }
+          ],
+        },
+      ]
+    },
+
+    ...VOID_BLOCKS.reduce((blocks, nodeType) => ({
+      ...blocks,
+      [nodeType]: { isVoid: true }
+    }), {}),
+
+    // TODO: add list schema
+
+    [BLOCKS.QUOTE]: {
+      nodes: [
+        {
+          match: [CONTAINERS[BLOCKS.QUOTE].map(type => ({ type }))],
+          min: 1
+        }
+      ],
+      normalize: (editor, error) => {
+        if (error.code === 'child_type_invalid') {
+          return editor.unwrapBlockByKey(error.node.key, BLOCKS.QUOTE);
+        }
+      }
+    }
+  },
+
+  inlines: {
+    [INLINES.HYPERLINK]: {
+      nodes: [
+        {
+          match: [{ object: 'text' }]
+        }
+      ]
+    },
+    [INLINES.ENTRY_HYPERLINK]: {
+      nodes: [
+        {
+          match: [{ object: 'text' }]
+        }
+      ]
+    },
+    [INLINES.ASSET_HYPERLINK]: {
+      nodes: [
+        {
+          match: [{ object: 'text' }]
+        }
+      ]
+    },
+    [INLINES.EMBEDDED_ENTRY]: {
+      isVoid: true
+    }
+  }
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1636,6 +1636,18 @@
     typescript "^4.0.5"
     yargs "16.1.0"
 
+"@contentful/contentful-slatejs-adapter@^14.2.0":
+  version "14.2.0"
+  resolved "https://registry.yarnpkg.com/@contentful/contentful-slatejs-adapter/-/contentful-slatejs-adapter-14.2.0.tgz#52c75e13d11d7cbdd3bbcd8c42756c2cb15425da"
+  integrity sha512-xBdv3iMJItA4SqOP2tI622hAYKdxPF3VXR7AoXE3bO2EbK3Ce8IF50HxWYQLu2NBAB57EzHXhGph2DEl/PWOLg==
+  dependencies:
+    "@contentful/rich-text-types" "^5.0.0"
+    jest "^26.6.3"
+    lodash.flatmap "^4.5.0"
+    lodash.get "^4.4.2"
+    lodash.omit "^4.5.0"
+    typescript "^4.2.4"
+
 "@contentful/eslint-config-extension@0.4.2":
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/@contentful/eslint-config-extension/-/eslint-config-extension-0.4.2.tgz#6d05e14474fd5a959a9e3a9d02565cf2bea15388"
@@ -1710,6 +1722,11 @@
   version "14.1.2"
   resolved "https://registry.yarnpkg.com/@contentful/rich-text-types/-/rich-text-types-14.1.2.tgz#33162fdbf427891122a96030f806ca9a9cf0e844"
   integrity sha512-XbgZ7op5uyYYszipgQg/bYobF4b+llXyTwS8hISRniQY9xKESz544eP2OGmRc4J3MHx29M7Vmx7TVA/IK65giQ==
+
+"@contentful/rich-text-types@^5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@contentful/rich-text-types/-/rich-text-types-5.0.0.tgz#d2d02d9b7c10115bcc960cee3e1c381eb9d16b84"
+  integrity sha512-NPmsk0xCC/OoZUIpZqByFEYCktIcyUakKrzDlSA9YLklCdgahEr6qbSghIsQ/wVclnQhwVq28psJ0agHXdLCSQ==
 
 "@cypress/listr-verbose-renderer@^0.4.1":
   version "0.4.1"
@@ -12550,7 +12567,7 @@ jest@^25.1.0, jest@^25.3.0:
     import-local "^3.0.2"
     jest-cli "^25.5.4"
 
-jest@^26.6.1:
+jest@^26.6.1, jest@^26.6.3:
   version "26.6.3"
   resolved "https://registry.yarnpkg.com/jest/-/jest-26.6.3.tgz#40e8fdbe48f00dfa1f0ce8121ca74b88ac9148ef"
   integrity sha512-lGS5PXGAzR4RF7V5+XObhqz2KZIDUA1yD0DG6pBVmy10eh0ZIXQImRuzocsI/N2XZ1GrLFwTS27In2i2jlpq1Q==
@@ -13241,6 +13258,11 @@ lodash.deburr@^4.1.0:
   resolved "https://registry.yarnpkg.com/lodash.deburr/-/lodash.deburr-4.1.0.tgz#ddb1bbb3ef07458c0177ba07de14422cb033ff9b"
   integrity sha1-3bG7s+8HRYwBd7oH3hRCLLAz/5s=
 
+lodash.flatmap@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.flatmap/-/lodash.flatmap-4.5.0.tgz#ef8cbf408f6e48268663345305c6acc0b778702e"
+  integrity sha1-74y/QI9uSCaGYzRTBcaswLd4cC4=
+
 lodash.get@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
@@ -13290,6 +13312,11 @@ lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
+
+lodash.omit@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.omit/-/lodash.omit-4.5.0.tgz#6eb19ae5a1ee1dd9df0b969e66ce0b7fa30b5e60"
+  integrity sha1-brGa5aHuHdnfC5aeZs4Lf6MLXmA=
 
 lodash.once@^4.1.1:
   version "4.1.1"
@@ -19639,6 +19666,11 @@ typescript@^4.0.5:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.2.tgz#1450f020618f872db0ea17317d16d8da8ddb8c4c"
   integrity sha512-tbb+NVrLfnsJy3M59lsDgrzWIflR4d4TIUjz+heUnHZwdF7YsrMTKoRERiIvI2lvBG95dfpLxB21WZhys1bgaQ==
+
+typescript@^4.2.4:
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.4.tgz#8610b59747de028fda898a8aef0e103f156d0961"
+  integrity sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==
 
 ua-parser-js@^0.7.18:
   version "0.7.21"


### PR DESCRIPTION
# Summary

- [x] Converts SlateJS markup to Contentful markup using the adapter via supplied `onChange` prop
- [x] Adds a [SlateJS schema](https://docs.slatejs.org/v/v0.47/slate-core/schema) based on [the one we're using in `master` currently](https://github.com/contentful/field-editors/blob/master/packages/rich-text/src/constants/Schema.js)

# TODO

- [ ] Convert Contentful markup back to SlateJS markup using state supplied from the SDK
- [ ] Add tests