### PR TITLE
feat: disable disabled features

### DIFF
--- a/packages/rich-text/src/Toolbar/index.tsx
+++ b/packages/rich-text/src/Toolbar/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { Fragment, useState } from 'react';
 
 import { css } from 'emotion';
 import { EditorToolbar, EditorToolbarDivider } from '@contentful/forma-36-react-components';
@@ -15,9 +15,12 @@ import { ToolbarTableButton } from '../plugins/Table';
 import { EmbeddedEntityDropdownButton } from '../plugins/EmbeddedEntity';
 import { ToolbarIcon as EmbeddedEntityBlockToolbarIcon } from '../plugins/EmbeddedEntityBlock';
 import { SPEditor, useStoreEditor } from '@udecode/slate-plugins-core';
-import { BLOCKS } from '@contentful/rich-text-types';
+import { BLOCKS, INLINES, MARKS } from '@contentful/rich-text-types';
 import { isNodeTypeSelected } from '../helpers/editor';
+import { isNodeTypeEnabled, isMarkEnabled } from '../helpers/validations';
 import { ToolbarEmbeddedEntityInlineButton } from '../plugins/EmbeddedEntityInline';
+import { useSdkContext } from '../SdkProvider';
+import { FieldExtensionSDK } from '@contentful/field-editor-reference/dist/types';
 
 type ToolbarProps = {
   isDisabled?: boolean;
@@ -42,61 +45,142 @@ const styles = {
   }),
 };
 
-const Toolbar = ({ isDisabled }: ToolbarProps) => {
-  const editor = useStoreEditor() as SPEditor;
-  const canInsertBlocks = !isNodeTypeSelected(editor, BLOCKS.TABLE);
+const EmbedAssetsWidget = ({ isDisabled }: ToolbarProps) => {
+  const sdk = useSdkContext();
   const [isEmbedDropdownOpen, setEmbedDropdownOpen] = useState(false);
   const onCloseEntityDropdown = () => setEmbedDropdownOpen(false);
   const onToggleEntityDropdown = () => setEmbedDropdownOpen(!isEmbedDropdownOpen);
+
+  const [canAccessAssets, setCanAccessAssets] = useState(false);
+  React.useEffect(() => {
+    sdk.access.can('read', 'Asset').then(setCanAccessAssets);
+  }, [sdk]);
+  const inlineEntryEmbedEnabled = isNodeTypeEnabled(sdk.field, INLINES.EMBEDDED_ENTRY);
+  const blockEntryEmbedEnabled = isNodeTypeEnabled(sdk.field, BLOCKS.EMBEDDED_ENTRY);
+  const blockAssetEmbedEnabled =
+    canAccessAssets && isNodeTypeEnabled(sdk.field, BLOCKS.EMBEDDED_ASSET);
+
+  const numEnabledEmbeds = [
+    inlineEntryEmbedEnabled,
+    blockEntryEmbedEnabled,
+    blockAssetEmbedEnabled,
+  ].filter(Boolean).length;
+  const shouldDisplayDropdown = numEnabledEmbeds > 1;
+
+  const icons = (
+    <Fragment>
+      {isNodeTypeEnabled(sdk.field, BLOCKS.EMBEDDED_ENTRY) && (
+        <EmbeddedEntityBlockToolbarIcon
+          isDisabled={!!isDisabled}
+          nodeType={BLOCKS.EMBEDDED_ENTRY}
+          onClose={onCloseEntityDropdown}
+          isButton={!shouldDisplayDropdown}
+        />
+      )}
+      {isNodeTypeEnabled(sdk.field, INLINES.EMBEDDED_ENTRY) && (
+        <ToolbarEmbeddedEntityInlineButton
+          isDisabled={!!isDisabled}
+          onClose={onCloseEntityDropdown}
+        />
+      )}
+      {isNodeTypeEnabled(sdk.field, BLOCKS.EMBEDDED_ASSET) && (
+        <EmbeddedEntityBlockToolbarIcon
+          isDisabled={!!isDisabled}
+          nodeType={BLOCKS.EMBEDDED_ASSET}
+          onClose={onCloseEntityDropdown}
+        />
+      )}
+    </Fragment>
+  );
+
+  if (shouldDisplayDropdown) {
+    return (
+      <EmbeddedEntityDropdownButton
+        isDisabled={isDisabled}
+        onClose={onCloseEntityDropdown}
+        onToggle={onToggleEntityDropdown}
+        isOpen={isEmbedDropdownOpen}>
+        {icons}
+      </EmbeddedEntityDropdownButton>
+    );
+  } else {
+    return icons;
+  }
+};
+
+const Toolbar = ({ isDisabled }: ToolbarProps) => {
+  const sdk = useSdkContext();
+  const editor = useStoreEditor() as SPEditor;
+  const canInsertBlocks = !isNodeTypeSelected(editor, BLOCKS.TABLE);
+  const validationInfo = React.useMemo(() => getValidationInfo(sdk.field), [sdk.field]);
 
   return (
     <EditorToolbar testId="toolbar">
       <div className={styles.formattingOptionsWrapper}>
         <ToolbarHeadingButton isDisabled={isDisabled || !canInsertBlocks} />
 
-        <EditorToolbarDivider />
+        {validationInfo.isAnyMarkEnabled && <EditorToolbarDivider />}
 
-        <ToolbarBoldButton isDisabled={isDisabled} />
-        <ToolbarItalicButton isDisabled={isDisabled} />
-        <ToolbarUnderlineButton isDisabled={isDisabled} />
-        <ToolbarCodeButton isDisabled={isDisabled} />
+        {isMarkEnabled(sdk.field, MARKS.BOLD) && <ToolbarBoldButton isDisabled={isDisabled} />}
+        {isMarkEnabled(sdk.field, MARKS.ITALIC) && <ToolbarItalicButton isDisabled={isDisabled} />}
+        {isMarkEnabled(sdk.field, MARKS.UNDERLINE) && (
+          <ToolbarUnderlineButton isDisabled={isDisabled} />
+        )}
+        {isMarkEnabled(sdk.field, MARKS.CODE) && <ToolbarCodeButton isDisabled={isDisabled} />}
 
-        <EditorToolbarDivider />
+        {validationInfo.isAnyHyperlinkEnabled && (
+          <Fragment>
+            <EditorToolbarDivider />
+            <ToolbarHyperlinkButton isDisabled={isDisabled} />
+          </Fragment>
+        )}
 
-        <ToolbarHyperlinkButton isDisabled={isDisabled} />
+        {validationInfo.isAnyBlockFormattingEnabled && <EditorToolbarDivider />}
 
-        <EditorToolbarDivider />
-
-        <ToolbarQuoteButton isDisabled={isDisabled || !canInsertBlocks} />
+        {isNodeTypeEnabled(sdk.field, BLOCKS.QUOTE) && (
+          <ToolbarQuoteButton isDisabled={isDisabled || !canInsertBlocks} />
+        )}
         <ToolbarListButton isDisabled={isDisabled || !canInsertBlocks} />
-        <ToolbarHrButton isDisabled={isDisabled || !canInsertBlocks} />
-
-        <ToolbarTableButton isDisabled={isDisabled || !canInsertBlocks} />
+        {isNodeTypeEnabled(sdk.field, BLOCKS.HR) && (
+          <ToolbarHrButton isDisabled={isDisabled || !canInsertBlocks} />
+        )}
+        {isNodeTypeEnabled(sdk.field, BLOCKS.TABLE) && (
+          <ToolbarTableButton isDisabled={isDisabled || !canInsertBlocks} />
+        )}
       </div>
       <div className={styles.embedActionsWrapper}>
-        <EmbeddedEntityDropdownButton
-          isDisabled={isDisabled}
-          onClose={onCloseEntityDropdown}
-          onToggle={onToggleEntityDropdown}
-          isOpen={isEmbedDropdownOpen}>
-          <EmbeddedEntityBlockToolbarIcon
-            isDisabled={!!isDisabled}
-            nodeType={BLOCKS.EMBEDDED_ENTRY}
-            onClose={onCloseEntityDropdown}
-          />
-          <ToolbarEmbeddedEntityInlineButton
-            isDisabled={!!isDisabled}
-            onClose={onCloseEntityDropdown}
-          />
-          <EmbeddedEntityBlockToolbarIcon
-            isDisabled={!!isDisabled}
-            nodeType={BLOCKS.EMBEDDED_ASSET}
-            onClose={onCloseEntityDropdown}
-          />
-        </EmbeddedEntityDropdownButton>
+        <EmbedAssetsWidget isDisabled={isDisabled} />
       </div>
     </EditorToolbar>
   );
 };
+
+function getValidationInfo(
+  field: FieldExtensionSDK['field']
+): {
+  isAnyMarkEnabled: boolean;
+  isAnyHyperlinkEnabled: boolean;
+  isAnyBlockFormattingEnabled: boolean;
+} {
+  const someWithValidation = (vals, validation) => vals.some((val) => validation(field, val));
+
+  const isAnyMarkEnabled = someWithValidation(Object.values(MARKS), isMarkEnabled);
+
+  const isAnyHyperlinkEnabled = someWithValidation(
+    [INLINES.HYPERLINK, INLINES.ASSET_HYPERLINK, INLINES.ENTRY_HYPERLINK],
+    isNodeTypeEnabled
+  );
+
+  const isAnyBlockFormattingEnabled = someWithValidation(
+    [BLOCKS.UL_LIST, BLOCKS.OL_LIST, BLOCKS.QUOTE, BLOCKS.HR],
+    isNodeTypeEnabled
+  );
+
+  return {
+    isAnyMarkEnabled,
+    isAnyHyperlinkEnabled,
+    isAnyBlockFormattingEnabled,
+  };
+}
 
 export default Toolbar;

--- a/packages/rich-text/src/helpers/validations.ts
+++ b/packages/rich-text/src/helpers/validations.ts
@@ -1,0 +1,40 @@
+/* eslint-disable you-dont-need-lodash-underscore/find */
+import find from 'lodash/find';
+import flow from 'lodash/flow';
+import get from 'lodash/get';
+import { BLOCKS, INLINES, TOP_LEVEL_BLOCKS } from '@contentful/rich-text-types';
+import { FieldExtensionSDK } from '@contentful/app-sdk';
+
+// TODO: Move this into separate package (maybe rich-text-types) and share with FE.
+export const VALIDATIONS = {
+  ENABLED_MARKS: 'enabledMarks',
+  ENABLED_NODE_TYPES: 'enabledNodeTypes'
+};
+
+export const VALIDATABLE_NODE_TYPES =
+  ([] as Array<BLOCKS | INLINES>)
+    .concat(TOP_LEVEL_BLOCKS)
+    .filter(type => type !== BLOCKS.PARAGRAPH)
+    .concat(Object.values(INLINES));
+
+const getRichTextValidation = (field, validationType) =>
+  flow(
+    v => find(v, validationType),
+    v => get(v, validationType)
+  )(field.validations);
+
+const isFormattingOptionEnabled = (field, validationType, nodeTypeOrMark) => {
+  const enabledFormattings = getRichTextValidation(field, validationType);
+
+  if (enabledFormattings === undefined) {
+    return true;
+  }
+
+  return enabledFormattings.includes(nodeTypeOrMark);
+};
+
+export const isNodeTypeEnabled = (field: FieldExtensionSDK['field'], nodeType): boolean =>
+  isFormattingOptionEnabled(field, VALIDATIONS.ENABLED_NODE_TYPES, nodeType);
+
+export const isMarkEnabled = (field: FieldExtensionSDK['field'], mark) =>
+  isFormattingOptionEnabled(field, VALIDATIONS.ENABLED_MARKS, mark);

--- a/packages/rich-text/src/plugins/EmbeddedEntity/index.tsx
+++ b/packages/rich-text/src/plugins/EmbeddedEntity/index.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { Dropdown, DropdownList, Button } from '@contentful/forma-36-react-components';
 
 interface EmbeddedEntityDropdownButtonProps {
-  children: React.ReactNode[];
+  children: React.ReactNode;
   isDisabled: boolean | undefined;
   isOpen: boolean;
   onClose: () => void;

--- a/packages/rich-text/src/plugins/Heading/index.tsx
+++ b/packages/rich-text/src/plugins/Heading/index.tsx
@@ -19,6 +19,8 @@ import {
 import { insertNodes, setNodes, toggleNodeType } from '@udecode/slate-plugins-common';
 import { CustomElement, CustomSlatePluginOptions } from '../../types';
 import { getElementFromCurrentSelection, hasSelectionText } from '../../helpers/editor';
+import { isNodeTypeEnabled } from '../../helpers/validations';
+import { useSdkContext } from '../../SdkProvider';
 
 const styles = {
   dropdown: {
@@ -158,6 +160,7 @@ interface ToolbarHeadingButtonProps {
 }
 
 export function ToolbarHeadingButton(props: ToolbarHeadingButtonProps) {
+  const sdk = useSdkContext();
   const editor = useStoreEditor();
   const [isOpen, setOpen] = React.useState(false);
   const [selected, setSelected] = React.useState<string>(BLOCKS.PARAGRAPH);
@@ -193,16 +196,23 @@ export function ToolbarHeadingButton(props: ToolbarHeadingButtonProps) {
         </Button>
       }>
       <DropdownList testId="dropdown-heading-list">
-        {Object.keys(LABELS).map((key) => (
-          <DropdownListItem
-            key={key}
-            isActive={selected === key}
-            onClick={() => handleOnSelectItem(key)}
-            testId={`dropdown-option-${key}`}
-            isDisabled={props.isDisabled}>
-            <span className={cx(styles.dropdown.root, styles.dropdown[key])}>{LABELS[key]}</span>
-          </DropdownListItem>
-        ))}
+        {Object.keys(LABELS)
+          .map(
+            (nodeType) =>
+              isNodeTypeEnabled(sdk.field, nodeType) && (
+                <DropdownListItem
+                  key={nodeType}
+                  isActive={selected === nodeType}
+                  onClick={() => handleOnSelectItem(nodeType)}
+                  testId={`dropdown-option-${nodeType}`}
+                  isDisabled={props.isDisabled}>
+                  <span className={cx(styles.dropdown.root, styles.dropdown[nodeType])}>
+                    {LABELS[nodeType]}
+                  </span>
+                </DropdownListItem>
+              )
+          )
+          .filter(Boolean)}
       </DropdownList>
     </Dropdown>
   );

--- a/packages/rich-text/src/plugins/List/index.tsx
+++ b/packages/rich-text/src/plugins/List/index.tsx
@@ -12,14 +12,17 @@ import {
 } from '@udecode/slate-plugins-list';
 import { useStoreEditor } from '@udecode/slate-plugins-core';
 import { isBlockSelected } from '../../helpers/editor';
+import { isNodeTypeEnabled } from '../../helpers/validations';
 import { CustomSlatePluginOptions } from 'types';
 import tokens from '@contentful/forma-36-tokens';
+import { useSdkContext } from '../../SdkProvider';
 
 interface ToolbarListButtonProps {
   isDisabled?: boolean;
 }
 
 export function ToolbarListButton(props: ToolbarListButtonProps) {
+  const sdk = useSdkContext();
   const editor = useStoreEditor();
 
   function handleClick(type: string): void {
@@ -34,24 +37,28 @@ export function ToolbarListButton(props: ToolbarListButtonProps) {
 
   return (
     <React.Fragment>
-      <EditorToolbarButton
-        icon="ListBulleted"
-        tooltip="UL"
-        label="UL"
-        testId="ul-toolbar-button"
-        onClick={() => handleClick(BLOCKS.UL_LIST)}
-        isActive={isBlockSelected(editor, BLOCKS.UL_LIST)}
-        disabled={props.isDisabled}
-      />
-      <EditorToolbarButton
-        icon="ListNumbered"
-        tooltip="OL"
-        label="OL"
-        testId="ol-toolbar-button"
-        onClick={() => handleClick(BLOCKS.OL_LIST)}
-        isActive={isBlockSelected(editor, BLOCKS.OL_LIST)}
-        disabled={props.isDisabled}
-      />
+      {isNodeTypeEnabled(sdk.field, BLOCKS.UL_LIST) && (
+        <EditorToolbarButton
+          icon="ListBulleted"
+          tooltip="UL"
+          label="UL"
+          testId="ul-toolbar-button"
+          onClick={() => handleClick(BLOCKS.UL_LIST)}
+          isActive={isBlockSelected(editor, BLOCKS.UL_LIST)}
+          disabled={props.isDisabled}
+        />
+      )}
+      {isNodeTypeEnabled(sdk.field, BLOCKS.OL_LIST) && (
+        <EditorToolbarButton
+          icon="ListNumbered"
+          tooltip="OL"
+          label="OL"
+          testId="ol-toolbar-button"
+          onClick={() => handleClick(BLOCKS.OL_LIST)}
+          isActive={isBlockSelected(editor, BLOCKS.OL_LIST)}
+          disabled={props.isDisabled}
+        />
+      )}
     </React.Fragment>
   );
 }


### PR DESCRIPTION
Wires toolbar buttons to the sdk-provided `enabledNodeTypes`, creating parity with the legacy editor behavior (also adding support for `table`). Doesn't disable keyboard shortcuts though.