### PR TITLE
feat: fix non-unique checkbox labels for multiple editors

### DIFF
--- a/packages/checkbox/src/CheckboxEditor.spec.tsx
+++ b/packages/checkbox/src/CheckboxEditor.spec.tsx
@@ -122,4 +122,30 @@ describe('CheckboxEditor', () => {
     fireEvent.click(getByTestId('cf-ui-text-link'));
     expect(field.removeValue).toHaveBeenCalledTimes(1);
   });
+
+  it('renders checkboxes with unique ids', async () => {
+    const predefined = ['banana', 'orange', 'strawberry'];
+    const [field] = createFakeFieldAPI((mock) => {
+      return {
+        ...mock,
+        items: {
+          type: '',
+          validations: [{ in: predefined }],
+        },
+      };
+    });
+    const locales = createFakeLocalesAPI();
+    const { findAllByTestId } = render(
+      <div>
+        <CheckboxEditor field={field} locales={locales} isInitiallyDisabled={false} />
+        <CheckboxEditor field={field} locales={locales} isInitiallyDisabled={false} />
+      </div>
+    );
+
+    const $labels = await findAllByTestId('cf-ui-form-label');
+
+    expect($labels).toHaveLength(6);
+    const uniqueIds = Array.from(new Set($labels.map((label) => label.getAttribute('for'))));
+    expect(uniqueIds).toHaveLength(6);
+  });
 });

--- a/packages/checkbox/src/CheckboxEditor.spec.tsx
+++ b/packages/checkbox/src/CheckboxEditor.spec.tsx
@@ -143,8 +143,6 @@ describe('CheckboxEditor', () => {
     );
 
     const $labels = await findAllByTestId('cf-ui-form-label');
-
-    expect($labels).toHaveLength(6);
     const uniqueIds = Array.from(new Set($labels.map((label) => label.getAttribute('for'))));
     expect(uniqueIds).toHaveLength(6);
   });

--- a/packages/checkbox/src/CheckboxEditor.tsx
+++ b/packages/checkbox/src/CheckboxEditor.tsx
@@ -10,6 +10,7 @@ import {
 import { CheckboxField, Form, TextLink } from '@contentful/forma-36-react-components';
 import * as styles from './styles';
 import { nanoid } from 'nanoid';
+import { useMemo } from 'react';
 
 export interface CheckboxEditorProps {
   /**
@@ -78,7 +79,7 @@ const getInvalidValues = (
 export function CheckboxEditor(props: CheckboxEditorProps) {
   const { field, locales } = props;
 
-  const options = getOptions(field);
+  const options = useMemo(() => getOptions(field), [field]);
   const misconfigured = options.length === 0;
 
   if (misconfigured) {

--- a/packages/checkbox/src/CheckboxEditor.tsx
+++ b/packages/checkbox/src/CheckboxEditor.tsx
@@ -1,16 +1,16 @@
 import * as React from 'react';
+import { useState } from 'react';
 import { cx } from 'emotion';
 import get from 'lodash/get';
 import {
   FieldAPI,
-  LocalesAPI,
   FieldConnector,
+  LocalesAPI,
   PredefinedValuesError,
 } from '@contentful/field-editor-shared';
 import { CheckboxField, Form, TextLink } from '@contentful/forma-36-react-components';
 import * as styles from './styles';
 import { nanoid } from 'nanoid';
-import { useMemo } from 'react';
 
 export interface CheckboxEditorProps {
   /**
@@ -35,7 +35,7 @@ function isEmptyListValue(value: ListValue | null) {
   return value === null || value.length === 0;
 }
 
-export function getOptions(field: FieldAPI): CheckboxOption[] {
+function getOptions(field: FieldAPI, id: string): CheckboxOption[] {
   // Get first object that has a 'in' property
   const validations = get(field, ['items', 'validations'], []) as Record<
     string,
@@ -52,7 +52,7 @@ export function getOptions(field: FieldAPI): CheckboxOption[] {
 
   return firstPredefinedValues.map((value: string, index) => ({
     // Append a random id to distinguish between checkboxes opened in two editors (e.g. slide-in)
-    id: ['entity', field.id, field.locale, index, nanoid(6)].join('.'),
+    id: ['entity', field.id, field.locale, index, id].join('.'),
     value,
     label: value,
   }));
@@ -77,9 +77,10 @@ const getInvalidValues = (
 };
 
 export function CheckboxEditor(props: CheckboxEditorProps) {
+  const [id] = useState(() => nanoid(6));
   const { field, locales } = props;
 
-  const options = useMemo(() => getOptions(field), [field]);
+  const options = getOptions(field, id);
   const misconfigured = options.length === 0;
 
   if (misconfigured) {

--- a/packages/checkbox/src/CheckboxEditor.tsx
+++ b/packages/checkbox/src/CheckboxEditor.tsx
@@ -9,6 +9,7 @@ import {
 } from '@contentful/field-editor-shared';
 import { CheckboxField, Form, TextLink } from '@contentful/forma-36-react-components';
 import * as styles from './styles';
+import { nanoid } from 'nanoid';
 
 export interface CheckboxEditorProps {
   /**
@@ -44,12 +45,13 @@ export function getOptions(field: FieldAPI): CheckboxOption[] {
     .filter((validation) => validation.in)
     .map((validation) => validation.in);
 
-  const firstPredefinedValues = (predefinedValues.length > 0
-    ? predefinedValues[0]
-    : []) as string[];
+  const firstPredefinedValues = (
+    predefinedValues.length > 0 ? predefinedValues[0] : []
+  ) as string[];
 
   return firstPredefinedValues.map((value: string, index) => ({
-    id: ['entity', field.id, field.locale, index].join('.'),
+    // Append a random id to distinguish between checkboxes opened in two editors (e.g. slide-in)
+    id: ['entity', field.id, field.locale, index, nanoid(6)].join('.'),
     value,
     label: value,
   }));


### PR DESCRIPTION
Fixes non-unique labels of multiple checkbox editors, which was causing incorrect behavior when clicking on those labels.