### PR TITLE
test: add tests for lists and toolbar mark buttons []

### DIFF
--- a/cypress/integration/RichTextEditor.spec.ts
+++ b/cypress/integration/RichTextEditor.spec.ts
@@ -307,4 +307,69 @@ describe('Rich Text Editor', () => {
       });
     });
   });
+
+  describe.only('Lists', () => {
+    function getUlToolbarButton() {
+      return cy.findByTestId('ul-toolbar-button');
+    }
+
+    function getOlToolbarButton() {
+      return cy.findByTestId('ol-toolbar-button');
+    }
+
+    const lists = [
+      { getList: getUlToolbarButton, listType: BLOCKS.UL_LIST, label: 'Unordered List (UL)' },
+      { getList: getOlToolbarButton, listType: BLOCKS.OL_LIST, label: 'Ordered List (OL)' },
+    ];
+
+    lists.forEach((test) => {
+      describe(test.label, () => {
+        it('should be visible', () => {
+          test.getList().should('be.visible');
+        });
+
+        it('should add a new list', () => {
+          editor().click();
+
+          test.getList().click();
+
+          // TODO: Find a way to test deeper lists
+          /*
+            Having issues with `.type('{enter})` to break lines.
+            The error is:
+            Cannot resolve a Slate node from DOM node: [object HTMLSpanElement]
+          */
+          editor().click().typeInSlate('item 1');
+
+          cy.wait(600);
+
+          const expectedValue = doc(
+            block(
+              test.listType,
+              {},
+              block(BLOCKS.LIST_ITEM, {}, block(BLOCKS.PARAGRAPH, {}, text('item 1', [])))
+            )
+          );
+
+          expectRichTextFieldValue(expectedValue);
+        });
+
+        it('should untoggle the list', () => {
+          editor().click();
+
+          test.getList().click();
+
+          editor().click().typeInSlate('some text');
+
+          test.getList().click();
+
+          cy.wait(600);
+
+          const expectedValue = doc(block(BLOCKS.PARAGRAPH, {}, text('some text', [])));
+
+          expectRichTextFieldValue(expectedValue);
+        });
+      });
+    });
+  });
 });

--- a/cypress/integration/RichTextEditor.spec.ts
+++ b/cypress/integration/RichTextEditor.spec.ts
@@ -67,37 +67,120 @@ describe('Rich Text Editor', () => {
       [MARKS.UNDERLINE, `{${mod}}u`],
       [MARKS.CODE, `{${mod}}/`],
     ].forEach(([mark, shortcut]) => {
-      // TODO: unskip when toolbar is available
-      // const toggleMarkViaToolbar = () => cy.findByTestId(`toolbar-toggle-${mark}`).click();
-      // const toggleMarkViaShortcut = () => editor.type(shortcut);
+      const toggleMarkViaToolbar = () => cy.findByTestId(`${mark}-toolbar-button`).click();
 
-      [
-        // TODO: unskip when toolbar is available
-        // ['toolbar', toggleMarkViaToolbar],
-        ['shortcut' /*, toggleMarkViaShortcut */],
-      ].forEach(([toggleType]) => {
-        describe(`${mark} mark toggle via ${toggleType}`, () => {
-          it('allows writing marked text', () => {
-            editor().click().type(shortcut).typeInSlate('some text');
+      describe(`${mark} mark toggle via toolbar`, () => {
+        it('allows writing marked text', () => {
+          editor().click();
 
-            cy.wait(600);
+          toggleMarkViaToolbar();
 
-            const expectedValue = doc(
-              block(BLOCKS.PARAGRAPH, {}, text('some text', [{ type: mark }]))
-            );
+          editor().typeInSlate('some text');
 
-            expectRichTextFieldValue(expectedValue);
-          });
+          cy.wait(600);
 
-          it('allows writing unmarked text', () => {
-            editor().click().type(shortcut).type(shortcut).typeInSlate('some text');
+          const expectedValue = doc(
+            block(BLOCKS.PARAGRAPH, {}, text('some text', [{ type: mark }]))
+          );
 
-            cy.wait(600);
+          expectRichTextFieldValue(expectedValue);
+        });
 
-            const expectedValue = doc(block(BLOCKS.PARAGRAPH, {}, text('some text', [])));
+        it('allows writing marked text by selecting text', () => {
+          editor().click().typeInSlate('some text').type('{selectall}');
 
-            expectRichTextFieldValue(expectedValue);
-          });
+          toggleMarkViaToolbar();
+
+          cy.wait(600);
+
+          const expectedValue = doc(
+            block(BLOCKS.PARAGRAPH, {}, text('some text', [{ type: mark }]))
+          );
+
+          expectRichTextFieldValue(expectedValue);
+        });
+
+        it('allows writing unmarked text', () => {
+          editor().click();
+
+          toggleMarkViaToolbar();
+          toggleMarkViaToolbar();
+
+          editor().typeInSlate('some text');
+
+          cy.wait(600);
+
+          const expectedValue = doc(block(BLOCKS.PARAGRAPH, {}, text('some text', [])));
+
+          expectRichTextFieldValue(expectedValue);
+        });
+
+        it('allows writing unmarked text by selecting text', () => {
+          editor().click().typeInSlate('some text').type('{selectall}');
+
+          toggleMarkViaToolbar();
+
+          editor().click().type('{selectall}');
+
+          toggleMarkViaToolbar();
+
+          cy.wait(600);
+
+          const expectedValue = doc(block(BLOCKS.PARAGRAPH, {}, text('some text', [])));
+
+          expectRichTextFieldValue(expectedValue);
+        });
+      });
+
+      describe(`${mark} mark toggle via shortcut`, () => {
+        it('allows writing marked text', () => {
+          editor().click().type(shortcut).typeInSlate('some text');
+
+          cy.wait(600);
+
+          const expectedValue = doc(
+            block(BLOCKS.PARAGRAPH, {}, text('some text', [{ type: mark }]))
+          );
+
+          expectRichTextFieldValue(expectedValue);
+        });
+
+        it('allows writing marked text by selecting text', () => {
+          editor().click().typeInSlate('some text').type('{selectall}').type(shortcut);
+
+          cy.wait(600);
+
+          const expectedValue = doc(
+            block(BLOCKS.PARAGRAPH, {}, text('some text', [{ type: mark }]))
+          );
+
+          expectRichTextFieldValue(expectedValue);
+        });
+
+        it('allows writing unmarked text', () => {
+          editor().click().type(shortcut).type(shortcut).typeInSlate('some text');
+
+          cy.wait(600);
+
+          const expectedValue = doc(block(BLOCKS.PARAGRAPH, {}, text('some text', [])));
+
+          expectRichTextFieldValue(expectedValue);
+        });
+
+        it('allows writing unmarked text by selecting text', () => {
+          editor()
+            .click()
+            .typeInSlate('some text')
+            .type('{selectall}')
+            .type(shortcut)
+            .type('{selectall}')
+            .type(shortcut);
+
+          cy.wait(600);
+
+          const expectedValue = doc(block(BLOCKS.PARAGRAPH, {}, text('some text', [])));
+
+          expectRichTextFieldValue(expectedValue);
         });
       });
     });
@@ -308,7 +391,7 @@ describe('Rich Text Editor', () => {
     });
   });
 
-  describe.only('Lists', () => {
+  describe('Lists', () => {
     function getUlToolbarButton() {
       return cy.findByTestId('ul-toolbar-button');
     }

--- a/cypress/integration/RichTextEditor.spec.ts
+++ b/cypress/integration/RichTextEditor.spec.ts
@@ -87,7 +87,11 @@ describe('Rich Text Editor', () => {
         });
 
         it('allows writing marked text by selecting text', () => {
-          editor().click().typeInSlate('some text').type('{selectall}');
+          editor().click().typeInSlate('some text');
+
+          cy.wait(100);
+
+          editor().type('{selectall}');
 
           toggleMarkViaToolbar();
 
@@ -116,9 +120,15 @@ describe('Rich Text Editor', () => {
         });
 
         it('allows writing unmarked text by selecting text', () => {
-          editor().click().typeInSlate('some text').type('{selectall}');
+          editor().click().typeInSlate('some text');
+
+          cy.wait(100);
+
+          editor().type('{selectall}');
 
           toggleMarkViaToolbar();
+
+          cy.wait(100);
 
           editor().click().type('{selectall}');
 
@@ -146,7 +156,11 @@ describe('Rich Text Editor', () => {
         });
 
         it('allows writing marked text by selecting text', () => {
-          editor().click().typeInSlate('some text').type('{selectall}').type(shortcut);
+          editor().click().typeInSlate('some text');
+
+          cy.wait(100);
+
+          editor().type('{selectall}').type(shortcut);
 
           cy.wait(600);
 
@@ -168,13 +182,11 @@ describe('Rich Text Editor', () => {
         });
 
         it('allows writing unmarked text by selecting text', () => {
-          editor()
-            .click()
-            .typeInSlate('some text')
-            .type('{selectall}')
-            .type(shortcut)
-            .type('{selectall}')
-            .type(shortcut);
+          editor().click().typeInSlate('some text');
+
+          cy.wait(100);
+
+          editor().type('{selectall}').type(shortcut).type('{selectall}').type(shortcut);
 
           cy.wait(600);
 

--- a/packages/rich-text/src/plugins/Bold/index.tsx
+++ b/packages/rich-text/src/plugins/Bold/index.tsx
@@ -28,6 +28,7 @@ export function ToolbarBoldButton(props: ToolbarBoldButtonProps) {
       icon="FormatBold"
       tooltip="Bold"
       label="Bold"
+      testId="bold-toolbar-button"
       onClick={handleClick}
       isActive={isMarkActive(editor, MARKS.BOLD)}
       disabled={props.isDisabled}

--- a/packages/rich-text/src/plugins/Code/index.tsx
+++ b/packages/rich-text/src/plugins/Code/index.tsx
@@ -28,6 +28,7 @@ export function ToolbarCodeButton(props: ToolbarCodeButtonProps) {
       icon="Code"
       tooltip="Code"
       label="Code"
+      testId="code-toolbar-button"
       onClick={handleClick}
       isActive={isMarkActive(editor, MARKS.CODE)}
       disabled={props.isDisabled}

--- a/packages/rich-text/src/plugins/Italic/index.tsx
+++ b/packages/rich-text/src/plugins/Italic/index.tsx
@@ -28,6 +28,7 @@ export function ToolbarItalicButton(props: ToolbarItalicButtonProps) {
       icon="FormatItalic"
       tooltip="Italic"
       label="Italic"
+      testId="italic-toolbar-button"
       onClick={handleClick}
       isActive={isMarkActive(editor, MARKS.ITALIC)}
       disabled={props.isDisabled}

--- a/packages/rich-text/src/plugins/List/index.tsx
+++ b/packages/rich-text/src/plugins/List/index.tsx
@@ -3,7 +3,13 @@ import * as Slate from 'slate-react';
 import { css } from 'emotion';
 import { BLOCKS } from '@contentful/rich-text-types';
 import { EditorToolbarButton } from '@contentful/forma-36-react-components';
-import { ELEMENT_LI, ELEMENT_UL, ELEMENT_OL, toggleList } from '@udecode/slate-plugins-list';
+import {
+  ELEMENT_LI,
+  ELEMENT_UL,
+  ELEMENT_OL,
+  toggleList,
+  ELEMENT_LIC,
+} from '@udecode/slate-plugins-list';
 import { useStoreEditor } from '@udecode/slate-plugins-core';
 import { isBlockSelected } from '../../helpers/editor';
 import { CustomSlatePluginOptions } from 'types';
@@ -76,6 +82,12 @@ export const OL = createList('ol', BLOCKS.OL_LIST);
 export const LI = createList('li', BLOCKS.LIST_ITEM);
 
 export const withListOptions: CustomSlatePluginOptions = {
+  // ELEMENT_LIC is a child of li, slatejs does ul > li > lic + ul
+  [ELEMENT_LIC]: {
+    type: BLOCKS.PARAGRAPH,
+    // TODO: We might want to change it to our paragraph in case we develop one, otherwise we can simply use the slatejs default element
+    component: Slate.DefaultElement,
+  },
   [ELEMENT_LI]: {
     type: BLOCKS.LIST_ITEM,
     component: LI,

--- a/packages/rich-text/src/plugins/Underline/index.tsx
+++ b/packages/rich-text/src/plugins/Underline/index.tsx
@@ -27,6 +27,7 @@ export function ToolbarUnderlineButton(props: ToolbarUnderlineButtonProps) {
       icon="FormatUnderlined"
       tooltip="Underline"
       label="Underline"
+      testId="underline-toolbar-button"
       onClick={handleClick}
       isActive={isMarkActive(editor, MARKS.UNDERLINE)}
       disabled={props.isDisabled}


### PR DESCRIPTION
Tests for lists and toolbar mark buttons.

I had some issues when trying to test deeper lists, I couldn't add more than one item on the list.

To do that, I need to simular an `Enter` key press, so I've used `.type('{enter'})`, however, whenever I use this command, it breaks the next command and SlateJS.

The error is:

```
Cannot resolve a Slate node from DOM node: [object HTMLSpanElement]
``` 

I don't know if this a Cypress version bug, or how SlateJS detects events, we can try updating Cypress version to the latest if the problem is gone.

Any other idea?

EDIT:

Somebody told to intercalate some `.type('{enter}')` calls with some delays. I'm still testing this approach for lists. 