### PR TITLE
feat: gracefully handle void elements

### DIFF
--- a/cypress/integration/MarkdownEditorVoidElements.spec.ts
+++ b/cypress/integration/MarkdownEditorVoidElements.spec.ts
@@ -1,0 +1,44 @@
+describe('Markdown Editor / Void elements', () => {
+  const selectors = {
+    getInput() {
+      return cy.get('[data-test-id="markdown-textarea"] textarea');
+    },
+    getPreviewButton() {
+      return cy.findByTestId('markdown-tab-preview');
+    },
+    getVoidElementsWarning() {
+      return cy.findByTestId('markdown-void-elements-warning');
+    },
+    getPreview() {
+      return cy.findByTestId('markdown-preview');
+    }
+  };
+
+  const type = value => {
+    return selectors.getInput().type(value, { force: true });
+  };
+
+  beforeEach(() => {
+    cy.visit('/markdown');
+    cy.wait(500);
+    cy.findByTestId('markdown-editor').should('be.visible');
+  });
+
+  it('renders warning if void elements are used', () => {
+    type('<link>link children</link>');
+
+    selectors.getPreviewButton().click();
+
+    selectors.getVoidElementsWarning().should('be.visible');
+    selectors.getPreview().should('not.contain.text', 'link children');
+  });
+
+  it('does not render warning if void elements are able to render', () => {
+    type('<link>link children');
+
+    selectors.getPreviewButton().click();
+
+    selectors.getVoidElementsWarning().should('not.be.visible');
+    selectors.getPreview().should('contain.text', 'link children');
+  });
+});

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -27,6 +27,7 @@
     "@types/codemirror": "0.0.108",
     "@types/markdown-to-jsx": "6.11.3",
     "codemirror": "^5.48.0",
+    "constate": "^3.2.0",
     "emotion": "^10.0.17",
     "lodash": "^4.17.15",
     "lodash-es": "^4.17.15",

--- a/packages/markdown/src/MarkdownEditor.tsx
+++ b/packages/markdown/src/MarkdownEditor.tsx
@@ -13,6 +13,7 @@ import { openCheatsheetModal } from './dialogs/CheatsheetModalDialog';
 import { MarkdownPreview } from './components/MarkdownPreview/MarkdownPreview';
 import { MarkdownConstraints } from './components/MarkdownConstraints';
 import { createMarkdownActions } from './MarkdownActions';
+import { VoidElementsWarning, VoidElementsContext } from './components/VoidElements';
 
 const styles = {
   container: css({
@@ -86,49 +87,52 @@ export function MarkdownEditor(
 
   return (
     <div className={styles.container} data-test-id="markdown-editor">
-      <MarkdownTabs
-        active={selectedTab}
-        onSelect={(tab) => {
-          setSelectedTab(tab);
-        }}
-      />
-      <MarkdownToolbar
-        mode="default"
-        disabled={isActionDisabled}
-        canUploadAssets={canUploadAssets}
-        actions={actions}
-      />
-      <MarkdownTextarea
-        minHeight={props.minHeight}
-        mode="default"
-        visible={selectedTab === 'editor'}
-        disabled={isActionDisabled}
-        direction={direction}
-        onReady={(editor) => {
-          editor.setContent(props.initialValue ?? '');
-          editor.setReadOnly(props.disabled);
-          setEditor(editor);
-          editor.events.onChange((value: string) => {
-            // Trim empty lines
-            const trimmedValue = value.replace(/^\s+$/gm, '');
-            props.saveValueToSDK(trimmedValue);
-            setCurrentValue(value);
-          });
-        }}
-      />
-      {selectedTab === 'preview' && (
-        <MarkdownPreview
-          direction={direction}
+      <VoidElementsContext>
+        {selectedTab === 'preview' && <VoidElementsWarning />}
+        <MarkdownTabs
+          active={selectedTab}
+          onSelect={(tab) => {
+            setSelectedTab(tab);
+          }}
+        />
+        <MarkdownToolbar
+          mode="default"
+          disabled={isActionDisabled}
+          canUploadAssets={canUploadAssets}
+          actions={actions}
+        />
+        <MarkdownTextarea
           minHeight={props.minHeight}
           mode="default"
-          value={currentValue}
-          previewComponents={props.previewComponents}
+          visible={selectedTab === 'editor'}
+          disabled={isActionDisabled}
+          direction={direction}
+          onReady={(editor) => {
+            editor.setContent(props.initialValue ?? '');
+            editor.setReadOnly(props.disabled);
+            setEditor(editor);
+            editor.events.onChange((value: string) => {
+              // Trim empty lines
+              const trimmedValue = value.replace(/^\s+$/gm, '');
+              props.saveValueToSDK(trimmedValue);
+              setCurrentValue(value);
+            });
+          }}
         />
-      )}
-      <MarkdownBottomBar>
-        <MarkdownHelp onClick={openMarkdownHelp} />
-      </MarkdownBottomBar>
-      <MarkdownConstraints sdk={props.sdk} value={currentValue} />
+        {selectedTab === 'preview' && (
+          <MarkdownPreview
+            direction={direction}
+            minHeight={props.minHeight}
+            mode="default"
+            value={currentValue}
+            previewComponents={props.previewComponents}
+          />
+        )}
+        <MarkdownBottomBar>
+          <MarkdownHelp onClick={openMarkdownHelp} />
+        </MarkdownBottomBar>
+        <MarkdownConstraints sdk={props.sdk} value={currentValue} />
+      </VoidElementsContext>
     </div>
   );
 }

--- a/packages/markdown/src/components/MarkdownPreview/MarkdownPreview.tsx
+++ b/packages/markdown/src/components/MarkdownPreview/MarkdownPreview.tsx
@@ -3,6 +3,24 @@ import Markdown from 'markdown-to-jsx';
 import tokens from '@contentful/forma-36-tokens';
 import { css, cx } from 'emotion';
 import { EditorDirection, PreviewComponents } from '../../types';
+import {
+  AreaElement,
+  BaseElement,
+  BrElement,
+  ColElement,
+  CommandElement,
+  EmbedElement,
+  HrElement,
+  ImgElement,
+  InputElement,
+  KeygenElement,
+  LinkElement,
+  MetaElement,
+  ParamElement,
+  SourceElement,
+  TrackElement,
+  WbrElement
+} from '../VoidElements';
 
 const styles = {
   root: css`
@@ -223,6 +241,27 @@ export const MarkdownPreview = React.memo((props: MarkdownPreviewProps) => {
       <Markdown
         options={{
           overrides: {
+            // these are all void elements, if the user provides children
+            // with it the rendering will fail due to the browser
+            // by overriding them we can surface the problem
+            // see https://www.w3.org/TR/2011/WD-html-markup-20110113/syntax.html#void-element
+            area: { component: AreaElement },
+            base: { component: BaseElement },
+            br: { component: BrElement },
+            col: { component: ColElement },
+            command: { component: CommandElement },
+            embed: { component: EmbedElement },
+            hr: { component: HrElement },
+            img: { component: ImgElement },
+            input: { component: InputElement },
+            keygen: { component: KeygenElement },
+            link: { component: LinkElement },
+            meta: { component: MetaElement },
+            param: { component: ParamElement },
+            source: { component: SourceElement },
+            track: { component: TrackElement },
+            wbr: { component: WbrElement },
+
             svg: {
               // eslint-disable-next-line @typescript-eslint/no-explicit-any
               component: SvgWrapper as any,

--- a/packages/markdown/src/components/VoidElements/VoidElements.tsx
+++ b/packages/markdown/src/components/VoidElements/VoidElements.tsx
@@ -1,0 +1,40 @@
+import React, { useEffect } from 'react';
+import { useVoidElements } from './useVoidElements';
+
+type ElementProps = React.PropsWithChildren<Record<string, unknown>>;
+
+type VoidElementProps = ElementProps & { Tag: string };
+
+function VoidElement({ children, Tag, ...props }: VoidElementProps) {
+  const { add, remove } = useVoidElements();
+
+  useEffect(() => {
+    if (!children) {
+      return;
+    }
+
+    add();
+    return () => remove();
+  }, [add, remove, children]);
+
+  return <Tag {...props} />;
+}
+
+// markdown-to-jsx does not provide the tag name for overrides
+// so we have to wrap all elements
+export const AreaElement = (props: ElementProps) => <VoidElement Tag="area" {...props} />;
+export const BaseElement = (props: ElementProps) => <VoidElement Tag="base" {...props} />;
+export const BrElement = (props: ElementProps) => <VoidElement Tag="br" {...props} />;
+export const ColElement = (props: ElementProps) => <VoidElement Tag="col" {...props} />;
+export const CommandElement = (props: ElementProps) => <VoidElement Tag="command" {...props} />;
+export const EmbedElement = (props: ElementProps) => <VoidElement Tag="embed" {...props} />;
+export const HrElement = (props: ElementProps) => <VoidElement Tag="hr" {...props} />;
+export const ImgElement = (props: ElementProps) => <VoidElement Tag="img" {...props} />;
+export const InputElement = (props: ElementProps) => <VoidElement Tag="input" {...props} />;
+export const KeygenElement = (props: ElementProps) => <VoidElement Tag="keygen" {...props} />;
+export const LinkElement = (props: ElementProps) => <VoidElement Tag="link" {...props} />;
+export const MetaElement = (props: ElementProps) => <VoidElement Tag="meta" {...props} />;
+export const ParamElement = (props: ElementProps) => <VoidElement Tag="param" {...props} />;
+export const SourceElement = (props: ElementProps) => <VoidElement Tag="source" {...props} />;
+export const TrackElement = (props: ElementProps) => <VoidElement Tag="track" {...props} />;
+export const WbrElement = (props: ElementProps) => <VoidElement Tag="wbr" {...props} />;

--- a/packages/markdown/src/components/VoidElements/VoidElementsWarning.tsx
+++ b/packages/markdown/src/components/VoidElements/VoidElementsWarning.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { useVoidElements } from './useVoidElements';
+import { Note, Paragraph, TextLink } from '@contentful/forma-36-react-components';
+import tokens from '@contentful/forma-36-tokens';
+
+import { css } from 'emotion';
+
+const styles = {
+  note: css({
+    margin: `${tokens.spacingM} 0`
+  }),
+  paragraph: css({
+    '&:not(:last-child)': {
+      paddingBottom: tokens.spacingS
+    }
+  })
+};
+
+export function VoidElementsWarning() {
+  const { isEmpty } = useVoidElements();
+
+  if (isEmpty) {
+    return null;
+  }
+
+  return (
+    <Note noteType="warning" hasCloseButton={false} className={styles.note} testId="markdown-void-elements-warning">
+      <Paragraph className={styles.paragraph}>
+        Your markdown contains <TextLink linkType="primary" icon="ExternalLink" iconPosition="right">void
+        elements</TextLink> that causes the preview to skip those parts. This indicates incorrect usage of one or more
+        of the following HTML elements: area, base, br, col, command, embed, hr, img, input, keygen, link, meta, param,
+        source, track, wbr.
+      </Paragraph>
+      <Paragraph className={styles.paragraph}>
+        In order to properly display the preview fix the elements or replace them with alternatives.
+      </Paragraph>
+    </Note>
+  );
+}

--- a/packages/markdown/src/components/VoidElements/VoidElementsWarning.tsx
+++ b/packages/markdown/src/components/VoidElements/VoidElementsWarning.tsx
@@ -26,7 +26,7 @@ export function VoidElementsWarning() {
   return (
     <Note noteType="warning" hasCloseButton={false} className={styles.note} testId="markdown-void-elements-warning">
       <Paragraph className={styles.paragraph}>
-        Your markdown contains <TextLink linkType="primary" icon="ExternalLink" iconPosition="right"
+        Your markdown contains <TextLink linkType="primary" icon="ExternalLink" iconPosition="right" target="_blank"
                                          href="https://www.w3.org/TR/2011/WD-html-markup-20110113/syntax.html#void-element">void
         elements</TextLink> that causes the preview to skip those parts.
       </Paragraph>

--- a/packages/markdown/src/components/VoidElements/VoidElementsWarning.tsx
+++ b/packages/markdown/src/components/VoidElements/VoidElementsWarning.tsx
@@ -26,13 +26,14 @@ export function VoidElementsWarning() {
   return (
     <Note noteType="warning" hasCloseButton={false} className={styles.note} testId="markdown-void-elements-warning">
       <Paragraph className={styles.paragraph}>
-        Your markdown contains <TextLink linkType="primary" icon="ExternalLink" iconPosition="right">void
-        elements</TextLink> that causes the preview to skip those parts. This indicates incorrect usage of one or more
-        of the following HTML elements: area, base, br, col, command, embed, hr, img, input, keygen, link, meta, param,
-        source, track, wbr.
+        Your markdown contains <TextLink linkType="primary" icon="ExternalLink" iconPosition="right"
+                                         href="https://www.w3.org/TR/2011/WD-html-markup-20110113/syntax.html#void-element">void
+        elements</TextLink> that causes the preview to skip those parts.
       </Paragraph>
       <Paragraph className={styles.paragraph}>
-        In order to properly display the preview fix the elements or replace them with alternatives.
+        This indicates incorrect usage of one or more of the following HTML elements: area, base, br, col, command,
+        embed, hr, img, input, keygen, link, meta, param, source, track, wbr.In order to properly display the preview
+        fix the elements or replace them with alternatives.
       </Paragraph>
     </Note>
   );

--- a/packages/markdown/src/components/VoidElements/index.ts
+++ b/packages/markdown/src/components/VoidElements/index.ts
@@ -1,0 +1,3 @@
+export * from './VoidElements';
+export { VoidElementsWarning } from './VoidElementsWarning';
+export { useVoidElements, VoidElementsContext } from './useVoidElements';

--- a/packages/markdown/src/components/VoidElements/useVoidElements.ts
+++ b/packages/markdown/src/components/VoidElements/useVoidElements.ts
@@ -1,0 +1,18 @@
+import { useCallback, useState } from 'react';
+import constate from 'constate';
+
+const [VoidElementsContext, useVoidElements] = constate(() => {
+  const [counter, setCounter] = useState(0);
+  const add = useCallback(() => setCounter((current) => current + 1), [setCounter]);
+  const remove = useCallback(() => setCounter((current) => current - 1), [setCounter]);
+
+  return {
+    add,
+    remove,
+    get isEmpty() {
+      return counter === 0;
+    }
+  };
+});
+
+export { VoidElementsContext, useVoidElements };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1636,7 +1636,7 @@
     typescript "^4.0.5"
     yargs "16.1.0"
 
-"@contentful/contentful-slatejs-adapter@^14.1.0":
+"@contentful/contentful-slatejs-adapter@14.1.2":
   version "14.1.2"
   resolved "https://registry.yarnpkg.com/@contentful/contentful-slatejs-adapter/-/contentful-slatejs-adapter-14.1.2.tgz#22fbacd93ee4b7cb2315978e1ed2b9326c362381"
   integrity sha512-kxIdzOI8M84TDtyw3U40lXmu9iX89zI+e0t5wmv6pmWcHbTpitAT5xe7V3XsixWqj7+5F5RMziBPzstXlkCUjg==
@@ -6612,7 +6612,7 @@ constants-browserify@^1.0.0:
   resolved "https://registry.yarnpkg.com/constants-browserify/-/constants-browserify-1.0.0.tgz#c20b96d8c617748aaf1c16021760cd27fcb8cb75"
   integrity sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=
 
-constate@3.2.0:
+constate@3.2.0, constate@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/constate/-/constate-3.2.0.tgz#6034e7b775ca0e58137274f87c25196e8932f685"
   integrity sha512-hP7sj9jt+KwVRoFlzaJuv3kBvchE9hNMAYJEH1weKZYD7+UAWRSo7oXARrfhipVLP3XZxIkmD+E9zXU+5RYKCQ==


### PR DESCRIPTION
Usage of void elements in the markdown crashes the preview because React won't let us render children for those elements. We hereby surface that problem to the user in order to give them a way out of that otherwise dead end.

![image](https://user-images.githubusercontent.com/863612/120289285-6beb6e00-c2c1-11eb-9338-5cbc178a2237.png)
