### PR TITLE
fix: FieldConnector setValue race conditions

### DIFF
--- a/packages/_shared/package.json
+++ b/packages/_shared/package.json
@@ -16,6 +16,8 @@
   "scripts": {
     "watch": "tsdx watch",
     "build": "tsdx build",
+    "test": "tsdx test --env=jsdom --watch",
+    "test:ci": "tsdx test --env=jsdom --ci",
     "tsc": "tsc -p ./ --noEmit"
   },
   "devDependencies": {

--- a/packages/_shared/src/FieldConnector.test.tsx
+++ b/packages/_shared/src/FieldConnector.test.tsx
@@ -1,0 +1,44 @@
+import { createFakeFieldAPI } from '@contentful/field-editor-test-utils';
+import { render } from '@testing-library/react';
+import noop from 'lodash/noop';
+import * as React from 'react';
+import { FieldConnector, FieldConnectorChildProps } from './FieldConnector';
+
+it('does not rerender with outdated value after calling setValue', () => {
+  function getChild(): FieldConnectorChildProps<any> {
+    return props.children.mock.calls[props.children.mock.calls.length - 1][0];
+  }
+
+  const onSchemaErrorsChanged = jest.fn();
+  const [field] = createFakeFieldAPI((field) => {
+    return {
+      ...field,
+      // this promise never resolves
+      setValue: () => new Promise(noop),
+      onSchemaErrorsChanged,
+    };
+  }, 'initial value');
+
+  const props = {
+    isInitiallyDisabled: false,
+    children: jest.fn().mockImplementation(() => null),
+    field,
+    throttle: 0,
+  };
+
+  render(<FieldConnector {...props} />);
+
+  let child = getChild();
+  expect(child.value).toBe('initial value');
+  const initialRenderCount = props.children.mock.calls.length;
+
+  child.setValue('new value');
+
+  onSchemaErrorsChanged.mock.calls.forEach(([cb]) => cb([]));
+
+  child = getChild();
+  expect(child.value).toBe('new value');
+
+  // to ensure that there was actually a rerender after calling `setValue` as we want to test that we don't rerender with outdated data
+  expect(props.children.mock.calls.length).toBeGreaterThan(initialRenderCount);
+});

--- a/packages/_shared/src/FieldConnector.ts
+++ b/packages/_shared/src/FieldConnector.ts
@@ -1,6 +1,6 @@
 import React from 'react';
-import throttle from 'lodash/throttle';
 import isEqual from 'lodash/isEqual';
+import throttle from 'lodash/throttle';
 import { FieldAPI } from '@contentful/app-sdk';
 
 type Nullable = null | undefined;
@@ -18,7 +18,6 @@ export interface FieldConnectorChildProps<ValueType> {
 interface FieldConnectorState<ValueType> {
   isLocalValueChange: boolean;
   externalReset: number;
-  lastSetValue: ValueType | Nullable;
   lastRemoteValue: ValueType | Nullable;
   value: ValueType | Nullable;
   disabled: boolean;
@@ -60,7 +59,6 @@ export class FieldConnector<ValueType> extends React.Component<
       isLocalValueChange: false,
       externalReset: 0,
       value: initialValue,
-      lastSetValue: initialValue,
       lastRemoteValue: initialValue,
       disabled: props.isInitiallyDisabled,
       errors: [],
@@ -71,34 +69,30 @@ export class FieldConnector<ValueType> extends React.Component<
   unsubscribeDisabled: Function | null = null;
   unsubscribeValue: Function | null = null;
 
-  setValue = throttle(
+  setValue = async (value: ValueType | Nullable) => {
+    if (this.props.isEmptyValue(value === undefined ? null : value)) {
+      this.setState({ value: undefined });
+    } else {
+      this.setState({ value });
+    }
+
+    await this.triggerSetValueCallbacks(value);
+  };
+
+  triggerSetValueCallbacks = throttle(
     (value: ValueType | Nullable) => {
-      if (this.props.isEmptyValue(value === undefined ? null : value)) {
-        return new Promise((resolve, reject) => {
-          this.setState(
-            {
-              lastSetValue: undefined,
-            },
-            () => {
-              this.props.field.removeValue().then(resolve).catch(reject);
-            }
-          );
-        });
-      } else {
-        return new Promise((resolve, reject) => {
-          this.setState(
-            {
-              lastSetValue: value,
-            },
-            () => {
-              this.props.field.setValue(value).then(resolve).catch(reject);
-            }
-          );
-        });
-      }
+      return new Promise((resolve, reject) => {
+        if (this.props.isEmptyValue(value === undefined ? null : value)) {
+          this.props.field.removeValue().then(resolve).catch(reject);
+        } else {
+          this.props.field.setValue(value).then(resolve).catch(reject);
+        }
+      });
     },
     this.props.throttle,
-    { leading: this.props.throttle === 0 }
+    {
+      leading: this.props.throttle === 0,
+    }
   );
 
   componentDidMount() {
@@ -115,12 +109,11 @@ export class FieldConnector<ValueType> extends React.Component<
     });
     this.unsubscribeValue = field.onValueChanged((value: ValueType | Nullable) => {
       this.setState((currentState) => {
-        const isLocalValueChange = this.props.isEqualValues(value, currentState.lastSetValue);
+        const isLocalValueChange = this.props.isEqualValues(value, currentState.value);
         const lastRemoteValue = isLocalValueChange ? currentState.lastRemoteValue : value;
         const externalReset = currentState.externalReset + (isLocalValueChange ? 0 : 1);
         return {
           value,
-          lastSetValue: value,
           lastRemoteValue,
           isLocalValueChange,
           externalReset,
@@ -142,15 +135,8 @@ export class FieldConnector<ValueType> extends React.Component<
   }
 
   render() {
-    const childProps = { ...this.state };
-    // `lastSetValue` can be either the `setValue()` value right after it got called
-    // or the current remote value. No use-case for passing this to child.
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    delete childProps.lastSetValue;
     return this.props.children({
-      ...childProps,
-      // @ts-expect-error
+      ...this.state,
       setValue: this.setValue,
     });
   }

--- a/packages/_shared/src/FieldConnector.ts
+++ b/packages/_shared/src/FieldConnector.ts
@@ -70,7 +70,7 @@ export class FieldConnector<ValueType> extends React.Component<
   unsubscribeValue: Function | null = null;
 
   setValue = async (value: ValueType | Nullable) => {
-    if (this.props.isEmptyValue(value === undefined ? null : value)) {
+    if (this.props.isEmptyValue(value ?? null)) {
       this.setState({ value: undefined });
     } else {
       this.setState({ value });
@@ -82,7 +82,7 @@ export class FieldConnector<ValueType> extends React.Component<
   triggerSetValueCallbacks = throttle(
     (value: ValueType | Nullable) => {
       return new Promise((resolve, reject) => {
-        if (this.props.isEmptyValue(value === undefined ? null : value)) {
+        if (this.props.isEmptyValue(value ?? null)) {
           this.props.field.removeValue().then(resolve).catch(reject);
         } else {
           this.props.field.setValue(value).then(resolve).catch(reject);


### PR DESCRIPTION
The `FieldConnector` currently only works correctly when the `onValueChanged` is triggered immediately after calling `setValue`. If another callback triggers a rerender (e.g. `onSchemaErrorsChanged`) the child component is rerendered with an outdated `value`. This can be potentially caused by `setValue` triggering a longer async function (e.g. a network connection). This gives plenty of time for another callback to fire. Also, throttling the `setValue` may also cause race conditions here.

This PR resolves this problem by immediately storing the value of `setValue` in the `FieldConnector`'s state. That way all future rerenders triggered by any callback will always pass the correct value to the component's `children`. The `setValue` call of the `FieldAPI` stays throttled to not break any existing behaviour.

This PR includes a test that demonstrates the issue and fails on `master`.