### PR TITLE
feat: add embedded entity inline

### DIFF
--- a/cypress/integration/RichTextEditor.spec.ts
+++ b/cypress/integration/RichTextEditor.spec.ts
@@ -1145,17 +1145,13 @@ describe('Rich Text Editor', () => {
           cy.wait(100);
         },
       ],
-
-      // TODO:
-      // This works in the browser, but not in Cypress. Maybe upgrading will help.
-      // For now, it's okay to ensure addition via the toolbar button works.
-      // [
-      //   'using the keyboard shortcut',
-      //   () => {
-      //     editor().type(`{${mod}}{shift}a`);
-      //     cy.wait(100);
-      //   }
-      // ]
+      [
+        'using the keyboard shortcut',
+        () => {
+          editor().type(`{${mod}}{shift}a`);
+          cy.wait(100);
+        }
+      ]
     ];
 
     for (const [triggerMethod, triggerEmbeddedAsset] of methods) {
@@ -1224,6 +1220,79 @@ describe('Rich Text Editor', () => {
               block(BLOCKS.PARAGRAPH, {}, text('bar')),
             )
           );
+        });
+      });
+    }
+  });
+
+  describe('Embedded Entry Inlines', () => {
+    const methods: [string, () => void][] = [
+      [
+        'using the toolbar button',
+        () => {
+          cy.findByTestId('toolbar-entity-dropdown-toggle').click();
+          cy.findByTestId('toolbar-toggle-embedded-entry-inline').click();
+          cy.wait(100);
+        },
+      ],
+      [
+        'using the keyboard shortcut',
+        () => {
+          editor().type(`{${mod}}{shift}2`);
+          cy.wait(100);
+        }
+      ]
+    ];
+
+    for (const [triggerMethod, triggerEmbeddedAsset] of methods) {
+      describe(triggerMethod, () => {
+        it('adds and removes embedded entries', () => {
+          editor().click().typeInSlate('hello')
+          triggerEmbeddedAsset();
+          editor().click().typeInSlate('world')
+
+          cy.wait(500);
+
+          expectRichTextFieldValue(
+            doc(
+              block(
+                BLOCKS.PARAGRAPH,
+                {},
+                text('hello'),
+                inline(
+                  INLINES.EMBEDDED_ENTRY,
+                  {
+                    target: {
+                      sys: {
+                        id: 'example-entity-id',
+                        type: 'Link',
+                        linkType: 'Entry',
+                      },
+                    },
+                  },
+                ),
+                text('world')),
+            )
+          );
+
+          cy.findByTestId('cf-ui-card-actions').findByTestId('cf-ui-icon-button').click();
+          cy.findByTestId('card-action-remove').click();
+
+          cy.wait(500);
+
+          expectRichTextFieldValue(
+            doc(
+              block(
+                BLOCKS.PARAGRAPH,
+                {},
+                text('hello'),
+                text('world')
+              ),
+            )
+          );
+
+          // TODO: we should also test deletion via {backspace},
+          // but this breaks in cypress even though it works in the editor
         });
       });
     }

--- a/packages/rich-text/package.json
+++ b/packages/rich-text/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@contentful/contentful-slatejs-adapter": "^14.2.0",
-    "@contentful/field-editor-reference": "^2.13.1",
+    "@contentful/field-editor-reference": "^2.20.1",
     "@contentful/rich-text-types": "^15.0.0",
     "@udecode/slate-plugins-common": "^1.0.0-alpha.25",
     "@udecode/slate-plugins-core": "^1.0.0-alpha.25",

--- a/packages/rich-text/src/RichTextEditor.tsx
+++ b/packages/rich-text/src/RichTextEditor.tsx
@@ -30,9 +30,13 @@ import {
   withEmbeddedAssetBlockOptions,
   withEmbeddedEntryBlockOptions,
 } from './plugins/EmbeddedEntityBlock';
+import {
+  createEmbeddedEntityInlinePlugin,
+  withEmbeddedEntityInlineOptions,
+} from './plugins/EmbeddedEntityInline';
 import { SdkProvider } from './SdkProvider';
 import { sanitizeIncomingSlateDoc, sanitizeSlateDoc } from './helpers/sanitizeSlateDoc';
-import { TextOrCustomElement } from 'types';
+import { TextOrCustomElement } from './types';
 
 type ConnectedProps = {
   editorId?: string;
@@ -67,6 +71,7 @@ const getPlugins = (sdk: FieldExtensionSDK) => {
 
     // Inline elements
     createHyperlinkPlugin(sdk),
+    createEmbeddedEntityInlinePlugin(),
 
     // Marks
     createBoldPlugin(),
@@ -91,6 +96,7 @@ const options = {
 
   // Inline elements
   ...withHyperlinkOptions,
+  ...withEmbeddedEntityInlineOptions,
 
   // Marks
   ...withBoldOptions,

--- a/packages/rich-text/src/RichTextEditor.tsx
+++ b/packages/rich-text/src/RichTextEditor.tsx
@@ -10,7 +10,7 @@ import deepEquals from 'fast-deep-equal';
 import Toolbar from './Toolbar';
 import StickyToolbarWrapper from './Toolbar/StickyToolbarWrapper';
 import { withListOptions } from './plugins/List';
-import { SlatePlugins, createHistoryPlugin, createReactPlugin } from '@udecode/slate-plugins-core';
+import { SlatePlugins, createHistoryPlugin, createReactPlugin, SlatePlugin, SPEditor } from '@udecode/slate-plugins-core';
 import { createListPlugin } from '@udecode/slate-plugins-list';
 import { createDeserializeHTMLPlugin } from '@udecode/slate-plugins-html-serializer';
 import { createHrPlugin, withHrOptions } from './plugins/Hr';
@@ -71,7 +71,7 @@ const getPlugins = (sdk: FieldExtensionSDK) => {
 
     // Inline elements
     createHyperlinkPlugin(sdk),
-    createEmbeddedEntityInlinePlugin(),
+    createEmbeddedEntityInlinePlugin(sdk),
 
     // Marks
     createBoldPlugin(),
@@ -80,7 +80,9 @@ const getPlugins = (sdk: FieldExtensionSDK) => {
     createUnderlinePlugin(),
   ];
 
-  return [...plugins, createDeserializeHTMLPlugin({ plugins })];
+  return plugins.concat([
+    createDeserializeHTMLPlugin({ plugins })
+  ] as SlatePlugin<SPEditor>[]);
 };
 
 const options = {

--- a/packages/rich-text/src/RichTextEditor.tsx
+++ b/packages/rich-text/src/RichTextEditor.tsx
@@ -10,7 +10,13 @@ import deepEquals from 'fast-deep-equal';
 import Toolbar from './Toolbar';
 import StickyToolbarWrapper from './Toolbar/StickyToolbarWrapper';
 import { withListOptions } from './plugins/List';
-import { SlatePlugins, createHistoryPlugin, createReactPlugin, SlatePlugin, SPEditor } from '@udecode/slate-plugins-core';
+import {
+  SlatePlugins,
+  createHistoryPlugin,
+  createReactPlugin,
+  SlatePlugin,
+  SPEditor,
+} from '@udecode/slate-plugins-core';
 import { createListPlugin } from '@udecode/slate-plugins-list';
 import { createDeserializeHTMLPlugin } from '@udecode/slate-plugins-html-serializer';
 import { createHrPlugin, withHrOptions } from './plugins/Hr';
@@ -80,9 +86,7 @@ const getPlugins = (sdk: FieldExtensionSDK) => {
     createUnderlinePlugin(),
   ];
 
-  return plugins.concat([
-    createDeserializeHTMLPlugin({ plugins })
-  ] as SlatePlugin<SPEditor>[]);
+  return plugins.concat([createDeserializeHTMLPlugin({ plugins })] as SlatePlugin<SPEditor>[]);
 };
 
 const options = {

--- a/packages/rich-text/src/RichTextEditor.tsx
+++ b/packages/rich-text/src/RichTextEditor.tsx
@@ -126,6 +126,7 @@ const ConnectedRichTextEditor = (props: ConnectedProps) => {
         plugins={plugins}
         editableProps={{
           className: classNames,
+          readOnly: props.isDisabled,
         }}
         onChange={(newValue) => {
           const slateDoc = sanitizeSlateDoc(newValue as TextOrCustomElement[]);

--- a/packages/rich-text/src/Toolbar/index.tsx
+++ b/packages/rich-text/src/Toolbar/index.tsx
@@ -17,6 +17,7 @@ import { ToolbarIcon as EmbeddedEntityBlockToolbarIcon } from '../plugins/Embedd
 import { SPEditor, useStoreEditor } from '@udecode/slate-plugins-core';
 import { BLOCKS } from '@contentful/rich-text-types';
 import { isNodeTypeSelected } from '../helpers/editor';
+import { ToolbarEmbeddedEntityInlineButton } from '../plugins/EmbeddedEntityInline';
 
 type ToolbarProps = {
   isDisabled?: boolean;
@@ -81,6 +82,10 @@ const Toolbar = ({ isDisabled }: ToolbarProps) => {
           <EmbeddedEntityBlockToolbarIcon
             isDisabled={!!isDisabled}
             nodeType={BLOCKS.EMBEDDED_ENTRY}
+            onClose={onCloseEntityDropdown}
+          />
+          <ToolbarEmbeddedEntityInlineButton
+            isDisabled={!!isDisabled}
             onClose={onCloseEntityDropdown}
           />
           <EmbeddedEntityBlockToolbarIcon

--- a/packages/rich-text/src/plugins/EmbeddedEntityBlock/LinkedEntityBlock.tsx
+++ b/packages/rich-text/src/plugins/EmbeddedEntityBlock/LinkedEntityBlock.tsx
@@ -5,7 +5,7 @@ import { FetchingWrappedAssetCard } from '../shared/FetchingWrappedAssetCard';
 import { useSdkContext } from '../../SdkProvider';
 import { useStoreEditor } from '@udecode/slate-plugins-core';
 import { CustomElement } from 'types';
-import { ReactEditor, useSelected } from 'slate-react';
+import { ReactEditor, useSelected, useReadOnly } from 'slate-react';
 import { Transforms } from 'slate';
 
 const styles = {
@@ -38,6 +38,7 @@ export function LinkedEntityBlock(props: LinkedEntityBlockProps) {
   const isSelected = useSelected();
   const editor = useStoreEditor();
   const sdk = useSdkContext();
+  const isDisabled = useReadOnly();
   const { id: entityId, linkType: entityType } = element.data.target.sys;
 
   const handleEditClick = () => {
@@ -51,8 +52,6 @@ export function LinkedEntityBlock(props: LinkedEntityBlockProps) {
     Transforms.removeNodes(editor, { at: pathToElement });
   };
 
-  // TODO: fixme -- props not available on new editor
-  const isDisabled = false; // editor.props.readOnly || editor.props.actionsDisabled;
   return (
     <div {...attributes} className={styles.root}>
       <div contentEditable={false}>

--- a/packages/rich-text/src/plugins/EmbeddedEntityBlock/index.tsx
+++ b/packages/rich-text/src/plugins/EmbeddedEntityBlock/index.tsx
@@ -35,7 +35,7 @@ export const withEmbeddedAssetBlockOptions: CustomSlatePluginOptions = {
   },
 };
 
-type A = 64;
+type A = 65;
 type E = 69;
 type AEvent = KeyboardEvent & { keyCode: A };
 type EEvent = KeyboardEvent & { keyCode: E };
@@ -46,7 +46,7 @@ type ModEvent = CtrlEvent | MetaEvent;
 type EmbeddedAssetEvent = ModEvent & ShiftEvent & AEvent;
 type EmbeddedEntryEvent = ModEvent & ShiftEvent & EEvent;
 
-const isA = (event: KeyboardEvent): event is AEvent => event.keyCode === 64;
+const isA = (event: KeyboardEvent): event is AEvent => event.keyCode === 65;
 const isE = (event: KeyboardEvent): event is EEvent => event.keyCode === 69;
 const isMod = (event: KeyboardEvent): event is ModEvent => event.ctrlKey || event.metaKey;
 const isShift = (event: KeyboardEvent): event is ShiftEvent => event.shiftKey;

--- a/packages/rich-text/src/plugins/EmbeddedEntityInline/FetchingWrappedInlineEntryCard.tsx
+++ b/packages/rich-text/src/plugins/EmbeddedEntityInline/FetchingWrappedInlineEntryCard.tsx
@@ -87,10 +87,16 @@ export function FetchingWrappedInlineEntryCard(props: FetchingWrappedInlineEntry
       status={status}
       dropdownListElements={
         <DropdownList>
-          <DropdownListItem onClick={props.onEdit} isDisabled={props.isDisabled}>
+          <DropdownListItem
+            onClick={props.onEdit}
+            isDisabled={props.isDisabled}
+            testId="card-action-edit">
             Edit
           </DropdownListItem>
-          <DropdownListItem onClick={props.onRemove} isDisabled={props.isDisabled}>
+          <DropdownListItem
+            onClick={props.onRemove}
+            isDisabled={props.isDisabled}
+            testId="card-action-remove">
             Remove
           </DropdownListItem>
         </DropdownList>

--- a/packages/rich-text/src/plugins/EmbeddedEntityInline/FetchingWrappedInlineEntryCard.tsx
+++ b/packages/rich-text/src/plugins/EmbeddedEntityInline/FetchingWrappedInlineEntryCard.tsx
@@ -51,13 +51,16 @@ export function FetchingWrappedInlineEntryCard(props: FetchingWrappedInlineEntry
         defaultLocaleCode: props.sdk.locales.default,
         defaultTitle: 'Untitled',
       }),
-    [entry, contentType, props.sdk]
+    [entry, contentType, props.sdk.field.locale, props.sdk.locales.default]
   );
 
   React.useEffect(() => {
     if (!props.entryId) return;
     getOrLoadEntry(props.entryId);
-  }, [props.entryId]); // eslint-disable-line
+  // We don't include getOrLoadEntry below because it's part of the constate-derived
+  // useEntities(), not props.
+  // eslint-disable-next-line
+  }, [props.entryId]);
 
   if (entry === 'failed') {
     return (

--- a/packages/rich-text/src/plugins/EmbeddedEntityInline/FetchingWrappedInlineEntryCard.tsx
+++ b/packages/rich-text/src/plugins/EmbeddedEntityInline/FetchingWrappedInlineEntryCard.tsx
@@ -57,9 +57,9 @@ export function FetchingWrappedInlineEntryCard(props: FetchingWrappedInlineEntry
   React.useEffect(() => {
     if (!props.entryId) return;
     getOrLoadEntry(props.entryId);
-  // We don't include getOrLoadEntry below because it's part of the constate-derived
-  // useEntities(), not props.
-  // eslint-disable-next-line
+    // We don't include getOrLoadEntry below because it's part of the constate-derived
+    // useEntities(), not props.
+    // eslint-disable-next-line
   }, [props.entryId]);
 
   if (entry === 'failed') {

--- a/packages/rich-text/src/plugins/EmbeddedEntityInline/FetchingWrappedInlineEntryCard.tsx
+++ b/packages/rich-text/src/plugins/EmbeddedEntityInline/FetchingWrappedInlineEntryCard.tsx
@@ -1,0 +1,107 @@
+import React from 'react';
+import { css } from 'emotion';
+import tokens from '@contentful/forma-36-tokens';
+import {
+  InlineEntryCard,
+  DropdownListItem,
+  DropdownList,
+  Icon,
+} from '@contentful/forma-36-react-components';
+import { entityHelpers, FieldExtensionSDK } from '@contentful/field-editor-shared';
+import { useEntities, ScheduledIconWithTooltip } from '@contentful/field-editor-reference';
+import { INLINES } from '@contentful/rich-text-types';
+
+const { getEntryTitle, getEntryStatus } = entityHelpers;
+
+const styles = {
+  scheduledIcon: css({
+    verticalAlign: 'text-bottom',
+    marginRight: tokens.spacing2Xs,
+  }),
+};
+
+interface FetchingWrappedInlineEntryCardProps {
+  entryId: string;
+  sdk: FieldExtensionSDK;
+  isSelected: boolean;
+  isDisabled: boolean;
+  onEdit: (event: React.MouseEvent<Element, MouseEvent>) => void;
+  onRemove: (event: React.MouseEvent<Element, MouseEvent>) => void;
+}
+
+export function FetchingWrappedInlineEntryCard(props: FetchingWrappedInlineEntryCardProps) {
+  const { getOrLoadEntry, loadEntityScheduledActions, entries } = useEntities();
+  const entry = React.useMemo(() => entries[props.entryId], [entries, props.entryId]);
+
+  const allContentTypes = props.sdk.space.getCachedContentTypes();
+  const contentType = React.useMemo(() => {
+    if (!entry || !allContentTypes) return undefined;
+
+    return allContentTypes.find(
+      (contentType) => contentType.sys.id === entry.sys.contentType.sys.id
+    );
+  }, [allContentTypes, entry]);
+
+  const title = React.useMemo(
+    () =>
+      getEntryTitle({
+        entry,
+        contentType,
+        localeCode: props.sdk.field.locale,
+        defaultLocaleCode: props.sdk.locales.default,
+        defaultTitle: 'Untitled',
+      }),
+    [entry, contentType, props.sdk]
+  );
+
+  React.useEffect(() => {
+    if (!props.entryId) return;
+    getOrLoadEntry(props.entryId);
+  }, [props.entryId]); // eslint-disable-line
+
+  if (entry === 'failed') {
+    return (
+      <InlineEntryCard testId={INLINES.EMBEDDED_ENTRY} isSelected={props.isSelected}>
+        Entry missing or inaccessible
+      </InlineEntryCard>
+    );
+  }
+
+  if (entry === undefined) {
+    return <InlineEntryCard isLoading={true}>Loading...</InlineEntryCard>;
+  }
+
+  const status = getEntryStatus(entry.sys);
+  if (status === 'deleted') {
+    return (
+      <InlineEntryCard testId={INLINES.EMBEDDED_ENTRY} isSelected={props.isSelected}>
+        Entry missing or inaccessible
+      </InlineEntryCard>
+    );
+  }
+
+  return (
+    <InlineEntryCard
+      testId={INLINES.EMBEDDED_ENTRY}
+      isSelected={props.isSelected}
+      status={status}
+      dropdownListElements={
+        <DropdownList>
+          <DropdownListItem onClick={props.onEdit} isDisabled={props.isDisabled}>
+            Edit
+          </DropdownListItem>
+          <DropdownListItem onClick={props.onRemove} isDisabled={props.isDisabled}>
+            Remove
+          </DropdownListItem>
+        </DropdownList>
+      }>
+      <ScheduledIconWithTooltip
+        getEntityScheduledActions={loadEntityScheduledActions}
+        entityType="Entry"
+        entityId={entry.sys.id}>
+        <Icon className={styles.scheduledIcon} icon="Clock" color="muted" testId="scheduled-icon" />
+      </ScheduledIconWithTooltip>
+      {title}
+    </InlineEntryCard>
+  );
+}

--- a/packages/rich-text/src/plugins/EmbeddedEntityInline/index.tsx
+++ b/packages/rich-text/src/plugins/EmbeddedEntityInline/index.tsx
@@ -1,0 +1,163 @@
+import * as React from 'react';
+import {
+  SlatePlugin,
+  getRenderElement,
+  getSlatePluginTypes,
+  useStoreEditor,
+} from '@udecode/slate-plugins-core';
+import { Transforms, Element } from 'slate';
+import { INLINES } from '@contentful/rich-text-types';
+import { RenderElementProps, useSelected, ReactEditor, useReadOnly } from 'slate-react';
+import { Button, DropdownListItem, Icon, Flex } from '@contentful/forma-36-react-components';
+import { css } from 'emotion';
+import { FieldExtensionSDK, Entry, Link } from '@contentful/field-editor-reference/dist/types';
+import { CustomSlatePluginOptions } from '../../types';
+import newEntitySelectorConfigFromRichTextField from '../../helpers/newEntitySelectorConfigFromRichTextField';
+import { useSdkContext } from '../../SdkProvider';
+import { FetchingWrappedInlineEntryCard } from './FetchingWrappedInlineEntryCard';
+
+const styles = {
+  icon: css({
+    marginRight: '10px',
+  }),
+
+  root: css({
+    margin: '0px 5px',
+    fontSize: 'inherit',
+    span: {
+      webkitUserSelect: 'none',
+      mozUserSelect: 'none',
+      msUserSelect: 'none',
+      userSelect: 'none',
+    },
+  }),
+};
+
+interface EmbeddedEntityInlineProps extends RenderElementProps {
+  element: Element & {
+    data: {
+      target: Link;
+    };
+    type: string;
+    isVoid: boolean;
+  };
+}
+
+function EmbeddedEntityInline(props: EmbeddedEntityInlineProps) {
+  const editor = useStoreEditor();
+  const sdk = useSdkContext();
+  const isSelected = useSelected();
+  const { id: entryId } = props.element.data.target.sys;
+  const isDisabled = useReadOnly();
+
+  function handleEditClick() {
+    return sdk.navigator.openEntry(entryId, { slideIn: true });
+  }
+
+  function handleRemoveClick() {
+    if (!editor) return;
+    const pathToElement = ReactEditor.findPath(editor, props.element);
+    Transforms.removeNodes(editor, { at: pathToElement });
+  }
+
+  return (
+    <span {...props.attributes} className={styles.root}>
+      <span contentEditable={false}>
+        <FetchingWrappedInlineEntryCard
+          sdk={sdk}
+          entryId={entryId}
+          isSelected={isSelected}
+          isDisabled={isDisabled}
+          onRemove={handleRemoveClick}
+          onEdit={handleEditClick}
+        />
+      </span>
+      {props.children}
+    </span>
+  );
+}
+
+interface ToolbarEmbeddedEntityInlineButtonProps {
+  onClose: () => void;
+  isDisabled: boolean;
+  isButton?: boolean;
+}
+
+export function ToolbarEmbeddedEntityInlineButton(props: ToolbarEmbeddedEntityInlineButtonProps) {
+  const editor = useStoreEditor();
+  const sdk: FieldExtensionSDK = useSdkContext();
+
+  async function handleClick(event) {
+    event.preventDefault();
+
+    if (!editor) return;
+
+    props.onClose();
+
+    const config = {
+      ...newEntitySelectorConfigFromRichTextField(sdk.field, INLINES.EMBEDDED_ENTRY),
+      withCreate: true,
+    };
+    const entry = await sdk.dialogs.selectSingleEntry<Entry>(config);
+    if (!entry) return;
+
+    const inlineEntryNode = {
+      type: INLINES.EMBEDDED_ENTRY,
+      children: [{ text: '' }],
+      data: {
+        target: {
+          sys: {
+            id: entry.sys.id,
+            type: 'Link',
+            linkType: 'Entry',
+          },
+        },
+      },
+    };
+
+    Transforms.insertNodes(editor, inlineEntryNode);
+  }
+
+  return props.isButton ? (
+    <Button
+      disabled={props.isDisabled}
+      className={`${INLINES.EMBEDDED_ENTRY}-button`}
+      size="small"
+      onClick={handleClick}
+      icon="EmbeddedEntryInline"
+      buttonType="muted"
+      testId={`toolbar-toggle-${INLINES.EMBEDDED_ENTRY}`}>
+      Embed inline entry
+    </Button>
+  ) : (
+    <DropdownListItem
+      isDisabled={props.isDisabled}
+      className="rich-text__entry-link-block-button"
+      testId={`toolbar-toggle-${INLINES.EMBEDDED_ENTRY}`}
+      onClick={handleClick}>
+      <Flex alignItems="center" flexDirection="row">
+        <Icon
+          icon="EmbeddedEntryInline"
+          color="secondary"
+          className={`rich-text__embedded-entry-list-icon ${styles.icon}`}
+        />
+        <span>Inline entry</span>
+      </Flex>
+    </DropdownListItem>
+  );
+}
+
+export function createEmbeddedEntityInlinePlugin(): SlatePlugin {
+  return {
+    renderElement: getRenderElement(INLINES.EMBEDDED_ENTRY),
+    pluginKeys: INLINES.EMBEDDED_ENTRY,
+    inlineTypes: getSlatePluginTypes(INLINES.EMBEDDED_ENTRY),
+  };
+}
+
+export const withEmbeddedEntityInlineOptions: CustomSlatePluginOptions = {
+  [INLINES.EMBEDDED_ENTRY]: {
+    type: INLINES.EMBEDDED_ENTRY,
+    component: EmbeddedEntityInline,
+  },
+};

--- a/packages/rich-text/src/plugins/EmbeddedEntityInline/index.tsx
+++ b/packages/rich-text/src/plugins/EmbeddedEntityInline/index.tsx
@@ -106,7 +106,6 @@ async function selectEntityAndInsert(editor, sdk: FieldExtensionSDK) {
   };
 
   Transforms.insertNodes(editor, inlineEntryNode);
-
 }
 
 export function ToolbarEmbeddedEntityInlineButton(props: ToolbarEmbeddedEntityInlineButtonProps) {
@@ -180,8 +179,9 @@ type EmbeddedEntryInlineEvent = ModEvent & ShiftEvent & TwoEvent;
 const isTwo = (event: KeyboardEvent): event is TwoEvent => event.keyCode === 50;
 const isMod = (event: KeyboardEvent): event is ModEvent => event.ctrlKey || event.metaKey;
 const isShift = (event: KeyboardEvent): event is ShiftEvent => event.shiftKey;
-const wasEmbeddedEntryInlineEventTriggered = (event: KeyboardEvent): event is EmbeddedEntryInlineEvent =>
-  isMod(event) && isShift(event) && isTwo(event);
+const wasEmbeddedEntryInlineEventTriggered = (
+  event: KeyboardEvent
+): event is EmbeddedEntryInlineEvent => isMod(event) && isShift(event) && isTwo(event);
 
 function getWithEmbeddedEntryInlineEvents(sdk) {
   return function withEmbeddedEntryInlineEvents(editor) {

--- a/packages/rich-text/src/plugins/shared/FetchingWrappedEntryCard.tsx
+++ b/packages/rich-text/src/plugins/shared/FetchingWrappedEntryCard.tsx
@@ -67,6 +67,7 @@ export function FetchingWrappedEntryCard(props: FetchingWrappedEntryCardProps) {
       onEdit={props.onEdit}
       onRemove={props.onRemove}
       size="default"
+      hasMoveOptions={false}
     />
   );
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1706,6 +1706,16 @@
     lodash "^4.17.15"
     lodash-es "^4.17.15"
 
+"@contentful/field-editor-shared@^0.22.0":
+  version "0.22.0"
+  resolved "https://registry.yarnpkg.com/@contentful/field-editor-shared/-/field-editor-shared-0.22.0.tgz#7c675c73bb3f4977fb3064eaef4af45ef675efa4"
+  integrity sha512-PJLcisKSDkN/1BqfuAhUoPkf3ncFtiU+pkL0O+QnlqojG1QlKg8hMua0AfLCCPaP2OLzJfHzioCN6QkPNqUvQQ==
+  dependencies:
+    "@contentful/forma-36-tokens" "^0.11.0"
+    emotion "^10.0.17"
+    lodash "^4.17.15"
+    lodash-es "^4.17.15"
+
 "@contentful/forma-36-fcss@^0.3.1":
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/@contentful/forma-36-fcss/-/forma-36-fcss-0.3.1.tgz#b111e14a0075693678325a528d4751a7a4cea925"
@@ -1719,6 +1729,13 @@
   integrity sha512-QTN/vmEV2SEDVmyk8FRDmi4DarykWATIBfZwR0ZQTkWxI3mBMULPias1mQlSBnqdgQ2wVU3StKs6QXfQE7Z+nw==
   dependencies:
     "@contentful/forma-36-tokens" "^0.10.2"
+
+"@contentful/forma-36-fcss@^0.3.3":
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/@contentful/forma-36-fcss/-/forma-36-fcss-0.3.3.tgz#ea0a11a5c3fea05f99d93113cda27b9e279828f2"
+  integrity sha512-QvXbGLAWPiohMQNzcUB1sMGbc02G0v+tod/iMgiQQQnTQh9ovlgmkENG9XFY2aOhLJGIeS1GDRN1/sU8XwyBfg==
+  dependencies:
+    "@contentful/forma-36-tokens" "^0.11.0"
 
 "@contentful/forma-36-react-components@^3.79.5":
   version "3.79.5"
@@ -1758,6 +1775,25 @@
     react-transition-group "^4.4.2"
     truncate "^2.0.1"
 
+"@contentful/forma-36-react-components@^3.93.1":
+  version "3.93.2"
+  resolved "https://registry.yarnpkg.com/@contentful/forma-36-react-components/-/forma-36-react-components-3.93.2.tgz#c054076b5adff2df261155c3b945a8a9c8778158"
+  integrity sha512-knMdxRPZFodyvTuNvrymmQLah6xe6dkmEaKgiauii99t9Qo4y5fOwiFceKXD5P5RHc6O8Xbb9KeOheRrV4E16Q==
+  dependencies:
+    "@babel/runtime" "^7.3.4"
+    "@contentful/forma-36-fcss" "^0.3.3"
+    "@contentful/forma-36-tokens" "^0.11.0"
+    "@popperjs/core" "^2.4.4"
+    classnames "^2.2.6"
+    csstype "^3.0.5"
+    dayjs "^1.9.1"
+    react-animate-height "^2.0.7"
+    react-copy-to-clipboard "^5.0.1"
+    react-modal "^3.11.2"
+    react-popper "^2.2.3"
+    react-transition-group "^4.4.2"
+    truncate "^2.0.1"
+
 "@contentful/forma-36-tokens@^0.10.0", "@contentful/forma-36-tokens@^0.10.1":
   version "0.10.1"
   resolved "https://registry.yarnpkg.com/@contentful/forma-36-tokens/-/forma-36-tokens-0.10.1.tgz#e98f4cabc8381927317c7507279fcd6721c46735"
@@ -1767,6 +1803,11 @@
   version "0.10.2"
   resolved "https://registry.yarnpkg.com/@contentful/forma-36-tokens/-/forma-36-tokens-0.10.2.tgz#a6f806e6e21f50dc38ff577762a4fb3f29352d67"
   integrity sha512-HHLwIN8mQv41GYxcTBYJjiDwpmmWwbcIRV09ciSDxhciYJ+wQkIurQ2lmnKHebPwv35X6fHXB4OdSTK1d9mUug==
+
+"@contentful/forma-36-tokens@^0.11.0":
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/@contentful/forma-36-tokens/-/forma-36-tokens-0.11.0.tgz#c28a9b30ecab33eaae4c4544eaacfbbdaa6a9bc5"
+  integrity sha512-PP+gia5E0u7H2TyfB31YHGeE2OOZtuIe9aKayH6fIwONO3XHTNN5mElnD5uVcockVQ36laAU2Iif8eVe3Zpvnw==
 
 "@contentful/mimetype@^1.4.0":
   version "1.4.38"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1676,6 +1676,25 @@
     read-pkg-up "^7.0.1"
     semver "^7.3.2"
 
+"@contentful/field-editor-reference@^2.20.1":
+  version "2.20.1"
+  resolved "https://registry.yarnpkg.com/@contentful/field-editor-reference/-/field-editor-reference-2.20.1.tgz#984fa0c0009352bc092f1f417006046281a26413"
+  integrity sha512-EpgT0TnWU2UcI4VDFMZ4ZqXtH3kLbm2kQuH4mzX5rdHiCIsxo3bCjx3gi3NEDXMerXQYZts7jHRzVvKJuR4xdw==
+  dependencies:
+    "@contentful/field-editor-shared" "^0.22.0"
+    "@contentful/forma-36-react-components" "^3.93.1"
+    "@contentful/forma-36-tokens" "^0.11.0"
+    "@contentful/mimetype" "^1.4.0"
+    "@types/deep-equal" "^1.0.1"
+    array-move "^3.0.0"
+    constate "3.2.0"
+    deep-equal "2.0.5"
+    emotion "^10.0.17"
+    lodash "^4.17.15"
+    lodash-es "^4.17.15"
+    moment "^2.20.0"
+    react-sortable-hoc "^2.0.0"
+
 "@contentful/field-editor-shared@^0.14.0":
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/@contentful/field-editor-shared/-/field-editor-shared-0.14.0.tgz#13e942e36ee5350c27978ce625ac74152495c270"


### PR DESCRIPTION
- [x] adds embedded entity inline elements
  - keyboard shortcuts
  - cypress tests

Also
- [x] fixes keyboard shortcut for asset inlines
- [x] fixes "move to top" / "move to bottom" incorrectly appearing on embedded entry cards