### PR TITLE
chore: create insert before first void block global plugin

### DIFF
--- a/cypress/integration/RichTextEditor.spec.ts
+++ b/cypress/integration/RichTextEditor.spec.ts
@@ -302,6 +302,25 @@ describe('Rich Text Editor', () => {
         );
         expectRichTextFieldValue(expectedValue);
       });
+
+      // TODO: Cypress throwing after {enter}: Cannot resolve a Slate node from DOM node: [object HTMLSpanElement]
+      // Question: Can we fix it by upgrading the Cypress version? Is this one of those issues that happen because Cypress doesn't fire all the events Slate needs in its current version?
+      it.skip('should add line if HR is the first void block', () => {
+        editor().click();
+
+        getHrToolbarButton().click();
+
+        cy.findByTestId('rich-text-editor-hr').click();
+
+        editor().type('{enter}');
+
+        const expectedValue = doc(
+          block(BLOCKS.PARAGRAPH, {}, text('', [])),
+          block(BLOCKS.HR, {}),
+          block(BLOCKS.PARAGRAPH, {}, text('', []))
+        );
+        expectRichTextFieldValue(expectedValue);
+      });
     });
   });
 

--- a/packages/rich-text/src/RichTextEditor.tsx
+++ b/packages/rich-text/src/RichTextEditor.tsx
@@ -29,6 +29,7 @@ import { createUnderlinePlugin, withUnderlineOptions } from './plugins/Underline
 import { createParagraphPlugin, withParagraphOptions } from './plugins/Paragraph';
 import { createQuotePlugin, withQuoteOptions } from './plugins/Quote';
 import { createNewLinePlugin } from './plugins/NewLine';
+import { createInsertBeforeFirstVoidBlockPlugin } from './plugins/InsertBeforeFirstVoidBlock';
 import { createTablePlugin, withTableOptions } from './plugins/Table';
 import { createHyperlinkPlugin, withHyperlinkOptions } from './plugins/Hyperlink';
 import {
@@ -69,6 +70,7 @@ const getPlugins = (sdk: FieldExtensionSDK, tracking: TrackingProvider) => {
 
     // Global shortcuts
     createNewLinePlugin(),
+    createInsertBeforeFirstVoidBlockPlugin(),
 
     // Block Elements
     createParagraphPlugin(),

--- a/packages/rich-text/src/helpers/editor.ts
+++ b/packages/rich-text/src/helpers/editor.ts
@@ -57,7 +57,11 @@ export function isNodeTypeSelected(editor, nodeType: BLOCKS | INLINES): boolean 
 }
 
 export function moveToTheNextLine(editor) {
-  Transforms.move(editor, { distance: 1 });
+  Transforms.move(editor, { distance: 1, unit: 'line' });
+}
+
+export function moveToThePreviousLine(editor) {
+  Transforms.move(editor, { distance: 1, unit: 'line', reverse: true });
 }
 
 export function toggleBlock(editor, type: string): void {

--- a/packages/rich-text/src/plugins/InsertBeforeFirstVoidBlock/index.tsx
+++ b/packages/rich-text/src/plugins/InsertBeforeFirstVoidBlock/index.tsx
@@ -1,0 +1,40 @@
+import { KeyboardEvent } from 'react';
+import { PlatePlugin, SPEditor } from '@udecode/plate-core';
+import {
+  isFirstChild,
+  isVoid,
+  getElementFromCurrentSelection,
+  moveToThePreviousLine,
+} from '../../helpers/editor';
+import { Transforms, Path } from 'slate';
+import { BLOCKS } from '@contentful/rich-text-types';
+
+export function createInsertBeforeFirstVoidBlockPlugin(): PlatePlugin {
+  return {
+    onKeyDown: function (editor: SPEditor) {
+      return (event: KeyboardEvent) => {
+        const isEnter = event.key === 'Enter';
+        const [currentElement, currentPath] = getElementFromCurrentSelection(editor);
+        const isFirst = isFirstChild(currentPath as Path);
+
+        if (isEnter && isFirst && isVoid(editor, currentElement)) {
+          const paragraph = {
+            type: BLOCKS.PARAGRAPH,
+            data: {},
+            children: [{ text: '' }],
+          };
+
+          // It adds two paragraphs outside a timeout and after moving the cursor to the previous line, not sure why...
+          setTimeout(() => {
+            Transforms.insertNodes(editor, paragraph, { at: currentPath as Path });
+            moveToThePreviousLine(editor);
+          }, 0);
+
+          return true; // To prevent the next handler from running
+        }
+
+        return false; // something like next()
+      };
+    },
+  };
+}


### PR DESCRIPTION
It works for:

- HR
- Embedded asset
- Embedded entry

Any other void block?