### PR TITLE
feat: disable table block insertion

### DIFF
--- a/cypress/integration/RichTextEditor.spec.ts
+++ b/cypress/integration/RichTextEditor.spec.ts
@@ -551,9 +551,9 @@ describe('Rich Text Editor', () => {
     const emptyParagraph = () => paragraphWithText('');
     const emptyCell = () => cell(emptyParagraph());
     const cellWithText = (t) => cell(paragraphWithText(t));
+    const insertTable = () => editor().type(`{${mod}}{,}`);
     const insertTableWithExampleData = () => {
-      editor()
-        .type(`{${mod}}{,}`)
+      insertTable()
         .typeInSlate('foo')
         .type('{rightArrow}')
         .typeInSlate('bar')
@@ -764,6 +764,48 @@ describe('Rich Text Editor', () => {
         .type(`{${mod}}{leftArrow}`)
 
       expectTableToBeDeleted();
+    });
+
+    it('disables block element toolbar buttons when selected', () => {
+      insertTable();
+
+      cy.findByTestId('quote-toolbar-button').should('be.disabled');
+      cy.findByTestId('ul-toolbar-button').should('be.disabled');
+      cy.findByTestId('ol-toolbar-button').should('be.disabled');
+      cy.findByTestId('hr-toolbar-button').should('be.disabled');
+
+      getDropdownToolbarButton().click();
+      [
+        BLOCKS.PARAGRAPH,
+        BLOCKS.HEADING_1,
+        BLOCKS.HEADING_2,
+        BLOCKS.HEADING_3,
+        BLOCKS.HEADING_4,
+        BLOCKS.HEADING_5,
+        BLOCKS.HEADING_6,
+      ].map((type) => getDropdownItem(type).get('button').should('be.disabled'));
+
+      // select outside the table
+      editor()
+        .click()
+        .type('{downArrow}')
+        .wait(100);
+
+      cy.findByTestId('quote-toolbar-button').should('not.be.disabled');
+      cy.findByTestId('ul-toolbar-button').should('not.be.disabled');
+      cy.findByTestId('ol-toolbar-button').should('not.be.disabled');
+      cy.findByTestId('list-toolbar-button').should('not.be.disabled');
+
+      getDropdownToolbarButton().click();
+      [
+        BLOCKS.PARAGRAPH,
+        BLOCKS.HEADING_1,
+        BLOCKS.HEADING_2,
+        BLOCKS.HEADING_3,
+        BLOCKS.HEADING_4,
+        BLOCKS.HEADING_5,
+        BLOCKS.HEADING_6,
+      ].map((type) => getDropdownItem(type).get('button').should('not.be.disabled'));
     });
   });
 });

--- a/packages/rich-text/src/Toolbar/index.tsx
+++ b/packages/rich-text/src/Toolbar/index.tsx
@@ -11,6 +11,9 @@ import { ToolbarCodeButton } from '../plugins/Code';
 import { ToolbarItalicButton } from '../plugins/Italic';
 import { ToolbarUnderlineButton } from '../plugins/Underline';
 import { ToolbarHyperlinkButton } from '../plugins/Hyperlink';
+import { SPEditor, useStoreEditor } from '@udecode/slate-plugins-core';
+import { BLOCKS } from '@contentful/rich-text-types';
+import { isNodeTypeSelected } from '../helpers/editor';
 
 type ToolbarProps = {
   isDisabled?: boolean;
@@ -36,10 +39,12 @@ const styles = {
 };
 
 const Toolbar = ({ isDisabled }: ToolbarProps) => {
+  const editor = useStoreEditor() as SPEditor;
+  const canInsertBlocks = !isNodeTypeSelected(editor, BLOCKS.TABLE);
   return (
     <EditorToolbar testId="toolbar">
       <div className={styles.formattingOptionsWrapper}>
-        <ToolbarHeadingButton isDisabled={isDisabled} />
+        <ToolbarHeadingButton isDisabled={isDisabled || !canInsertBlocks} />
 
         <EditorToolbarDivider />
 
@@ -54,9 +59,9 @@ const Toolbar = ({ isDisabled }: ToolbarProps) => {
 
         <EditorToolbarDivider />
 
-        <ToolbarQuoteButton isDisabled={isDisabled} />
-        <ToolbarListButton isDisabled={isDisabled} />
-        <ToolbarHrButton isDisabled={isDisabled} />
+        <ToolbarQuoteButton isDisabled={isDisabled || !canInsertBlocks} />
+        <ToolbarListButton isDisabled={isDisabled || !canInsertBlocks} />
+        <ToolbarHrButton isDisabled={isDisabled || !canInsertBlocks} />
       </div>
     </EditorToolbar>
   );

--- a/packages/rich-text/src/helpers/editor.ts
+++ b/packages/rich-text/src/helpers/editor.ts
@@ -42,6 +42,15 @@ export function getNodeEntryFromSelection(
   return [];
 }
 
+export function isNodeTypeSelected(
+  editor: SPEditor,
+  nodeType: BLOCKS | INLINES
+): boolean {
+  if (!editor) return false;
+  const [node] = getNodeEntryFromSelection(editor, nodeType);
+  return !!node;
+};
+
 export function moveToTheNextLine(editor) {
   Transforms.move(editor, { distance: 1 });
 }

--- a/packages/rich-text/src/plugins/Quote/index.tsx
+++ b/packages/rich-text/src/plugins/Quote/index.tsx
@@ -18,6 +18,7 @@ import {
   toggleBlock,
   hasSelectionText,
   getElementFromCurrentSelection,
+  isNodeTypeSelected,
 } from '../../helpers/editor';
 
 const styles = {
@@ -96,7 +97,7 @@ export function withQuoteEvents(editor: SPEditor) {
     const isOneKey = event.keyCode === 49;
 
     // shift + cmd/ctrl + 1 = shortcut to toggle blockquote
-    if (isMod && isShift && isOneKey) {
+    if (isMod && isShift && isOneKey && !isNodeTypeSelected(editor, BLOCKS.TABLE)) {
       createBlockQuote(editor);
     }
 


### PR DESCRIPTION
Disables the toolbar button and keyboard shortcuts for block element insertion within tables.