### PR TITLE
refactor: use exit break plugin instead

### DIFF
--- a/packages/rich-text/package.json
+++ b/packages/rich-text/package.json
@@ -27,10 +27,11 @@
     "prepublishOnly": "yarn build"
   },
   "dependencies": {
-    "@contentful/forma-36-react-components": "^3.97.0",
     "@contentful/contentful-slatejs-adapter": "^14.2.0",
     "@contentful/field-editor-reference": "^2.20.6",
+    "@contentful/forma-36-react-components": "^3.97.0",
     "@contentful/rich-text-types": "^15.3.0",
+    "@udecode/plate-break": "^3.0.3",
     "@udecode/plate-common": "^2.0.0",
     "@udecode/plate-core": "^1.0.0",
     "@udecode/plate-html-serializer": "^2.0.0",

--- a/packages/rich-text/src/plugins/InsertBeforeFirstVoidBlock/index.tsx
+++ b/packages/rich-text/src/plugins/InsertBeforeFirstVoidBlock/index.tsx
@@ -1,40 +1,17 @@
-import { KeyboardEvent } from 'react';
-import { PlatePlugin, SPEditor } from '@udecode/plate-core';
-import {
-  isFirstChild,
-  isVoid,
-  getElementFromCurrentSelection,
-  moveToThePreviousLine,
-} from '../../helpers/editor';
-import { Transforms, Path } from 'slate';
-import { BLOCKS } from '@contentful/rich-text-types';
+import { PlatePlugin } from '@udecode/plate-core';
+import { isFirstChild } from '../../helpers/editor';
+import { ExitBreakPluginOptions, createExitBreakPlugin } from '@udecode/plate-break';
 
 export function createInsertBeforeFirstVoidBlockPlugin(): PlatePlugin {
-  return {
-    onKeyDown: function (editor: SPEditor) {
-      return (event: KeyboardEvent) => {
-        const isEnter = event.key === 'Enter';
-        const [currentElement, currentPath] = getElementFromCurrentSelection(editor);
-        const isFirst = isFirstChild(currentPath as Path);
-
-        if (isEnter && isFirst && isVoid(editor, currentElement)) {
-          const paragraph = {
-            type: BLOCKS.PARAGRAPH,
-            data: {},
-            children: [{ text: '' }],
-          };
-
-          // It adds two paragraphs outside a timeout and after moving the cursor to the previous line, not sure why...
-          setTimeout(() => {
-            Transforms.insertNodes(editor, paragraph, { at: currentPath as Path });
-            moveToThePreviousLine(editor);
-          }, 0);
-
-          return true; // To prevent the next handler from running
-        }
-
-        return false; // something like next()
-      };
-    },
+  const optionsExitBreakPlugin: ExitBreakPluginOptions = {
+    rules: [
+      {
+        hotkey: 'enter',
+        before: true,
+        query: { filter: ([node, path]) => isFirstChild(path) && !!node.isVoid },
+      },
+    ],
   };
+
+  return createExitBreakPlugin(optionsExitBreakPlugin);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4776,6 +4776,14 @@
     "@typescript-eslint/types" "4.27.0"
     eslint-visitor-keys "^2.0.0"
 
+"@udecode/plate-break@^3.0.3":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@udecode/plate-break/-/plate-break-3.0.3.tgz#a274f668dadab33c508bc4ec9cccfa8948a85e7e"
+  integrity sha512-2HowGJbuB8RAw6iFT694xDns+IiqUp13Y8D66ssmkz2KVQ7msKhaU5VedfAg+h3VO2aJJzTZLyYQH2V9N33NwA==
+  dependencies:
+    "@udecode/plate-common" "2.0.0"
+    "@udecode/plate-core" "1.0.0"
+
 "@udecode/plate-common@2.0.0", "@udecode/plate-common@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@udecode/plate-common/-/plate-common-2.0.0.tgz#60587a7a4238ba88b5286a2b5c2e0c9838208711"


### PR DESCRIPTION
Using one of their solutions to replace `setTimeout`. We decided to use their own plugin. The whole conversation can be read here: https://slate-js.slack.com/archives/C013QHXSCG1/p1631208644108100?thread_ts=1631022429.081900&cid=C013QHXSCG1

The second solution would be just adding a `select: true` property to `Transforms.insertNodes` such as:

```
Transforms.insertNodes(editor, paragraph, { at: currentPath as Path, select: true }
```