### PR TITLE
feat: export shared util to validate images

### DIFF
--- a/cypress/integration/LocationEditor.spec.ts
+++ b/cypress/integration/LocationEditor.spec.ts
@@ -1,5 +1,5 @@
 const LOCATION_1 = {
-  address: 'Platz der Deutschen Einheit 1, 20457 Hamburg, Germany',
+  address: 'Platz d. Deutschen Einheit 1, 20457 Hamburg, Germany',
   value: { lon: 9.98413, lat: 53.54132 },
 };
 const LOCATION_2 = {

--- a/packages/_shared/src/index.tsx
+++ b/packages/_shared/src/index.tsx
@@ -32,4 +32,6 @@ export { entityHelpers };
 import * as ConstraintsUtils from './utils/constraints';
 export { ConstraintsUtils };
 
+export { isValidImage } from './utils/isValidImage';
+
 export { Entry, File, Asset } from './typesEntity';

--- a/packages/_shared/src/utils/isValidImage.ts
+++ b/packages/_shared/src/utils/isValidImage.ts
@@ -1,0 +1,22 @@
+import { File } from '../typesEntity';
+
+/**
+ * Checks whether the passed content type matches one of our valid MIME types
+ */
+export function isValidImage(file: File) {
+  const validMimeTypes = [
+    'image/bmp',
+    'image/x-windows-bmp',
+    'image/gif',
+    'image/webp',
+    // This is not a valid MIME type but we supported it in the past.
+    'image/jpg',
+    'image/jpeg',
+    'image/pjpeg',
+    'image/x-jps',
+    'image/png',
+    'image/svg+xml',
+  ];
+
+  return validMimeTypes.includes(file.contentType);
+}


### PR DESCRIPTION
Next step: remove this util from the `reference` package and bump a minor version there, so current packages using it won't break.