### PR TITLE
feat: throttle slug editor uniqueness requests

### DIFF
--- a/packages/slug/package.json
+++ b/packages/slug/package.json
@@ -28,7 +28,8 @@
     "emotion": "^10.0.17",
     "lodash": "^4.17.15",
     "lodash-es": "^4.17.15",
-    "speakingurl": "^13.0.0"
+    "speakingurl": "^13.0.0",
+    "use-debounce": "^7.0.0"
   },
   "devDependencies": {
     "@contentful/app-sdk": "^3.36.0",

--- a/packages/slug/src/SlugEditor.test.tsx
+++ b/packages/slug/src/SlugEditor.test.tsx
@@ -17,6 +17,10 @@ jest.mock(
   { virtual: true }
 );
 
+jest.mock('use-debounce', () => ({
+  useDebounce: (text: string) => [text],
+}));
+
 function createMocks(
   initialValues: { field?: string; titleField?: string; descriptionField?: string } = {}
 ) {

--- a/packages/slug/src/SlugEditor.tsx
+++ b/packages/slug/src/SlugEditor.tsx
@@ -51,18 +51,21 @@ export function SlugEditor(props: SlugEditorProps) {
     isOptionalFieldLocale && localeFallbackCode && locales.available.includes(localeFallbackCode)
   );
 
-  const performUniqueCheck = React.useCallback((value: string) => {
-    const searchQuery = {
-      content_type: entrySys.contentType.sys.id,
-      [`fields.${field.id}.${field.locale}`]: value,
-      'sys.id[ne]': entrySys.id,
-      'sys.publishedAt[exists]': true,
-      limit: 0,
-    };
-    return space.getEntries(searchQuery).then((res) => {
-      return res.total === 0;
-    });
-  }, []);
+  const performUniqueCheck = React.useCallback(
+    (value: string) => {
+      const searchQuery = {
+        content_type: entrySys.contentType.sys.id,
+        [`fields.${field.id}.${field.locale}`]: value,
+        'sys.id[ne]': entrySys.id,
+        'sys.publishedAt[exists]': true,
+        limit: 0,
+      };
+      return space.getEntries(searchQuery).then((res) => {
+        return res.total === 0;
+      });
+    },
+    [entrySys.contentType.sys.id, field.id, field.locale, entrySys.id, space]
+  );
 
   return (
     <TrackingFieldConnector<string>

--- a/packages/slug/src/SlugEditor.tsx
+++ b/packages/slug/src/SlugEditor.tsx
@@ -28,6 +28,59 @@ function isSupportedFieldTypes(val: string): val is 'Symbol' {
   return val === 'Symbol';
 }
 
+function FieldConnectorCallback({
+  Component,
+  value,
+  disabled,
+  setValue,
+  errors,
+  titleValue,
+  isOptionalLocaleWithFallback,
+  locale,
+  createdAt,
+  performUniqueCheck,
+}: {
+  Component: typeof SlugEditorFieldStatic | typeof SlugEditorField;
+  value: string | null | undefined;
+  disabled: boolean;
+  titleValue: string | null | undefined;
+  setValue: (value: string | null | undefined) => Promise<unknown>;
+  errors: Error[];
+  isOptionalLocaleWithFallback: boolean;
+  locale: FieldAPI['locale'];
+  createdAt: string;
+  performUniqueCheck: (value: string) => Promise<boolean>;
+}) {
+  // it is needed to silent permission errors
+  // this happens when setValue is called on a field which is disabled for permission reasons
+  const safeSetValue = React.useCallback(
+    async (...args: Parameters<typeof setValue>) => {
+      try {
+        await setValue(...args);
+      } catch (e) {
+        // do nothing
+      }
+    },
+    [setValue]
+  );
+
+  return (
+    <div data-test-id="slug-editor">
+      <Component
+        locale={locale}
+        createdAt={createdAt}
+        performUniqueCheck={performUniqueCheck}
+        hasError={errors.length > 0}
+        value={value}
+        isOptionalLocaleWithFallback={isOptionalLocaleWithFallback}
+        isDisabled={disabled}
+        titleValue={titleValue}
+        setValue={safeSetValue}
+      />
+    </div>
+  );
+}
+
 export function SlugEditor(props: SlugEditorProps) {
   const { field, parameters } = props;
   const { locales, entry, space } = props.baseSdk;
@@ -54,7 +107,7 @@ export function SlugEditor(props: SlugEditorProps) {
   const performUniqueCheck = React.useCallback(
     (value: string) => {
       const searchQuery = {
-        content_type: entrySys.contentType.sys.id,
+        content_type: entrySys?.contentType?.sys?.id,
         [`fields.${field.id}.${field.locale}`]: value,
         'sys.id[ne]': entrySys.id,
         'sys.publishedAt[exists]': true,
@@ -64,7 +117,7 @@ export function SlugEditor(props: SlugEditorProps) {
         return res.total === 0;
       });
     },
-    [entrySys.contentType.sys.id, field.id, field.locale, entrySys.id, space]
+    [entrySys?.contentType?.sys?.id, field.id, field.locale, entrySys.id, space]
   );
 
   return (
@@ -84,31 +137,20 @@ export function SlugEditor(props: SlugEditorProps) {
 
             const Component = shouldTrackTitle ? SlugEditorField : SlugEditorFieldStatic;
 
-            // it is needed to silent permission errors
-            // this happens when setValue is called on a field which is disabled for permission reasons
-            const safeSetValue = async (...args: Parameters<typeof setValue>) => {
-              try {
-                await setValue(...args);
-              } catch (e) {
-                // do nothing
-              }
-            };
-
             return (
-              <div data-test-id="slug-editor">
-                <Component
-                  key={`slug-editor-${externalReset}`}
-                  locale={field.locale}
-                  createdAt={entrySys.createdAt}
-                  performUniqueCheck={performUniqueCheck}
-                  hasError={errors.length > 0}
-                  value={value}
-                  isOptionalLocaleWithFallback={isOptionalLocaleWithFallback}
-                  isDisabled={disabled}
-                  titleValue={titleValue}
-                  setValue={safeSetValue}
-                />
-              </div>
+              <FieldConnectorCallback
+                Component={Component}
+                titleValue={titleValue}
+                value={value}
+                errors={errors}
+                disabled={disabled}
+                setValue={setValue}
+                isOptionalLocaleWithFallback={isOptionalLocaleWithFallback}
+                createdAt={entrySys.createdAt}
+                locale={field.locale}
+                performUniqueCheck={performUniqueCheck}
+                key={`slug-editor-${externalReset}`}
+              />
             );
           }}
         </FieldConnector>

--- a/packages/slug/src/SlugEditorField.tsx
+++ b/packages/slug/src/SlugEditorField.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useDebounce } from 'use-debounce';
 import { TextInput, Icon, Spinner, ValidationMessage } from '@contentful/forma-36-react-components';
 import { makeSlug } from './services/makeSlug';
 import * as styles from './styles';
@@ -32,12 +33,13 @@ function useSlugUpdater(props: SlugEditorFieldProps, check: boolean) {
     if (newSlug !== value) {
       setValue(newSlug);
     }
-  }, [value, titleValue, isOptionalLocaleWithFallback, check]);
+  }, [value, titleValue, isOptionalLocaleWithFallback, check, createdAt, locale, setValue]);
 }
 
 function useUniqueChecker(props: SlugEditorFieldProps) {
-  const { value, performUniqueCheck } = props;
-  const [status, setStatus] = React.useState<CheckerState>(value ? 'checking' : 'unique');
+  const { performUniqueCheck } = props;
+  const [status, setStatus] = React.useState<CheckerState>(props.value ? 'checking' : 'unique');
+  const [debouncedValue] = useDebounce(props.value, 500, { leading: true });
 
   /**
    * Check the uniqueness of the slug in the current space.
@@ -45,19 +47,19 @@ function useUniqueChecker(props: SlugEditorFieldProps) {
    * current one, with the same slug.
    */
   React.useEffect(() => {
-    if (!value) {
+    if (!debouncedValue) {
       setStatus('unique');
       return;
     }
     setStatus('checking');
-    performUniqueCheck(value)
+    performUniqueCheck(debouncedValue)
       .then((unique) => {
         setStatus(unique ? 'unique' : 'duplicate');
       })
       .catch(() => {
         setStatus('checking');
       });
-  }, [value, performUniqueCheck]);
+  }, [debouncedValue, performUniqueCheck]);
 
   return status;
 }

--- a/packages/slug/src/SlugEditorField.tsx
+++ b/packages/slug/src/SlugEditorField.tsx
@@ -39,7 +39,7 @@ function useSlugUpdater(props: SlugEditorFieldProps, check: boolean) {
 function useUniqueChecker(props: SlugEditorFieldProps) {
   const { performUniqueCheck } = props;
   const [status, setStatus] = React.useState<CheckerState>(props.value ? 'checking' : 'unique');
-  const [debouncedValue] = useDebounce(props.value, 500, { leading: true });
+  const [debouncedValue] = useDebounce(props.value, 1000);
 
   /**
    * Check the uniqueness of the slug in the current space.
@@ -108,14 +108,16 @@ export function SlugEditorFieldStatic(
 }
 
 export function SlugEditorField(props: SlugEditorFieldProps) {
-  const areEqual = () => {
-    const potentialSlug = makeSlug(props.titleValue, {
-      isOptionalLocaleWithFallback: props.isOptionalLocaleWithFallback,
-      locale: props.locale,
-      createdAt: props.createdAt,
+  const { titleValue, isOptionalLocaleWithFallback, locale, createdAt, value } = props;
+
+  const areEqual = React.useCallback(() => {
+    const potentialSlug = makeSlug(titleValue, {
+      isOptionalLocaleWithFallback: isOptionalLocaleWithFallback,
+      locale: locale,
+      createdAt: createdAt,
     });
-    return props.value === potentialSlug;
-  };
+    return value === potentialSlug;
+  }, [titleValue, isOptionalLocaleWithFallback, locale, createdAt, value]);
 
   const [check, setCheck] = React.useState<boolean>(() => {
     if (props.value) {
@@ -131,7 +133,7 @@ export function SlugEditorField(props: SlugEditorFieldProps) {
     if (areEqual()) {
       setCheck(true);
     }
-  }, [props.titleValue]);
+  }, [props.titleValue, areEqual]);
 
   useSlugUpdater(props, check);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -22222,6 +22222,11 @@ url@^0.11.0:
     punycode "1.3.2"
     querystring "0.2.0"
 
+use-debounce@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/use-debounce/-/use-debounce-7.0.0.tgz#00a67d23d4fe09905e11145a99278da06c01c880"
+  integrity sha512-4fvxEEs7ztdNMh+c497HAgysdq2+Ascem6EaDANGlCIap1JzqfL03Xw8xkYc2lShfXm4uO6PA6V5zcXN7gJdFA==
+
 use@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"


### PR DESCRIPTION
Introduce debounced logic (1000 ms) for firing requests to check for field uniqueness.
It should significantly decrease the number of requests to `entries` endpoint.

Optimized callbacks by wrapping them in React.useCallback and providing with a correct set of dependencies.
