### PR TITLE
feat: add serializer plugin for marks

### DIFF
--- a/packages/rich-text/package.json
+++ b/packages/rich-text/package.json
@@ -28,6 +28,7 @@
     "@contentful/rich-text-types": "^15.0.0",
     "@udecode/slate-plugins-common": "^1.0.0-alpha.25",
     "@udecode/slate-plugins-core": "^1.0.0-alpha.25",
+    "@udecode/slate-plugins-html-serializer": "^1.0.0-alpha.25",
     "@udecode/slate-plugins-list": "^1.0.0-alpha.25",
     "@udecode/slate-plugins-paragraph": "^1.0.0-alpha.25",
     "@udecode/slate-plugins-table": "^1.0.0-alpha.25",

--- a/packages/rich-text/src/RichTextEditor.tsx
+++ b/packages/rich-text/src/RichTextEditor.tsx
@@ -12,6 +12,7 @@ import StickyToolbarWrapper from './Toolbar/StickyToolbarWrapper';
 import { withListOptions } from './plugins/List';
 import { SlatePlugins, createHistoryPlugin, createReactPlugin } from '@udecode/slate-plugins-core';
 import { createListPlugin } from '@udecode/slate-plugins-list';
+import { createDeserializeHTMLPlugin } from '@udecode/slate-plugins-html-serializer';
 import { createHrPlugin, withHrOptions } from './plugins/Hr';
 import { withHeadingOptions, createHeadingPlugin } from './plugins/Heading';
 import { createBoldPlugin, withBoldOptions } from './plugins/Bold';
@@ -39,31 +40,35 @@ type ConnectedProps = {
   actionsDisabled?: boolean;
 };
 
-const getPlugins = (sdk: FieldExtensionSDK) => [
-  // Core
-  createReactPlugin(),
-  createHistoryPlugin(),
+const getPlugins = (sdk: FieldExtensionSDK) => {
+  const plugins = [
+    // Core
+    createReactPlugin(),
+    createHistoryPlugin(),
 
-  // Global shortcuts
-  createNewLinePlugin(),
+    // Global shortcuts
+    createNewLinePlugin(),
 
-  // Elements
-  createParagraphPlugin(),
-  createListPlugin(),
-  createHrPlugin(),
-  createHeadingPlugin(),
-  createQuotePlugin(),
-  createTablePlugin(),
+    // Elements
+    createParagraphPlugin(),
+    createListPlugin(),
+    createHrPlugin(),
+    createHeadingPlugin(),
+    createQuotePlugin(),
+    createTablePlugin(),
 
-  // Inline elements
-  createHyperlinkPlugin(sdk),
+    // Inline elements
+    createHyperlinkPlugin(sdk),
 
-  // Marks
-  createBoldPlugin(),
-  createCodePlugin(),
-  createItalicPlugin(),
-  createUnderlinePlugin(),
-];
+    // Marks
+    createBoldPlugin(),
+    createCodePlugin(),
+    createItalicPlugin(),
+    createUnderlinePlugin(),
+  ];
+
+  return [...plugins, createDeserializeHTMLPlugin({ plugins })];
+};
 
 const options = {
   // Elements

--- a/packages/rich-text/src/helpers/deserializer.ts
+++ b/packages/rich-text/src/helpers/deserializer.ts
@@ -1,4 +1,4 @@
-import { getSlatePluginOptions, SPEditor } from '@udecode/slate-plugins-core';
+import { getSlatePluginOptions, SPEditor, Deserialize } from '@udecode/slate-plugins-core';
 import { getLeafDeserializer } from '@udecode/slate-plugins-common';
 import { MARKS } from '@contentful/rich-text-types';
 
@@ -11,16 +11,26 @@ const leafRules = {
       },
     },
   ],
+  [MARKS.CODE]: [
+    { nodeNames: ['CODE', 'PRE'] },
+    {
+      style: {
+        fontFamily: ['monospace'],
+      },
+    },
+  ],
 };
 
-export function deserializeLeaf(editor: SPEditor, type: string, options = {}) {
-  const pluginOptions = getSlatePluginOptions(editor, type);
+export function deserializeLeaf(type: string, options = {}): Deserialize {
+  return function (editor: SPEditor) {
+    const pluginOptions = getSlatePluginOptions(editor, type);
 
-  return {
-    leaf: getLeafDeserializer({
-      rules: leafRules[type],
-      ...pluginOptions,
-      ...options,
-    }),
+    return {
+      leaf: getLeafDeserializer({
+        rules: leafRules[type],
+        ...pluginOptions,
+        ...options,
+      }),
+    };
   };
 }

--- a/packages/rich-text/src/helpers/deserializer.ts
+++ b/packages/rich-text/src/helpers/deserializer.ts
@@ -36,6 +36,14 @@ const leafRules: LeafRules = {
       },
     },
   ],
+  [MARKS.UNDERLINE]: [
+    { nodeNames: ['u'] },
+    {
+      style: {
+        textDecoration: ['underline'],
+      },
+    },
+  ],
 };
 
 export function deserializeLeaf(type: string, options = {}): Deserialize {

--- a/packages/rich-text/src/helpers/deserializer.ts
+++ b/packages/rich-text/src/helpers/deserializer.ts
@@ -29,7 +29,7 @@ const leafRules: LeafRules = {
     },
   ],
   [MARKS.ITALIC]: [
-    { nodeNames: ['I'] },
+    { nodeNames: ['I', 'EM'] },
     {
       style: {
         fontStyle: ['italic'],

--- a/packages/rich-text/src/helpers/deserializer.ts
+++ b/packages/rich-text/src/helpers/deserializer.ts
@@ -5,56 +5,15 @@ import {
   GetNodeDeserializerRule,
 } from '@udecode/slate-plugins-core';
 import { getLeafDeserializer } from '@udecode/slate-plugins-common';
-import { MARKS } from '@contentful/rich-text-types';
 
-type LeafRules = {
-  [key: string]: GetNodeDeserializerRule[];
-};
-
-const leafRules: LeafRules = {
-  [MARKS.BOLD]: [
-    { nodeNames: ['STRONG'] },
-    {
-      style: {
-        fontWeight: ['600', '700', 'bold'],
-      },
-    },
-  ],
-  [MARKS.CODE]: [
-    { nodeNames: ['CODE', 'PRE'] },
-    {
-      style: {
-        fontFamily: ['monospace'],
-      },
-    },
-  ],
-  [MARKS.ITALIC]: [
-    { nodeNames: ['I', 'EM'] },
-    {
-      style: {
-        fontStyle: ['italic'],
-      },
-    },
-  ],
-  [MARKS.UNDERLINE]: [
-    { nodeNames: ['u'] },
-    {
-      style: {
-        textDecoration: ['underline'],
-      },
-    },
-  ],
-};
-
-export function deserializeLeaf(type: string, options = {}): Deserialize {
+export function deserializeLeaf(type: string, rules: GetNodeDeserializerRule[]): Deserialize {
   return function (editor: SPEditor) {
     const pluginOptions = getSlatePluginOptions(editor, type);
 
     return {
       leaf: getLeafDeserializer({
-        rules: leafRules[type],
+        rules,
         ...pluginOptions,
-        ...options,
       }),
     };
   };

--- a/packages/rich-text/src/helpers/deserializer.ts
+++ b/packages/rich-text/src/helpers/deserializer.ts
@@ -1,8 +1,17 @@
-import { getSlatePluginOptions, SPEditor, Deserialize } from '@udecode/slate-plugins-core';
+import {
+  getSlatePluginOptions,
+  SPEditor,
+  Deserialize,
+  GetNodeDeserializerRule,
+} from '@udecode/slate-plugins-core';
 import { getLeafDeserializer } from '@udecode/slate-plugins-common';
 import { MARKS } from '@contentful/rich-text-types';
 
-const leafRules = {
+type LeafRules = {
+  [key: string]: GetNodeDeserializerRule[];
+};
+
+const leafRules: LeafRules = {
   [MARKS.BOLD]: [
     { nodeNames: ['STRONG'] },
     {
@@ -16,6 +25,14 @@ const leafRules = {
     {
       style: {
         fontFamily: ['monospace'],
+      },
+    },
+  ],
+  [MARKS.ITALIC]: [
+    { nodeNames: ['I'] },
+    {
+      style: {
+        fontStyle: ['italic'],
       },
     },
   ],

--- a/packages/rich-text/src/helpers/deserializer.ts
+++ b/packages/rich-text/src/helpers/deserializer.ts
@@ -1,0 +1,26 @@
+import { getSlatePluginOptions, SPEditor } from '@udecode/slate-plugins-core';
+import { getLeafDeserializer } from '@udecode/slate-plugins-common';
+import { MARKS } from '@contentful/rich-text-types';
+
+const leafRules = {
+  [MARKS.BOLD]: [
+    { nodeNames: ['STRONG'] },
+    {
+      style: {
+        fontWeight: ['600', '700', 'bold'],
+      },
+    },
+  ],
+};
+
+export function deserializeLeaf(editor: SPEditor, type: string, options = {}) {
+  const pluginOptions = getSlatePluginOptions(editor, type);
+
+  return {
+    leaf: getLeafDeserializer({
+      rules: leafRules[type],
+      ...pluginOptions,
+      ...options,
+    }),
+  };
+}

--- a/packages/rich-text/src/plugins/Bold/index.tsx
+++ b/packages/rich-text/src/plugins/Bold/index.tsx
@@ -6,7 +6,6 @@ import { MARKS } from '@contentful/rich-text-types';
 import { getToggleMarkOnKeyDown, isMarkActive, toggleMark } from '@udecode/slate-plugins-common';
 import { EditorToolbarButton } from '@contentful/forma-36-react-components';
 import { CustomSlatePluginOptions } from 'types';
-import { deserializeLeaf } from '../../helpers/deserializer';
 
 interface ToolbarBoldButtonProps {
   isDisabled?: boolean;
@@ -56,7 +55,30 @@ export function createBoldPlugin(): SlatePlugin {
     pluginKeys: MARKS.BOLD,
     renderLeaf: getRenderLeaf(MARKS.BOLD),
     onKeyDown: getToggleMarkOnKeyDown(MARKS.BOLD),
-    deserialize: deserializeLeaf(MARKS.BOLD),
+    deserialize: () => {
+      return {
+        leaf: [
+          {
+            type: MARKS.BOLD,
+            deserialize: (element) => {
+              // We ignore it otherwise everything will be bold
+              const isGoogleBoldWrapper =
+                element.id.startsWith('docs-internal-guid') && element.tagName === 'B';
+
+              const isBold =
+                ['600', '700', 'bold'].includes(element.style.fontWeight) ||
+                ['STRONG', 'B'].includes(element.tagName);
+
+              if (isGoogleBoldWrapper || !isBold) return undefined;
+
+              return {
+                [MARKS.BOLD]: true,
+              };
+            },
+          },
+        ],
+      };
+    },
   };
 }
 

--- a/packages/rich-text/src/plugins/Bold/index.tsx
+++ b/packages/rich-text/src/plugins/Bold/index.tsx
@@ -6,6 +6,7 @@ import { MARKS } from '@contentful/rich-text-types';
 import { getToggleMarkOnKeyDown, isMarkActive, toggleMark } from '@udecode/slate-plugins-common';
 import { EditorToolbarButton } from '@contentful/forma-36-react-components';
 import { CustomSlatePluginOptions } from 'types';
+import { deserializeLeaf } from '../../helpers/deserializer';
 
 interface ToolbarBoldButtonProps {
   isDisabled?: boolean;
@@ -55,6 +56,7 @@ export function createBoldPlugin(): SlatePlugin {
     pluginKeys: MARKS.BOLD,
     renderLeaf: getRenderLeaf(MARKS.BOLD),
     onKeyDown: getToggleMarkOnKeyDown(MARKS.BOLD),
+    deserialize: (editor) => deserializeLeaf(editor, MARKS.BOLD),
   };
 }
 

--- a/packages/rich-text/src/plugins/Bold/index.tsx
+++ b/packages/rich-text/src/plugins/Bold/index.tsx
@@ -56,7 +56,7 @@ export function createBoldPlugin(): SlatePlugin {
     pluginKeys: MARKS.BOLD,
     renderLeaf: getRenderLeaf(MARKS.BOLD),
     onKeyDown: getToggleMarkOnKeyDown(MARKS.BOLD),
-    deserialize: (editor) => deserializeLeaf(editor, MARKS.BOLD),
+    deserialize: deserializeLeaf(MARKS.BOLD),
   };
 }
 

--- a/packages/rich-text/src/plugins/Code/index.tsx
+++ b/packages/rich-text/src/plugins/Code/index.tsx
@@ -6,6 +6,7 @@ import { MARKS } from '@contentful/rich-text-types';
 import { getToggleMarkOnKeyDown, isMarkActive, toggleMark } from '@udecode/slate-plugins-common';
 import { EditorToolbarButton } from '@contentful/forma-36-react-components';
 import { CustomSlatePluginOptions } from 'types';
+import { deserializeLeaf } from '../../helpers/deserializer';
 
 interface ToolbarCodeButtonProps {
   isDisabled?: boolean;
@@ -56,6 +57,7 @@ export function createCodePlugin(): SlatePlugin {
     pluginKeys: MARKS.CODE,
     renderLeaf: getRenderLeaf(MARKS.CODE),
     onKeyDown: getToggleMarkOnKeyDown(MARKS.CODE),
+    deserialize: deserializeLeaf(MARKS.CODE),
   };
 }
 

--- a/packages/rich-text/src/plugins/Code/index.tsx
+++ b/packages/rich-text/src/plugins/Code/index.tsx
@@ -1,7 +1,12 @@
 import * as React from 'react';
 import * as Slate from 'slate-react';
 import { css } from 'emotion';
-import { SlatePlugin, getRenderLeaf, useStoreEditor } from '@udecode/slate-plugins-core';
+import {
+  SlatePlugin,
+  getRenderLeaf,
+  useStoreEditor,
+  GetNodeDeserializerRule,
+} from '@udecode/slate-plugins-core';
 import { MARKS } from '@contentful/rich-text-types';
 import { getToggleMarkOnKeyDown, isMarkActive, toggleMark } from '@udecode/slate-plugins-common';
 import { EditorToolbarButton } from '@contentful/forma-36-react-components';
@@ -53,11 +58,20 @@ export function Code(props: Slate.RenderLeafProps) {
 }
 
 export function createCodePlugin(): SlatePlugin {
+  const deserializeRule: GetNodeDeserializerRule[] = [
+    { nodeNames: ['CODE', 'PRE'] },
+    {
+      style: {
+        fontFamily: ['monospace'],
+      },
+    },
+  ];
+
   return {
     pluginKeys: MARKS.CODE,
     renderLeaf: getRenderLeaf(MARKS.CODE),
     onKeyDown: getToggleMarkOnKeyDown(MARKS.CODE),
-    deserialize: deserializeLeaf(MARKS.CODE),
+    deserialize: deserializeLeaf(MARKS.CODE, deserializeRule),
   };
 }
 

--- a/packages/rich-text/src/plugins/Italic/index.tsx
+++ b/packages/rich-text/src/plugins/Italic/index.tsx
@@ -1,7 +1,12 @@
 import * as React from 'react';
 import * as Slate from 'slate-react';
 import { css } from 'emotion';
-import { SlatePlugin, getRenderLeaf, useStoreEditor } from '@udecode/slate-plugins-core';
+import {
+  SlatePlugin,
+  getRenderLeaf,
+  useStoreEditor,
+  GetNodeDeserializerRule,
+} from '@udecode/slate-plugins-core';
 import { getToggleMarkOnKeyDown, toggleMark, isMarkActive } from '@udecode/slate-plugins-common';
 import { MARKS } from '@contentful/rich-text-types';
 import { EditorToolbarButton } from '@contentful/forma-36-react-components';
@@ -52,11 +57,20 @@ export function Italic(props: Slate.RenderLeafProps) {
 }
 
 export function createItalicPlugin(): SlatePlugin {
+  const deserializeRules: GetNodeDeserializerRule[] = [
+    { nodeNames: ['I', 'EM'] },
+    {
+      style: {
+        fontStyle: ['italic'],
+      },
+    },
+  ];
+
   return {
     pluginKeys: MARKS.ITALIC,
     renderLeaf: getRenderLeaf(MARKS.ITALIC),
     onKeyDown: getToggleMarkOnKeyDown(MARKS.ITALIC),
-    deserialize: deserializeLeaf(MARKS.ITALIC),
+    deserialize: deserializeLeaf(MARKS.ITALIC, deserializeRules),
   };
 }
 

--- a/packages/rich-text/src/plugins/Italic/index.tsx
+++ b/packages/rich-text/src/plugins/Italic/index.tsx
@@ -6,6 +6,7 @@ import { getToggleMarkOnKeyDown, toggleMark, isMarkActive } from '@udecode/slate
 import { MARKS } from '@contentful/rich-text-types';
 import { EditorToolbarButton } from '@contentful/forma-36-react-components';
 import { CustomSlatePluginOptions } from 'types';
+import { deserializeLeaf } from '../../helpers/deserializer';
 
 interface ToolbarItalicButtonProps {
   isDisabled?: boolean;
@@ -55,6 +56,7 @@ export function createItalicPlugin(): SlatePlugin {
     pluginKeys: MARKS.ITALIC,
     renderLeaf: getRenderLeaf(MARKS.ITALIC),
     onKeyDown: getToggleMarkOnKeyDown(MARKS.ITALIC),
+    deserialize: deserializeLeaf(MARKS.ITALIC),
   };
 }
 

--- a/packages/rich-text/src/plugins/Underline/index.tsx
+++ b/packages/rich-text/src/plugins/Underline/index.tsx
@@ -1,6 +1,11 @@
 import * as React from 'react';
 import * as Slate from 'slate-react';
-import { SlatePlugin, getRenderLeaf, useStoreEditor } from '@udecode/slate-plugins-core';
+import {
+  SlatePlugin,
+  getRenderLeaf,
+  useStoreEditor,
+  GetNodeDeserializerRule,
+} from '@udecode/slate-plugins-core';
 import { MARKS } from '@contentful/rich-text-types';
 import { getToggleMarkOnKeyDown, toggleMark, isMarkActive } from '@udecode/slate-plugins-common';
 import { EditorToolbarButton } from '@contentful/forma-36-react-components';
@@ -41,11 +46,20 @@ export function Underline(props: Slate.RenderLeafProps) {
 }
 
 export function createUnderlinePlugin(): SlatePlugin {
+  const deserializeRules: GetNodeDeserializerRule[] = [
+    { nodeNames: ['U'] },
+    {
+      style: {
+        textDecoration: ['underline'],
+      },
+    },
+  ];
+
   return {
     pluginKeys: MARKS.UNDERLINE,
     renderLeaf: getRenderLeaf(MARKS.UNDERLINE),
     onKeyDown: getToggleMarkOnKeyDown(MARKS.UNDERLINE),
-    deserialize: deserializeLeaf(MARKS.UNDERLINE),
+    deserialize: deserializeLeaf(MARKS.UNDERLINE, deserializeRules),
   };
 }
 

--- a/packages/rich-text/src/plugins/Underline/index.tsx
+++ b/packages/rich-text/src/plugins/Underline/index.tsx
@@ -5,6 +5,7 @@ import { MARKS } from '@contentful/rich-text-types';
 import { getToggleMarkOnKeyDown, toggleMark, isMarkActive } from '@udecode/slate-plugins-common';
 import { EditorToolbarButton } from '@contentful/forma-36-react-components';
 import { CustomSlatePluginOptions } from 'types';
+import { deserializeLeaf } from '../../helpers/deserializer';
 
 interface ToolbarUnderlineButtonProps {
   isDisabled?: boolean;
@@ -44,6 +45,7 @@ export function createUnderlinePlugin(): SlatePlugin {
     pluginKeys: MARKS.UNDERLINE,
     renderLeaf: getRenderLeaf(MARKS.UNDERLINE),
     onKeyDown: getToggleMarkOnKeyDown(MARKS.UNDERLINE),
+    deserialize: deserializeLeaf(MARKS.UNDERLINE),
   };
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4100,6 +4100,14 @@
     lodash "^4.17.21"
     zustand "^3.3.2"
 
+"@udecode/slate-plugins-html-serializer@^1.0.0-alpha.25":
+  version "1.0.0-alpha.25"
+  resolved "https://registry.yarnpkg.com/@udecode/slate-plugins-html-serializer/-/slate-plugins-html-serializer-1.0.0-alpha.25.tgz#2b91a5f57c7dbc05aaa587efe04438cbb9fa28b6"
+  integrity sha512-t0n1coXm4pgSTNUfMaDnLKOQiLuMs+Ip9eYmTzCdH4z7VVB0CIZd81qFAWZv+WIZeMEjxLTMNW/SFdectnzw4Q==
+  dependencies:
+    "@udecode/slate-plugins-common" "^1.0.0-alpha.25"
+    "@udecode/slate-plugins-core" "^1.0.0-alpha.25"
+
 "@udecode/slate-plugins-list@^1.0.0-alpha.25":
   version "1.0.0-alpha.25"
   resolved "https://registry.yarnpkg.com/@udecode/slate-plugins-list/-/slate-plugins-list-1.0.0-alpha.25.tgz#e894aa0cdde5060dd3f3ab62d5715e9abfa3f79f"


### PR DESCRIPTION
~~**Cypress tests are coming.**~~

Cypress doesn't support really well copying & pasting so we decided to skip it. Unit tests were also taken into consideration but we decided not to do it as well because we would be testing SlateJS functions only.

**Google Docs**
![image](https://user-images.githubusercontent.com/954889/126766873-7b3ee7e8-343a-4ba4-96f8-fa9e58afa75e.png)

**Result**
![image](https://user-images.githubusercontent.com/954889/126766937-984a0bf4-b4fb-4137-87e5-b17512c3722f.png)

