### PR TITLE
fix: block embeds

### DIFF
--- a/packages/rich-text/src/plugins/EmbeddedEntityBlock/Util.ts
+++ b/packages/rich-text/src/plugins/EmbeddedEntityBlock/Util.ts
@@ -13,10 +13,12 @@ export async function selectEntityAndInsert(nodeType, sdk, editor, logAction) {
     baseConfig.entityType === 'Asset' ? dialogs.selectSingleAsset : dialogs.selectSingleEntry;
   const config = { ...baseConfig, withCreate: true };
   try {
+    const { selection } = editor;
     const entity = await selectEntity(config);
     if (!entity) {
       return;
     }
+    Transforms.select(editor, selection);
     insertBlock(editor, nodeType, entity);
     logAction('insert', { nodeType });
   } catch (error) {


### PR DESCRIPTION
Fixes block embed insertion in the webapp (or in other embedded contexts).

It's possible for the `selection` to get lost in these contexts when, e.g., selecting an entity means prompting a modal (and selecting from that modal using the mouse). To address this, we capture the selection before reaching `selectEntity` and reset the selection with `Transforms.select` right afterward.