### PR TITLE
fix: do not resubscribe to errors on every render

### DIFF
--- a/packages/default-field-editors/src/FieldWrapper.tsx
+++ b/packages/default-field-editors/src/FieldWrapper.tsx
@@ -44,7 +44,7 @@ export const FieldWrapper: React.FC<FieldWrapperProps> = function (props: FieldW
     return field.onSchemaErrorsChanged((errors: unknown[]) => {
       setHasErrors((errors || []).length > 0);
     });
-  });
+  }, [field]);
 
   return (
     <FieldGroup


### PR DESCRIPTION
We currently resubscribe to `onSchemaErrorsChanged` on every render of the field. So we do not actually listen to changes but only use the current value that is emitted when subscribing.

This PR adds a `useEffect` dependency and to every field only subscribes to the errors once.