### PR TITLE
chore: update dependencies on RT by other packages

### DIFF
--- a/apps/rich-text-app/package.json
+++ b/apps/rich-text-app/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@contentful/app-sdk": "^3.36.0",
-    "@contentful/field-editor-rich-text": "^0.19.1",
+    "@contentful/field-editor-rich-text": "^0.21.6-next",
     "@contentful/field-editor-single-line": "^0.14.1",
     "@contentful/forma-36-fcss": "^0.3.3",
     "@contentful/forma-36-react-components": "^3.93.4",

--- a/packages/default-field-editors/package.json
+++ b/packages/default-field-editors/package.json
@@ -34,7 +34,7 @@
     "@contentful/field-editor-radio": "^0.13.2",
     "@contentful/field-editor-rating": "^0.12.2",
     "@contentful/field-editor-reference": "^2.20.6",
-    "@contentful/field-editor-rich-text": "^0.19.9",
+    "@contentful/field-editor-rich-text": "^0.21.6-next",
     "@contentful/field-editor-shared": "^0.22.1",
     "@contentful/field-editor-single-line": "^0.15.2",
     "@contentful/field-editor-slug": "^0.12.1",


### PR DESCRIPTION
Ensures all packages in the mono repo reference the `next` branch's `@contentful/field-editor-rich-text` version to avoid pulling in the old RT version which seems like it can cause issues.