### PR TITLE
test: 💍 Enable back the "CreateEntryLinkButton" test

### DIFF
--- a/apps/entry-app-collapsible/package.json
+++ b/apps/entry-app-collapsible/package.json
@@ -8,7 +8,7 @@
     "@contentful/field-editor-shared": "^0.19.0",
     "@contentful/field-editor-single-line": "^0.14.1",
     "@contentful/forma-36-fcss": "^0.3.3",
-    "@contentful/forma-36-react-components": "^3.93.1",
+    "@contentful/forma-36-react-components": "^3.93.4",
     "@contentful/forma-36-tokens": "^0.11.0",
     "emotion": "^10.0.17",
     "prop-types": "^15.7.2",

--- a/apps/markdown-app/package.json
+++ b/apps/markdown-app/package.json
@@ -8,7 +8,7 @@
     "@contentful/field-editor-shared": "^0.19.0",
     "@contentful/field-editor-single-line": "^0.14.1",
     "@contentful/forma-36-fcss": "^0.3.3",
-    "@contentful/forma-36-react-components": "^3.93.1",
+    "@contentful/forma-36-react-components": "^3.93.4",
     "@contentful/forma-36-tokens": "^0.11.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"

--- a/apps/multiple-references-app/package.json
+++ b/apps/multiple-references-app/package.json
@@ -7,7 +7,7 @@
     "@contentful/field-editor-reference": "^2.16.0",
     "@contentful/field-editor-single-line": "^0.14.1",
     "@contentful/forma-36-fcss": "^0.3.3",
-    "@contentful/forma-36-react-components": "^3.93.1",
+    "@contentful/forma-36-react-components": "^3.93.4",
     "@contentful/forma-36-tokens": "^0.11.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"

--- a/apps/rich-text-app/package.json
+++ b/apps/rich-text-app/package.json
@@ -7,7 +7,7 @@
     "@contentful/field-editor-rich-text": "^0.19.1",
     "@contentful/field-editor-single-line": "^0.14.1",
     "@contentful/forma-36-fcss": "^0.3.3",
-    "@contentful/forma-36-react-components": "^3.93.1",
+    "@contentful/forma-36-react-components": "^3.93.4",
     "@contentful/forma-36-tokens": "^0.11.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"

--- a/apps/singleline-app/package.json
+++ b/apps/singleline-app/package.json
@@ -6,7 +6,7 @@
     "@contentful/app-sdk": "^3.36.0",
     "@contentful/field-editor-single-line": "^0.14.1",
     "@contentful/forma-36-fcss": "^0.3.3",
-    "@contentful/forma-36-react-components": "^3.93.1",
+    "@contentful/forma-36-react-components": "^3.93.4",
     "@contentful/forma-36-tokens": "^0.11.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@contentful/contentful-extension-scripts": "^0.20.4",
     "@contentful/eslint-config-extension": "0.4.2",
     "@contentful/forma-36-fcss": "^0.3.3",
-    "@contentful/forma-36-react-components": "^3.93.1",
+    "@contentful/forma-36-react-components": "^3.93.4",
     "@contentful/forma-36-tokens": "^0.11.0",
     "@cypress/webpack-preprocessor": "4.1.5",
     "@testing-library/cypress": "5.3.1",

--- a/packages/boolean/package.json
+++ b/packages/boolean/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@contentful/field-editor-shared": "^0.22.0",
-    "@contentful/forma-36-react-components": "^3.93.1",
+    "@contentful/forma-36-react-components": "^3.93.4",
     "@contentful/forma-36-tokens": "^0.11.0",
     "emotion": "^10.0.17",
     "lodash": "^4.17.15",

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@contentful/field-editor-shared": "^0.22.0",
-    "@contentful/forma-36-react-components": "^3.93.1",
+    "@contentful/forma-36-react-components": "^3.93.4",
     "@contentful/forma-36-tokens": "^0.11.0",
     "emotion": "^10.0.17",
     "lodash": "^4.17.15",

--- a/packages/date/package.json
+++ b/packages/date/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@contentful/field-editor-shared": "^0.22.0",
-    "@contentful/forma-36-react-components": "^3.93.1",
+    "@contentful/forma-36-react-components": "^3.93.4",
     "@contentful/forma-36-tokens": "^0.11.0",
     "emotion": "^10.0.17",
     "lodash": "^4.17.15",

--- a/packages/default-field-editors/package.json
+++ b/packages/default-field-editors/package.json
@@ -41,7 +41,7 @@
     "@contentful/field-editor-tags": "^0.14.0",
     "@contentful/field-editor-url": "^0.12.0",
     "@contentful/field-editor-validation-errors": "^0.6.0",
-    "@contentful/forma-36-react-components": "^3.93.1",
+    "@contentful/forma-36-react-components": "^3.93.4",
     "emotion": "^10.0.27"
   },
   "devDependencies": {

--- a/packages/dropdown/package.json
+++ b/packages/dropdown/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@contentful/field-editor-shared": "^0.22.0",
-    "@contentful/forma-36-react-components": "^3.93.1",
+    "@contentful/forma-36-react-components": "^3.93.4",
     "@contentful/forma-36-tokens": "^0.11.0",
     "emotion": "^10.0.0",
     "lodash": "^4.17.15",

--- a/packages/json/package.json
+++ b/packages/json/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@contentful/field-editor-shared": "^0.22.0",
-    "@contentful/forma-36-react-components": "^3.93.1",
+    "@contentful/forma-36-react-components": "^3.93.4",
     "@contentful/forma-36-tokens": "^0.11.0",
     "@types/deep-equal": "1.0.1",
     "@types/react-codemirror": "1.0.3",

--- a/packages/list/package.json
+++ b/packages/list/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@contentful/field-editor-shared": "^0.22.0",
-    "@contentful/forma-36-react-components": "^3.93.1",
+    "@contentful/forma-36-react-components": "^3.93.4",
     "@contentful/forma-36-tokens": "^0.11.0",
     "emotion": "^10.0.17",
     "lodash": "^4.17.15",

--- a/packages/location/package.json
+++ b/packages/location/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@contentful/field-editor-shared": "^0.22.0",
-    "@contentful/forma-36-react-components": "^3.93.1",
+    "@contentful/forma-36-react-components": "^3.93.4",
     "@contentful/forma-36-tokens": "^0.11.0",
     "@types/google-map-react": "1.1.8",
     "deep-equal": "2.0.5",

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@contentful/field-editor-shared": "^0.22.0",
-    "@contentful/forma-36-react-components": "^3.93.1",
+    "@contentful/forma-36-react-components": "^3.93.4",
     "@contentful/forma-36-tokens": "^0.11.0",
     "@types/codemirror": "0.0.108",
     "@types/markdown-to-jsx": "6.11.3",

--- a/packages/multiple-line/package.json
+++ b/packages/multiple-line/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@contentful/field-editor-shared": "^0.22.0",
-    "@contentful/forma-36-react-components": "^3.93.1",
+    "@contentful/forma-36-react-components": "^3.93.4",
     "@contentful/forma-36-tokens": "^0.11.0",
     "emotion": "^10.0.17",
     "lodash": "^4.17.15",

--- a/packages/number/package.json
+++ b/packages/number/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@contentful/field-editor-shared": "^0.22.0",
-    "@contentful/forma-36-react-components": "^3.93.1",
+    "@contentful/forma-36-react-components": "^3.93.4",
     "@contentful/forma-36-tokens": "^0.11.0",
     "emotion": "^10.0.17",
     "lodash": "^4.17.15",

--- a/packages/radio/package.json
+++ b/packages/radio/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@contentful/field-editor-dropdown": "^0.14.0",
     "@contentful/field-editor-shared": "^0.22.0",
-    "@contentful/forma-36-react-components": "^3.93.1",
+    "@contentful/forma-36-react-components": "^3.93.4",
     "@contentful/forma-36-tokens": "^0.11.0",
     "emotion": "^10.0.17",
     "lodash": "^4.17.15",

--- a/packages/rating/package.json
+++ b/packages/rating/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@contentful/field-editor-shared": "^0.22.0",
-    "@contentful/forma-36-react-components": "^3.93.1",
+    "@contentful/forma-36-react-components": "^3.93.4",
     "@contentful/forma-36-tokens": "^0.11.0",
     "emotion": "^10.0.17",
     "lodash": "^4.17.15",

--- a/packages/reference/package.json
+++ b/packages/reference/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@contentful/field-editor-shared": "^0.22.0",
-    "@contentful/forma-36-react-components": "^3.93.1",
+    "@contentful/forma-36-react-components": "^3.93.4",
     "@contentful/forma-36-tokens": "^0.11.0",
     "@contentful/mimetype": "^1.4.0",
     "@types/deep-equal": "^1.0.1",

--- a/packages/reference/src/components/CreateEntryLinkButton/CreateEntryLinkButton.spec.tsx
+++ b/packages/reference/src/components/CreateEntryLinkButton/CreateEntryLinkButton.spec.tsx
@@ -95,7 +95,7 @@ describe('CreateEntryLinkButton with multiple entries', () => {
     },
   };
 
-  it.skip('should display and close menu on button click', () => {
+  it('should display and close menu on button click', () => {
     const { getByTestId } = render(<CreateEntryLinkButton {...props} />);
     fireEvent.click(findButton(getByTestId));
     expect(getByTestId('add-entry-menu-container')).toBeDefined();

--- a/packages/rich-text/package.json
+++ b/packages/rich-text/package.json
@@ -27,7 +27,7 @@
     "@contentful/field-editor-reference": "^2.20.1",
     "@contentful/field-editor-shared": "^0.22.0",
     "@contentful/field-editor-test-utils": "^0.17.0",
-    "@contentful/forma-36-react-components": "^3.93.1",
+    "@contentful/forma-36-react-components": "^3.93.4",
     "@contentful/forma-36-tokens": "^0.11.0",
     "@contentful/rich-text-plain-text-renderer": "^14.0.0",
     "@contentful/rich-text-types": "^14.0.1",

--- a/packages/single-line/package.json
+++ b/packages/single-line/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@contentful/field-editor-shared": "^0.22.0",
-    "@contentful/forma-36-react-components": "^3.93.1",
+    "@contentful/forma-36-react-components": "^3.93.4",
     "@contentful/forma-36-tokens": "^0.11.0",
     "emotion": "^10.0.17",
     "lodash": "^4.17.15",

--- a/packages/slug/package.json
+++ b/packages/slug/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@contentful/field-editor-shared": "^0.22.0",
-    "@contentful/forma-36-react-components": "^3.93.1",
+    "@contentful/forma-36-react-components": "^3.93.4",
     "@contentful/forma-36-tokens": "^0.11.0",
     "@types/speakingurl": "^13.0.2",
     "emotion": "^10.0.17",

--- a/packages/tags/package.json
+++ b/packages/tags/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@contentful/field-editor-shared": "^0.22.0",
-    "@contentful/forma-36-react-components": "^3.93.1",
+    "@contentful/forma-36-react-components": "^3.93.4",
     "@contentful/forma-36-tokens": "^0.11.0",
     "array-move": "^3.0.0",
     "emotion": "^10.0.0",

--- a/packages/url/package.json
+++ b/packages/url/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@contentful/field-editor-shared": "^0.22.0",
-    "@contentful/forma-36-react-components": "^3.93.1",
+    "@contentful/forma-36-react-components": "^3.93.4",
     "@contentful/forma-36-tokens": "^0.11.0",
     "emotion": "^10.0.17",
     "lodash": "^4.17.15",

--- a/packages/validation-errors/package.json
+++ b/packages/validation-errors/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@contentful/field-editor-shared": "^0.22.0",
-    "@contentful/forma-36-react-components": "^3.93.1",
+    "@contentful/forma-36-react-components": "^3.93.4",
     "@contentful/forma-36-tokens": "^0.11.0",
     "emotion": "^10.0.17"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1384,7 +1384,7 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.2.0", "@babel/runtime@^7.3.4", "@babel/runtime@^7.4.4", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.3", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.7", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.10.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.2.0", "@babel/runtime@^7.3.4", "@babel/runtime@^7.4.4", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.3", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.7", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
   version "7.14.8"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.14.8.tgz#7119a56f421018852694290b9f9148097391b446"
   integrity sha512-twj3L8Og5SaCRCErB4x4ajbvBIVV77CGeFglHpeg5WC5FF8TZzBWXtTJ4MqaD9QszLYTtr+IsaAL2rEUevb+eg==
@@ -1989,17 +1989,36 @@
     "@contentful/forma-36-tokens" "^0.10.1"
     emotion "^10.0.17"
 
-"@contentful/forma-36-fcss@^0.3.2", "@contentful/forma-36-fcss@^0.3.3":
+"@contentful/forma-36-fcss@^0.3.3":
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/@contentful/forma-36-fcss/-/forma-36-fcss-0.3.3.tgz#ea0a11a5c3fea05f99d93113cda27b9e279828f2"
   integrity sha512-QvXbGLAWPiohMQNzcUB1sMGbc02G0v+tod/iMgiQQQnTQh9ovlgmkENG9XFY2aOhLJGIeS1GDRN1/sU8XwyBfg==
   dependencies:
     "@contentful/forma-36-tokens" "^0.11.0"
 
-"@contentful/forma-36-react-components@^3.79.5", "@contentful/forma-36-react-components@^3.93.1":
+"@contentful/forma-36-react-components@^3.79.5":
   version "3.93.2"
   resolved "https://registry.yarnpkg.com/@contentful/forma-36-react-components/-/forma-36-react-components-3.93.2.tgz#c054076b5adff2df261155c3b945a8a9c8778158"
   integrity sha512-knMdxRPZFodyvTuNvrymmQLah6xe6dkmEaKgiauii99t9Qo4y5fOwiFceKXD5P5RHc6O8Xbb9KeOheRrV4E16Q==
+  dependencies:
+    "@babel/runtime" "^7.3.4"
+    "@contentful/forma-36-fcss" "^0.3.3"
+    "@contentful/forma-36-tokens" "^0.11.0"
+    "@popperjs/core" "^2.4.4"
+    classnames "^2.2.6"
+    csstype "^3.0.5"
+    dayjs "^1.9.1"
+    react-animate-height "^2.0.7"
+    react-copy-to-clipboard "^5.0.1"
+    react-modal "^3.11.2"
+    react-popper "^2.2.3"
+    react-transition-group "^4.4.2"
+    truncate "^2.0.1"
+
+"@contentful/forma-36-react-components@^3.93.4":
+  version "3.93.5"
+  resolved "https://registry.yarnpkg.com/@contentful/forma-36-react-components/-/forma-36-react-components-3.93.5.tgz#2443b02fd52dd7578c0fcac764235cf4a8cd5d54"
+  integrity sha512-Oi3JetsK+utH9WBBstJz2FQoYLPYE6ziRSp+LAroDh2kFyikihwVj1WE66jUMWS3sifU0TxrcQ97mPJBYGS71w==
   dependencies:
     "@babel/runtime" "^7.3.4"
     "@contentful/forma-36-fcss" "^0.3.3"
@@ -8837,13 +8856,6 @@ dom-converter@^0.2.0:
   integrity sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==
   dependencies:
     utila "~0.4"
-
-dom-helpers@^3.4.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.4.0.tgz#e9b369700f959f62ecde5a6babde4bccd9169af8"
-  integrity sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==
-  dependencies:
-    "@babel/runtime" "^7.1.2"
 
 dom-helpers@^5.0.1:
   version "5.2.1"
@@ -18325,16 +18337,6 @@ react-test-renderer@^16.0.0-0:
     prop-types "^15.6.2"
     react-is "^16.8.6"
     scheduler "^0.18.0"
-
-react-transition-group@^2.4.0:
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-2.9.0.tgz#df9cdb025796211151a436c69a8f3b97b5b07c8d"
-  integrity sha512-+HzNTCHpeQyl4MJ/bdE0u6XRMe9+XG/+aL4mCxVN4DnPBQ0/5bfHWPDuOZUzYdMj94daZaZdCCc1Dzt9R/xSSg==
-  dependencies:
-    dom-helpers "^3.4.0"
-    loose-envify "^1.4.0"
-    prop-types "^15.6.2"
-    react-lifecycles-compat "^3.0.4"
 
 react-transition-group@^4.4.2:
   version "4.4.2"


### PR DESCRIPTION
This PR enables back the test we disabled for color tokens migration. Now the forma-36 package is updated and doesn't cause tests to fail with a type error.