### PR TITLE
refactor: implement entry card for rich text

### DIFF
--- a/cypress/integration/RichTextEditor.spec.ts
+++ b/cypress/integration/RichTextEditor.spec.ts
@@ -1065,6 +1065,31 @@ describe('Rich Text Editor', () => {
           expectRichTextFieldValue(undefined);
         });
 
+        it('adds and removes embedded entries by selecting and pressing `backspace`', () => {
+          editor().click().then(triggerEmbeddedEntry);
+
+          expectRichTextFieldValue(
+            doc(
+              block(BLOCKS.EMBEDDED_ENTRY, {
+                target: {
+                  sys: {
+                    id: 'example-entity-id',
+                    type: 'Link',
+                    linkType: 'Entry',
+                  },
+                },
+              }),
+              block(BLOCKS.PARAGRAPH, {}, text(''))
+            )
+          );
+
+          cy.findByTestId('cf-ui-entry-card').click();
+          // .type('{backspace}') does not work on non-typable elements.(contentEditable=false)
+          editor().trigger('keydown', { keyCode: 8, which: 8, key: 'Backspace' }); // 8 = delete/backspace
+
+          expectRichTextFieldValue(undefined);
+        });
+
         it('adds embedded entries between words', () => {
           editor()
             .click()

--- a/cypress/integration/RichTextEditor.spec.ts
+++ b/cypress/integration/RichTextEditor.spec.ts
@@ -1060,7 +1060,7 @@ describe('Rich Text Editor', () => {
           );
 
           cy.findByTestId('cf-ui-card-actions').click();
-          cy.findByTestId('delete').click();
+          cy.findByTestId('card-action-remove').click();
 
           expectRichTextFieldValue(undefined);
         });

--- a/cypress/integration/RichTextEditor.spec.ts
+++ b/cypress/integration/RichTextEditor.spec.ts
@@ -1159,6 +1159,31 @@ describe('Rich Text Editor', () => {
           expectRichTextFieldValue(undefined);
         });
 
+        it('adds and removes embedded assets by selecting and pressing `backspace`', () => {
+          editor().click().then(triggerEmbeddedAsset);
+
+          expectRichTextFieldValue(
+            doc(
+              block(BLOCKS.EMBEDDED_ASSET, {
+                target: {
+                  sys: {
+                    id: 'example-entity-id',
+                    type: 'Link',
+                    linkType: 'Asset',
+                  },
+                },
+              }),
+              block(BLOCKS.PARAGRAPH, {}, text(''))
+            )
+          );
+
+          cy.findByTestId('cf-ui-asset-card').click();
+          // .type('{backspace}') does not work on non-typable elements.(contentEditable=false)
+          editor().trigger('keydown', { keyCode: 8, which: 8, key: 'Backspace' }); // 8 = delete/backspace
+
+          expectRichTextFieldValue(undefined);
+        });
+
         it('adds embedded assets between words', () => {
           editor()
             .click()

--- a/packages/rich-text/package.json
+++ b/packages/rich-text/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@contentful/contentful-slatejs-adapter": "^15.3.5",
     "@contentful/field-editor-reference": "^2.20.6",
-    "@contentful/field-editor-shared": "^0.23.0",
+    "@contentful/field-editor-shared": "^0.24.0",
     "@contentful/forma-36-react-components": "^3.98.3",
     "@contentful/rich-text-types": "^15.3.6",
     "@udecode/plate-break": "^3.2.0",

--- a/packages/rich-text/package.json
+++ b/packages/rich-text/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "@contentful/contentful-slatejs-adapter": "^15.3.5",
     "@contentful/field-editor-reference": "^2.20.6",
+    "@contentful/field-editor-shared": "^0.23.0",
     "@contentful/forma-36-react-components": "^3.98.3",
     "@contentful/rich-text-types": "^15.3.6",
     "@udecode/plate-break": "^3.2.0",

--- a/packages/rich-text/src/plugins/EmbeddedEntityBlock/LinkedEntityBlock.tsx
+++ b/packages/rich-text/src/plugins/EmbeddedEntityBlock/LinkedEntityBlock.tsx
@@ -64,11 +64,6 @@ export function LinkedEntityBlock(props: LinkedEntityBlockProps) {
             isSelected={isSelected}
             onRemove={handleRemoveClick}
             onEdit={handleEditClick}
-            getEntryUrl={() => {
-              const getEntryUrl = sdk.parameters.instance.getEntryUrl;
-              return typeof getEntryUrl === 'function' ? getEntryUrl(entityId) : '';
-            }}
-            onEntityFetchComplete={onEntityFetchComplete}
           />
         )}
         {entityType === 'Asset' && (

--- a/packages/rich-text/src/plugins/EmbeddedEntityBlock/LinkedEntityBlock.tsx
+++ b/packages/rich-text/src/plugins/EmbeddedEntityBlock/LinkedEntityBlock.tsx
@@ -14,23 +14,18 @@ const styles = {
   }),
 };
 
-type LinkedEntityBlockProps = CustomRenderElementProps<
-  {
-    target: {
-      sys: {
-        id: string;
-        linkType: 'Entry' | 'Asset';
-        type: 'Link';
-      };
+type LinkedEntityBlockProps = CustomRenderElementProps<{
+  target: {
+    sys: {
+      id: string;
+      linkType: 'Entry' | 'Asset';
+      type: 'Link';
     };
-  },
-  {
-    onEntityFetchComplete: () => void;
-  }
->;
+  };
+}>;
 
 export function LinkedEntityBlock(props: LinkedEntityBlockProps) {
-  const { attributes, children, element, onEntityFetchComplete } = props;
+  const { attributes, children, element } = props;
   const isSelected = useSelected();
   const editor = useContentfulEditor();
   const sdk = useSdkContext();
@@ -75,11 +70,6 @@ export function LinkedEntityBlock(props: LinkedEntityBlockProps) {
             isSelected={isSelected}
             onRemove={handleRemoveClick}
             onEdit={handleEditClick}
-            getAssetUrl={() => {
-              const getAssetUrl = sdk.parameters.instance.getAssetUrl;
-              return typeof getAssetUrl === 'function' ? getAssetUrl(entityId) : '';
-            }}
-            onEntityFetchComplete={onEntityFetchComplete}
           />
         )}
       </div>

--- a/packages/rich-text/src/plugins/shared/EntityStatusIcon.tsx
+++ b/packages/rich-text/src/plugins/shared/EntityStatusIcon.tsx
@@ -1,0 +1,36 @@
+import * as React from 'react';
+import { Entry, Asset } from '@contentful/field-editor-shared';
+import { useEntities, ScheduledIconWithTooltip } from '@contentful/field-editor-reference';
+import { Icon } from '@contentful/forma-36-react-components';
+import { css } from 'emotion';
+import tokens from '@contentful/forma-36-tokens';
+
+const styles = {
+  scheduleIcon: css({
+    marginRight: tokens.spacing2Xs,
+  }),
+};
+
+interface EntityStatusIconProps {
+  entity: Entry | Asset;
+  entityType: 'Entry' | 'Asset';
+}
+
+export function EntityStatusIcon({ entity, entityType }: EntityStatusIconProps) {
+  const { loadEntityScheduledActions } = useEntities();
+
+  return (
+    <ScheduledIconWithTooltip
+      getEntityScheduledActions={loadEntityScheduledActions}
+      entityType={entityType}
+      entityId={entity.sys.id}>
+      <Icon
+        className={styles.scheduleIcon}
+        icon="Clock"
+        size="small"
+        color="muted"
+        testId="schedule-icon"
+      />
+    </ScheduledIconWithTooltip>
+  );
+}

--- a/packages/rich-text/src/plugins/shared/FetchingWrappedAssetCard.tsx
+++ b/packages/rich-text/src/plugins/shared/FetchingWrappedAssetCard.tsx
@@ -29,14 +29,14 @@ interface FetchingWrappedAssetCardProps {
   isDisabled: boolean;
   isSelected: boolean;
   locale: string;
-  onEdit: () => void;
-  onRemove: () => unknown;
+  onEdit?: () => void;
+  onRemove?: () => unknown;
   sdk: FieldExtensionSDK;
 }
 
 interface AssetDropdownMenuProps {
-  onEdit: () => void;
-  onRemove: () => void;
+  onEdit?: () => void;
+  onRemove?: () => void;
   isDisabled: boolean;
   entityFile: File;
 }
@@ -55,17 +55,21 @@ function AssetDropdownMenu({ onEdit, onRemove, isDisabled, entityFile }: AssetDr
     <React.Fragment>
       <DropdownList>
         <DropdownListItem isTitle={true}>Actions</DropdownListItem>
-        <DropdownListItem onClick={onEdit} testId="edit">
-          Edit
-        </DropdownListItem>
+        {onEdit && (
+          <DropdownListItem onClick={onEdit} testId="edit">
+            Edit
+          </DropdownListItem>
+        )}
         {entityFile && (
           <DropdownListItem onClick={downloadAsset} testId="card-action-download">
             Download
           </DropdownListItem>
         )}
-        <DropdownListItem onClick={onRemove} isDisabled={isDisabled} testId="delete">
-          Remove
-        </DropdownListItem>
+        {onRemove && (
+          <DropdownListItem onClick={onRemove} isDisabled={isDisabled} testId="delete">
+            Remove
+          </DropdownListItem>
+        )}
       </DropdownList>
 
       <DropdownList border="top">

--- a/packages/rich-text/src/plugins/shared/FetchingWrappedAssetCard.tsx
+++ b/packages/rich-text/src/plugins/shared/FetchingWrappedAssetCard.tsx
@@ -56,7 +56,7 @@ function AssetDropdownMenu({ onEdit, onRemove, isDisabled, entityFile }: AssetDr
       <DropdownList>
         <DropdownListItem isTitle={true}>Actions</DropdownListItem>
         {onEdit && (
-          <DropdownListItem onClick={onEdit} testId="edit">
+          <DropdownListItem onClick={onEdit} testId="card-action-edit">
             Edit
           </DropdownListItem>
         )}
@@ -66,7 +66,7 @@ function AssetDropdownMenu({ onEdit, onRemove, isDisabled, entityFile }: AssetDr
           </DropdownListItem>
         )}
         {onRemove && (
-          <DropdownListItem onClick={onRemove} isDisabled={isDisabled} testId="delete">
+          <DropdownListItem onClick={onRemove} isDisabled={isDisabled} testId="card-action-remove">
             Remove
           </DropdownListItem>
         )}

--- a/packages/rich-text/src/plugins/shared/FetchingWrappedAssetCard.tsx
+++ b/packages/rich-text/src/plugins/shared/FetchingWrappedAssetCard.tsx
@@ -1,38 +1,141 @@
 import * as React from 'react';
-import { AssetCard } from '@contentful/forma-36-react-components';
 import {
-  useEntities,
-  MissingEntityCard,
-  WrappedAssetCard,
-} from '@contentful/field-editor-reference';
+  AssetCard,
+  AssetType,
+  DropdownList,
+  DropdownListItem,
+} from '@contentful/forma-36-react-components';
+import { useEntities, MissingEntityCard } from '@contentful/field-editor-reference';
 import { FieldExtensionSDK } from '@contentful/app-sdk';
+import { entityHelpers, File, shortenStorageUnit } from '@contentful/field-editor-shared';
+import mimetype from '@contentful/mimetype';
+import { css } from 'emotion';
+import { EntityStatusIcon } from './EntityStatusIcon';
+
+const styles = {
+  assetCard: css({ cursor: 'pointer' }),
+  cardDropdown: css({
+    width: '300px',
+  }),
+  truncated: css({
+    overflow: 'hidden',
+    whiteSpace: 'nowrap',
+    textOverflow: 'ellipsis',
+  }),
+};
 
 interface FetchingWrappedAssetCardProps {
   assetId: string;
-  getAssetUrl?: (assetId: string) => string;
   isDisabled: boolean;
   isSelected: boolean;
   locale: string;
-  onEdit?: () => void;
-  onEntityFetchComplete?: () => void;
-  onRemove?: () => unknown;
+  onEdit: () => void;
+  onRemove: () => unknown;
   sdk: FieldExtensionSDK;
 }
 
+interface AssetDropdownMenuProps {
+  onEdit: () => void;
+  onRemove: () => void;
+  isDisabled: boolean;
+  entityFile: File;
+}
+
+function AssetDropdownMenu({ onEdit, onRemove, isDisabled, entityFile }: AssetDropdownMenuProps) {
+  const { fileName, contentType: mimeType, details } = entityFile;
+  const { size: fileSize, image } = details;
+
+  function downloadAsset() {
+    if (!entityFile) return;
+
+    window.open(entityFile.url, '_blank', 'noopener,noreferrer');
+  }
+
+  return (
+    <React.Fragment>
+      <DropdownList>
+        <DropdownListItem isTitle={true}>Actions</DropdownListItem>
+        <DropdownListItem onClick={onEdit} testId="edit">
+          Edit
+        </DropdownListItem>
+        {entityFile && (
+          <DropdownListItem onClick={downloadAsset} testId="card-action-download">
+            Download
+          </DropdownListItem>
+        )}
+        <DropdownListItem onClick={onRemove} isDisabled={isDisabled} testId="delete">
+          Remove
+        </DropdownListItem>
+      </DropdownList>
+
+      <DropdownList border="top">
+        <DropdownListItem isTitle={true}>File info</DropdownListItem>
+        {fileName && (
+          <DropdownListItem>
+            <div className={styles.truncated}>{fileName}</div>
+          </DropdownListItem>
+        )}
+        {mimeType && (
+          <DropdownListItem>
+            <div>{mimeType}</div>
+          </DropdownListItem>
+        )}
+        {fileSize && <DropdownListItem>{shortenStorageUnit(fileSize, 'B')}</DropdownListItem>}
+        {image && <DropdownListItem>{`${image.width} × ${image.height}`}</DropdownListItem>}
+      </DropdownList>
+    </React.Fragment>
+  );
+}
+
 export function FetchingWrappedAssetCard(props: FetchingWrappedAssetCardProps) {
-  const { getOrLoadAsset, loadEntityScheduledActions, assets } = useEntities();
+  const { getOrLoadAsset, assets } = useEntities();
+  const asset = assets[props.assetId];
+  const defaultLocaleCode = props.sdk.locales.default;
+  const entityFile: File | undefined = asset?.fields.file
+    ? asset.fields.file[props.locale] || asset.fields.file[defaultLocaleCode]
+    : undefined;
 
   React.useEffect(() => {
     getOrLoadAsset(props.assetId);
   }, [props.assetId]); // eslint-disable-line
 
-  const asset = assets[props.assetId];
+  function getAssetSrc() {
+    if (!entityFile?.url) return '';
 
-  React.useEffect(() => {
-    if (!asset) return;
+    return `${entityFile.url}?h=300`;
+  }
 
-    props.onEntityFetchComplete && props.onEntityFetchComplete();
-  }, [asset]); // eslint-disable-line
+  function getFileType(): AssetType {
+    const groupToIconMap = {
+      image: 'image',
+      video: 'video',
+      audio: 'audio',
+      richtext: 'richtext',
+      presentation: 'presentation',
+      spreadsheet: 'spreadsheet',
+      pdfdocument: 'pdf',
+      archive: 'archive',
+      plaintext: 'plaintext',
+      code: 'code',
+      markup: 'markup',
+    };
+    const archive = groupToIconMap['archive'] as AssetType;
+
+    if (!entityFile) {
+      return archive;
+    }
+
+    const groupName: keyof typeof groupToIconMap = mimetype.getGroupLabel({
+      type: entityFile.contentType,
+      fallbackFileName: entityFile.fileName,
+    });
+
+    return (groupToIconMap[groupName] as AssetType) || archive;
+  }
+
+  if (asset === undefined) {
+    return <AssetCard size="default" isLoading={true} title="" src="" href="" />;
+  }
 
   if (asset === 'failed') {
     return (
@@ -44,25 +147,45 @@ export function FetchingWrappedAssetCard(props: FetchingWrappedAssetCardProps) {
     );
   }
 
-  if (asset === undefined) {
-    return <AssetCard size="default" isLoading title="" src="" href="" />;
+  const status = asset ? entityHelpers.getEntryStatus(asset.sys) : undefined;
+  if (status === 'deleted') {
+    return (
+      <MissingEntityCard
+        entityType="Asset"
+        asSquare={true}
+        isDisabled={props.isDisabled}
+        onRemove={props.onRemove}
+      />
+    );
   }
 
+  const entityTitle = entityHelpers.getAssetTitle({
+    asset,
+    localeCode: props.locale,
+    defaultLocaleCode,
+    defaultTitle: 'Untitled',
+  });
+
   return (
-    <WrappedAssetCard
-      asset={asset}
-      defaultLocaleCode={props.sdk.locales.default}
-      // @ts-expect-error
-      getAsset={props.sdk.space.getAsset} // TODO: How can we fix its type?
-      getAssetUrl={props.getAssetUrl}
-      getEntityScheduledActions={loadEntityScheduledActions}
-      isClickable={false}
-      isDisabled={props.isDisabled}
-      isSelected={props.isSelected}
-      localeCode={props.locale}
-      onEdit={props.onEdit}
-      onRemove={props.onRemove}
+    <AssetCard
+      title={entityTitle}
+      selected={props.isSelected}
       size="default"
+      src={getAssetSrc()}
+      type={getFileType()}
+      status={status}
+      statusIcon={<EntityStatusIcon entityType="Asset" entity={asset} />}
+      className={styles.assetCard}
+      dropdownListElements={
+        entityFile && (
+          <AssetDropdownMenu
+            onEdit={props.onEdit}
+            onRemove={props.onRemove}
+            isDisabled={props.isDisabled}
+            entityFile={entityFile}
+          />
+        )
+      }
     />
   );
 }

--- a/packages/rich-text/src/plugins/shared/FetchingWrappedEntryCard.tsx
+++ b/packages/rich-text/src/plugins/shared/FetchingWrappedEntryCard.tsx
@@ -40,10 +40,10 @@ function EntryDropdownMenu({ onEdit, onRemove, isDisabled }: EntryDropdownMenuPr
   return (
     <DropdownList>
       <DropdownListItem isTitle={true}>Actions</DropdownListItem>
-      <DropdownListItem onClick={onEdit} testId="edit">
+      <DropdownListItem onClick={onEdit} testId="card-action-edit">
         Edit
       </DropdownListItem>
-      <DropdownListItem onClick={onRemove} isDisabled={isDisabled} testId="delete">
+      <DropdownListItem onClick={onRemove} isDisabled={isDisabled} testId="card-action-remove">
         Remove
       </DropdownListItem>
     </DropdownList>

--- a/packages/rich-text/src/plugins/shared/FetchingWrappedEntryCard.tsx
+++ b/packages/rich-text/src/plugins/shared/FetchingWrappedEntryCard.tsx
@@ -1,38 +1,132 @@
 import * as React from 'react';
-import { EntryCard } from '@contentful/forma-36-react-components';
+import {
+  EntryCard,
+  DropdownList,
+  DropdownListItem,
+  Icon,
+} from '@contentful/forma-36-react-components';
 import {
   useEntities,
   MissingEntityCard,
-  WrappedEntryCard,
+  ScheduledIconWithTooltip,
+  AssetThumbnail,
 } from '@contentful/field-editor-reference';
+import tokens from '@contentful/forma-36-tokens';
 import { FieldExtensionSDK } from '@contentful/app-sdk';
+import { entityHelpers, File, Entry, isValidImage } from '@contentful/field-editor-shared';
+import { css } from 'emotion';
+
+const styles = {
+  entryCard: css({ cursor: 'pointer' }),
+  scheduleIcon: css({
+    marginRight: tokens.spacing2Xs,
+  }),
+};
 
 interface FetchingWrappedEntryCardProps {
   entryId: string;
-  getEntryUrl?: (entryId: string) => string;
   isDisabled: boolean;
   isSelected: boolean;
   locale: string;
-  onEdit?: () => void;
-  onEntityFetchComplete?: () => void;
-  onRemove?: () => unknown;
+  onEdit: () => void;
+  onRemove: () => void;
   sdk: FieldExtensionSDK;
 }
 
+interface EntryThumbnailProps {
+  file: File;
+}
+
+interface EntryStatusIconProps {
+  entry: Entry;
+}
+
+interface EntryDropdownMenuProps {
+  onEdit: () => void;
+  onRemove: () => void;
+  isDisabled: boolean;
+}
+
+function EntryThumbnail({ file }: EntryThumbnailProps) {
+  if (!isValidImage(file)) return null;
+
+  return <AssetThumbnail file={file as File} />;
+}
+
+function EntryStatusIcon({ entry }: EntryStatusIconProps) {
+  const { loadEntityScheduledActions } = useEntities();
+
+  return (
+    <ScheduledIconWithTooltip
+      getEntityScheduledActions={loadEntityScheduledActions}
+      entityType="Entry"
+      entityId={entry.sys.id}>
+      <Icon
+        className={styles.scheduleIcon}
+        icon="Clock"
+        size="small"
+        color="muted"
+        testId="schedule-icon"
+      />
+    </ScheduledIconWithTooltip>
+  );
+}
+
+function EntryDropdownMenu({ onEdit, onRemove, isDisabled }: EntryDropdownMenuProps) {
+  return (
+    <DropdownList>
+      <DropdownListItem onClick={onEdit} testId="edit">
+        Edit
+      </DropdownListItem>
+      <DropdownListItem onClick={onRemove} isDisabled={isDisabled} testId="delete">
+        Remove
+      </DropdownListItem>
+    </DropdownList>
+  );
+}
+
 export function FetchingWrappedEntryCard(props: FetchingWrappedEntryCardProps) {
-  const { getOrLoadEntry, loadEntityScheduledActions, entries } = useEntities();
+  const { getOrLoadEntry, entries } = useEntities();
+  const [file, setFile] = React.useState<null | File>(null);
+  const entry = React.useMemo(() => entries[props.entryId], [entries, props.entryId]);
+  const contentType = React.useMemo(
+    () =>
+      props.sdk.space
+        .getCachedContentTypes()
+        .find((contentType) => contentType.sys.id === entry?.sys.contentType.sys.id),
+    [props.sdk, entry]
+  );
+  const entryStatus = React.useMemo(
+    () => (entry ? entityHelpers.getEntryStatus(entry.sys) : undefined),
+    [entry]
+  );
+
+  const defaultLocaleCode = props.sdk.locales.default;
+
+  React.useEffect(() => {
+    if (!entry) return;
+
+    entityHelpers
+      .getEntryImage(
+        {
+          entry,
+          contentType,
+          localeCode: props.locale,
+          defaultLocaleCode,
+        },
+        props.sdk.space.getAsset
+      )
+      .then(setFile)
+      .catch(() => setFile(null));
+  }, [entry, contentType, props.locale, defaultLocaleCode, props.sdk, file]);
 
   React.useEffect(() => {
     getOrLoadEntry(props.entryId);
   }, [props.entryId]); // eslint-disable-line
 
-  const entry = entries[props.entryId];
-
-  React.useEffect(() => {
-    if (!entry) return;
-
-    props.onEntityFetchComplete && props.onEntityFetchComplete();
-  }, [entry]); // eslint-disable-line
+  if (entry === undefined) {
+    return <EntryCard size="default" loading={true} />;
+  }
 
   if (entry === 'failed') {
     return (
@@ -44,30 +138,49 @@ export function FetchingWrappedEntryCard(props: FetchingWrappedEntryCardProps) {
     );
   }
 
-  if (entry === undefined) {
-    return <EntryCard size="default" loading={true} />;
+  if (entryStatus === 'deleted') {
+    return (
+      <MissingEntityCard
+        entityType="Entry"
+        isDisabled={props.isDisabled}
+        onRemove={props.onRemove}
+      />
+    );
   }
 
-  const contentType = props.sdk.space
-    .getCachedContentTypes()
-    .find((contentType) => contentType.sys.id === entry.sys.contentType.sys.id);
+  const title = entityHelpers.getEntryTitle({
+    entry,
+    contentType,
+    localeCode: props.locale,
+    defaultLocaleCode,
+    defaultTitle: 'Untitled',
+  });
+
+  const description = entityHelpers.getEntityDescription({
+    entity: entry,
+    contentType,
+    localeCode: props.locale,
+    defaultLocaleCode,
+  });
 
   return (
-    <WrappedEntryCard
-      contentType={contentType}
-      defaultLocaleCode={props.sdk.locales.default}
-      entry={entry}
-      entryUrl={props.getEntryUrl && props.getEntryUrl(entry.sys.id)}
-      getAsset={props.sdk.space.getAsset}
-      getEntityScheduledActions={loadEntityScheduledActions}
-      isClickable={false}
-      isDisabled={props.isDisabled}
-      isSelected={props.isSelected}
-      localeCode={props.locale}
-      onEdit={props.onEdit}
-      onRemove={props.onRemove}
+    <EntryCard
+      contentType={contentType?.name}
+      title={title}
+      description={description}
       size="default"
-      hasMoveOptions={false}
+      selected={props.isSelected}
+      status={entryStatus}
+      className={styles.entryCard}
+      thumbnailElement={file ? <EntryThumbnail file={file} /> : null}
+      statusIcon={<EntryStatusIcon entry={entry} />}
+      dropdownListElements={
+        <EntryDropdownMenu
+          isDisabled={props.isDisabled}
+          onEdit={props.onEdit}
+          onRemove={props.onRemove}
+        />
+      }
     />
   );
 }

--- a/packages/rich-text/src/plugins/shared/FetchingWrappedEntryCard.tsx
+++ b/packages/rich-text/src/plugins/shared/FetchingWrappedEntryCard.tsx
@@ -15,9 +15,9 @@ interface FetchingWrappedEntryCardProps {
   isDisabled: boolean;
   isSelected: boolean;
   locale: string;
-  onEdit: () => void;
-  onRemove: () => void;
   sdk: FieldExtensionSDK;
+  onEdit?: () => void;
+  onRemove?: () => void;
 }
 
 interface EntryThumbnailProps {
@@ -84,6 +84,18 @@ export function FetchingWrappedEntryCard(props: FetchingWrappedEntryCardProps) {
     getOrLoadEntry(props.entryId);
   }, [props.entryId]); // eslint-disable-line
 
+  function renderDropdown() {
+    if (!props.onEdit || !props.onRemove) return undefined;
+
+    return (
+      <EntryDropdownMenu
+        isDisabled={props.isDisabled}
+        onEdit={props.onEdit}
+        onRemove={props.onRemove}
+      />
+    );
+  }
+
   if (entry === undefined) {
     return <EntryCard size="default" loading={true} />;
   }
@@ -135,13 +147,7 @@ export function FetchingWrappedEntryCard(props: FetchingWrappedEntryCardProps) {
       className={styles.entryCard}
       thumbnailElement={file ? <EntryThumbnail file={file} /> : null}
       statusIcon={<EntityStatusIcon entityType="Entry" entity={entry} />}
-      dropdownListElements={
-        <EntryDropdownMenu
-          isDisabled={props.isDisabled}
-          onEdit={props.onEdit}
-          onRemove={props.onRemove}
-        />
-      }
+      dropdownListElements={renderDropdown()}
     />
   );
 }

--- a/packages/rich-text/src/plugins/shared/FetchingWrappedEntryCard.tsx
+++ b/packages/rich-text/src/plugins/shared/FetchingWrappedEntryCard.tsx
@@ -1,26 +1,13 @@
 import * as React from 'react';
-import {
-  EntryCard,
-  DropdownList,
-  DropdownListItem,
-  Icon,
-} from '@contentful/forma-36-react-components';
-import {
-  useEntities,
-  MissingEntityCard,
-  ScheduledIconWithTooltip,
-  AssetThumbnail,
-} from '@contentful/field-editor-reference';
-import tokens from '@contentful/forma-36-tokens';
+import { EntryCard, DropdownList, DropdownListItem } from '@contentful/forma-36-react-components';
+import { useEntities, MissingEntityCard, AssetThumbnail } from '@contentful/field-editor-reference';
 import { FieldExtensionSDK } from '@contentful/app-sdk';
-import { entityHelpers, File, Entry, isValidImage } from '@contentful/field-editor-shared';
+import { entityHelpers, File, isValidImage } from '@contentful/field-editor-shared';
 import { css } from 'emotion';
+import { EntityStatusIcon } from './EntityStatusIcon';
 
 const styles = {
   entryCard: css({ cursor: 'pointer' }),
-  scheduleIcon: css({
-    marginRight: tokens.spacing2Xs,
-  }),
 };
 
 interface FetchingWrappedEntryCardProps {
@@ -37,10 +24,6 @@ interface EntryThumbnailProps {
   file: File;
 }
 
-interface EntryStatusIconProps {
-  entry: Entry;
-}
-
 interface EntryDropdownMenuProps {
   onEdit: () => void;
   onRemove: () => void;
@@ -53,28 +36,10 @@ function EntryThumbnail({ file }: EntryThumbnailProps) {
   return <AssetThumbnail file={file as File} />;
 }
 
-function EntryStatusIcon({ entry }: EntryStatusIconProps) {
-  const { loadEntityScheduledActions } = useEntities();
-
-  return (
-    <ScheduledIconWithTooltip
-      getEntityScheduledActions={loadEntityScheduledActions}
-      entityType="Entry"
-      entityId={entry.sys.id}>
-      <Icon
-        className={styles.scheduleIcon}
-        icon="Clock"
-        size="small"
-        color="muted"
-        testId="schedule-icon"
-      />
-    </ScheduledIconWithTooltip>
-  );
-}
-
 function EntryDropdownMenu({ onEdit, onRemove, isDisabled }: EntryDropdownMenuProps) {
   return (
     <DropdownList>
+      <DropdownListItem isTitle={true}>Actions</DropdownListItem>
       <DropdownListItem onClick={onEdit} testId="edit">
         Edit
       </DropdownListItem>
@@ -87,8 +52,8 @@ function EntryDropdownMenu({ onEdit, onRemove, isDisabled }: EntryDropdownMenuPr
 
 export function FetchingWrappedEntryCard(props: FetchingWrappedEntryCardProps) {
   const { getOrLoadEntry, entries } = useEntities();
-  const [file, setFile] = React.useState<null | File>(null);
-  const entry = React.useMemo(() => entries[props.entryId], [entries, props.entryId]);
+  const [file, setFile] = React.useState<File | null>(null);
+  const entry = entries[props.entryId];
   const contentType = React.useMemo(
     () =>
       props.sdk.space
@@ -96,11 +61,6 @@ export function FetchingWrappedEntryCard(props: FetchingWrappedEntryCardProps) {
         .find((contentType) => contentType.sys.id === entry?.sys.contentType.sys.id),
     [props.sdk, entry]
   );
-  const entryStatus = React.useMemo(
-    () => (entry ? entityHelpers.getEntryStatus(entry.sys) : undefined),
-    [entry]
-  );
-
   const defaultLocaleCode = props.sdk.locales.default;
 
   React.useEffect(() => {
@@ -138,6 +98,7 @@ export function FetchingWrappedEntryCard(props: FetchingWrappedEntryCardProps) {
     );
   }
 
+  const entryStatus = entry ? entityHelpers.getEntryStatus(entry.sys) : undefined;
   if (entryStatus === 'deleted') {
     return (
       <MissingEntityCard
@@ -173,7 +134,7 @@ export function FetchingWrappedEntryCard(props: FetchingWrappedEntryCardProps) {
       status={entryStatus}
       className={styles.entryCard}
       thumbnailElement={file ? <EntryThumbnail file={file} /> : null}
-      statusIcon={<EntryStatusIcon entry={entry} />}
+      statusIcon={<EntityStatusIcon entityType="Entry" entity={entry} />}
       dropdownListElements={
         <EntryDropdownMenu
           isDisabled={props.isDisabled}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1913,6 +1913,16 @@
     lodash "^4.17.15"
     lodash-es "^4.17.15"
 
+"@contentful/field-editor-shared@^0.23.0":
+  version "0.23.0"
+  resolved "https://registry.yarnpkg.com/@contentful/field-editor-shared/-/field-editor-shared-0.23.0.tgz#ce3b9c34edb901cc10ff401e13e03989288a1062"
+  integrity sha512-+yegJaiVvTL6rIHmXO9QVAbOFv9UVBZL4quDlFQM+ZGEnunY5ylNZhiY4r0Sz5bV7vDAEf1oyJFbWSqKW0a9VA==
+  dependencies:
+    "@contentful/forma-36-tokens" "^0.11.0"
+    emotion "^10.0.17"
+    lodash "^4.17.15"
+    lodash-es "^4.17.15"
+
 "@contentful/field-editor-single-line@^0.14.1", "@contentful/field-editor-single-line@^0.14.6":
   version "0.14.6"
   resolved "https://registry.yarnpkg.com/@contentful/field-editor-single-line/-/field-editor-single-line-0.14.6.tgz#9e2b78aa0c7537e6024241b40d9a856e4613ec6d"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1913,10 +1913,10 @@
     lodash "^4.17.15"
     lodash-es "^4.17.15"
 
-"@contentful/field-editor-shared@^0.23.0":
-  version "0.23.0"
-  resolved "https://registry.yarnpkg.com/@contentful/field-editor-shared/-/field-editor-shared-0.23.0.tgz#ce3b9c34edb901cc10ff401e13e03989288a1062"
-  integrity sha512-+yegJaiVvTL6rIHmXO9QVAbOFv9UVBZL4quDlFQM+ZGEnunY5ylNZhiY4r0Sz5bV7vDAEf1oyJFbWSqKW0a9VA==
+"@contentful/field-editor-shared@^0.24.0":
+  version "0.24.0"
+  resolved "https://registry.yarnpkg.com/@contentful/field-editor-shared/-/field-editor-shared-0.24.0.tgz#9a53f2c40d57e23af96b67bb831aafa67071819a"
+  integrity sha512-OWNmRhOKwG5EEtS04EUhC0Y242m/suuuCX7oMq9JGo1cTuEoEAOWWzSySiZNH7NO7OheBjpIt5vcIommxQ9TCg==
   dependencies:
     "@contentful/forma-36-tokens" "^0.11.0"
     emotion "^10.0.17"


### PR DESCRIPTION
It fixes and re-implement entry and asset cards. It mimics some of the behavior from the `referece` package but I removed all the unnecessary parts for the `rich-text`.
