### PR TITLE
chore: auto publish alpha Rich Text package

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,8 +75,8 @@ jobs:
       - run: git config --global user.name "contentful-ecosystem-bot"
       - yarn_install
       - run: yarn build
-      - run: yarn lerna version --no-private --conventional-commits --create-release github --yes
-      - run: yarn lerna publish from-git --yes
+      - run: yarn lerna version --no-private --conventional-commits --conventional-prerelease --create-release github --yes
+      - run: yarn lerna publish from-git --yes --dist-tag next
 
 workflows:
   version: 2
@@ -89,7 +89,9 @@ workflows:
       - release:
           filters:
             branches:
-              only: master
+              only:
+                - master
+                - next
           requires:
             - lint
             - unit-tests

--- a/lerna.json
+++ b/lerna.json
@@ -5,7 +5,7 @@
   "workspaces": ["packages/**", "extensions/**"],
   "command": {
     "version": {
-      "allowBranch": "master",
+      "allowBranch": ["master", "next"],
       "conventionalCommits": true,
       "message": "chore(release): updated release notes and package versions [ci skip]",
       "ignoreChanges": [

--- a/packages/rich-text/package.json
+++ b/packages/rich-text/package.json
@@ -54,5 +54,8 @@
     "@babel/preset-env": "7.12.11",
     "@babel/preset-react": "7.13.13",
     "@contentful/rich-text-react-renderer": "^14.1.3"
+  },
+  "publishConfig": {
+    "tag": "next"
   }
 }


### PR DESCRIPTION
Auto publishes packages in the `next` branch just like in master with a few exceptions:
* Packages should be published with `next` tag
* Github Releases should be marked as `prerelease` 

