### PR TITLE
fix: render dropdown list or fragment

### DIFF
--- a/packages/reference/src/entries/WrappedEntryCard/WrappedEntryCard.tsx
+++ b/packages/reference/src/entries/WrappedEntryCard/WrappedEntryCard.tsx
@@ -156,7 +156,7 @@ export function WrappedEntryCard(props: WrappedEntryCardProps) {
                 </DropdownListItem>
               )}
             </DropdownList>
-            {props.hasMoveOptions && (
+            {props.hasMoveOptions ? (
               <DropdownList
                 border="top"
                 // @ts-expect-error
@@ -176,7 +176,7 @@ export function WrappedEntryCard(props: WrappedEntryCardProps) {
                   Move to bottom
                 </DropdownListItem>
               </DropdownList>
-            )}
+            ) : <React.Fragment />}
           </React.Fragment>
         ) : undefined
       }


### PR DESCRIPTION
Fixes https://github.com/contentful/field-editors/pull/784

For reasons not obvious to me, `false` actually causes this to fail with

```
TypeError: Cannot read property 'type' of null
```

I confess I am not sure why this solution works (ternary to default `undefined` or anything else falsy has the same problem), but it's low cost and accomplishes basically the same thing with the same DOM markup in the end. If anyone has any further suggestions / thoughts, I am open.