### PR TITLE
fix: revert prevent default

### DIFF
--- a/packages/reference/src/entries/WrappedEntryCard/WrappedEntryCard.tsx
+++ b/packages/reference/src/entries/WrappedEntryCard/WrappedEntryCard.tsx
@@ -176,13 +176,15 @@ export function WrappedEntryCard(props: WrappedEntryCardProps) {
                   Move to bottom
                 </DropdownListItem>
               </DropdownList>
-            ) : <React.Fragment />}
+            ) : (
+              <React.Fragment />
+            )}
           </React.Fragment>
         ) : undefined
       }
       onClick={(e) => {
-        if (!props.isClickable) return;
         e.preventDefault();
+        if (!props.isClickable) return;
         props.onEdit && props.onEdit();
       }}
     />


### PR DESCRIPTION
Reverts part of #784 

Only:

- doesn't impose `event.preventDefault()` on click events when the element is not clickable

This is making the embedded blocks being clickable on the rich text field.

A better solution should be made, for example, I think we don't need the `isClickable` at all, we can simply not pass the `entryUrl` or `getAssetUrl` property, but more time to test would be needed for this change.