### PR TITLE
chore: fix reference editor showCreateEntityAction/showLink params

### DIFF
--- a/packages/reference/src/assets/MultipleMediaEditor.mdx
+++ b/packages/reference/src/assets/MultipleMediaEditor.mdx
@@ -39,8 +39,8 @@ import { newReferenceEditorFakeSdk } from '../__fixtures__/FakeSdk';
           isInitiallyDisabled={false}
           parameters={{
             instance: {
-              canCreateEntity: true,
-              canLinkEntity: true
+              showCreateEntityAction: true,
+              showLinkEntityAction: true,
             }
           }}
          />
@@ -68,8 +68,8 @@ Note the alternative link actions injected via the `renderCustomActions` prop.
           renderCustomActions={(props) => (<CombinedLinkActions {...props}/>)}
           parameters={{
             instance: {
-              canCreateEntity: true,
-              canLinkEntity: true
+              showCreateEntityAction: true,
+              showLinkEntityAction: true,
             }
           }}
          />
@@ -93,8 +93,8 @@ Note the alternative link actions injected via the `renderCustomActions` prop.
           isInitiallyDisabled={false}
           parameters={{
             instance: {
-              canCreateEntity: true,
-              canLinkEntity: true,
+              showCreateEntityAction: true,
+              showLinkEntityAction: true,
             },
           }}
           renderCustomCard={(props) => {

--- a/packages/reference/src/assets/SingleMediaEditor.mdx
+++ b/packages/reference/src/assets/SingleMediaEditor.mdx
@@ -39,8 +39,8 @@ import { newReferenceEditorFakeSdk } from '../__fixtures__/FakeSdk';
           isInitiallyDisabled={false}
           parameters={{
             instance: {
-              canCreateEntity: true,
-              canLinkEntity: true
+              showCreateEntityAction: true,
+              showLinkEntityAction: true,
             }
           }}
          />
@@ -76,8 +76,8 @@ Note the alternative link actions injected via the `renderCustomActions` prop.
           }
           parameters={{
             instance: {
-              canCreateEntity: true,
-              canLinkEntity: true
+              showCreateEntityAction: true,
+              showLinkEntityAction: true,
             }
           }}
          />
@@ -103,8 +103,8 @@ Note the alternative link actions injected via the `renderCustomActions` prop.
           isInitiallyDisabled={false}
           parameters={{
             instance: {
-              canCreateEntity: true,
-              canLinkEntity: true,
+              showCreateEntityAction: true,
+              showLinkEntityAction: true,
             },
           }}
           renderCustomCard={(props) => {

--- a/packages/reference/src/entries/MultipleEntryReferenceEditor.mdx
+++ b/packages/reference/src/entries/MultipleEntryReferenceEditor.mdx
@@ -41,8 +41,8 @@ import { newReferenceEditorFakeSdk } from '../__fixtures__/FakeSdk';
           isInitiallyDisabled={isInitiallyDisabled}
           parameters={{
             instance: instanceParams || {
-              canCreateEntity: true,
-              canLinkEntity: true,
+              showCreateEntityAction: true,
+              showLinkEntityAction: true,
             },
           }}
         />
@@ -86,8 +86,8 @@ another reference rendered by the stardard card renderer.
           isInitiallyDisabled={isInitiallyDisabled}
           parameters={{
             instance: instanceParams || {
-              canCreateEntity: true,
-              canLinkEntity: true,
+              showCreateEntityAction: true,
+              showLinkEntityAction: true,
             },
           }}
         />
@@ -115,8 +115,8 @@ Note the alternative link actions injected via the `renderCustomActions` prop.
           isInitiallyDisabled={isInitiallyDisabled}
           parameters={{
             instance: instanceParams || {
-              canCreateEntity: true,
-              canLinkEntity: true,
+              showCreateEntityAction: true,
+              showLinkEntityAction: true,
             },
           }}
         />
@@ -150,8 +150,8 @@ Note the alternative link actions injected via the `renderCustomActions` prop.
           isInitiallyDisabled={isInitiallyDisabled}
           parameters={{
             instance: instanceParams || {
-              canCreateEntity: true,
-              canLinkEntity: true,
+              showCreateEntityAction: true,
+              showLinkEntityAction: true,
             },
           }}
         />
@@ -207,8 +207,8 @@ Same applies to `onLinkExisting` property that can be overriden to customize the
           isInitiallyDisabled={false}
           parameters={{
             instance: instanceParams || {
-              canCreateEntity: true,
-              canLinkEntity: true,
+              showCreateEntityAction: true,
+              showLinkEntityAction: true,
             },
           }}
         />
@@ -236,8 +236,8 @@ Same applies to `onLinkExisting` property that can be overriden to customize the
           isInitiallyDisabled={isInitiallyDisabled}
           parameters={{
             instance: instanceParams || {
-              canCreateEntity: true,
-              canLinkEntity: true,
+              showCreateEntityAction: true,
+              showLinkEntityAction: true,
             },
           }}
         />

--- a/packages/reference/src/entries/SingleEntryReferenceEditor.mdx
+++ b/packages/reference/src/entries/SingleEntryReferenceEditor.mdx
@@ -40,8 +40,8 @@ import { newReferenceEditorFakeSdk } from '../__fixtures__/FakeSdk'
           isInitiallyDisabled={false}
           parameters={{
             instance: {
-              canCreateEntity: true,
-              canLinkEntity: true
+              showCreateEntityAction: true,
+              showLinkEntityAction: true,
             }
           }}
          />
@@ -77,8 +77,8 @@ again to showcase inserting another reference rendered by the stardard card rend
           isInitiallyDisabled={false}
           parameters={{
             instance: instanceParams || {
-              canCreateEntity: true,
-              canLinkEntity: true
+              showCreateEntityAction: true,
+              showLinkEntityAction: true,
             }
           }}
          />
@@ -106,8 +106,8 @@ again to showcase inserting another reference rendered by the stardard card rend
           isInitiallyDisabled={false}
           parameters={{
             instance: instanceParams || {
-              canCreateEntity: true,
-              canLinkEntity: true
+              showCreateEntityAction: true,
+              showLinkEntityAction: true,
             }
           }}
         />


### PR DESCRIPTION
Fixes #741, previously we were using invalid reference editor instance parameters.