### PR TITLE
fix(rich-text): embed entity widget dropdown glitch

### DIFF
--- a/packages/rich-text/src/Toolbar/EmbedEntityWidget.tsx
+++ b/packages/rich-text/src/Toolbar/EmbedEntityWidget.tsx
@@ -37,6 +37,14 @@ export const EmbedEntityWidget = ({ isDisabled, canInsertBlocks }: EmbedEntityWi
 
   const shouldDisplayDropdown = numEnabledEmbeds > 1;
 
+  // Avoids UI glitching when switching back and forth between
+  // different layouts
+  React.useEffect(() => {
+    if (!shouldDisplayDropdown) {
+      setEmbedDropdownOpen(false);
+    }
+  }, [shouldDisplayDropdown]);
+
   const actions = (
     <>
       {blockEntryEmbedEnabled && (


### PR DESCRIPTION
Fixes a small UI issue when:
* Embed entity dropdown is open and
* The user focuses in and out of a table
* The dropdown will open and close

The fix is to force close the dropdown when we switch to a single button layout.