### PR TITLE
fix: paste issues

### DIFF
--- a/packages/rich-text/src/RichTextEditor.tsx
+++ b/packages/rich-text/src/RichTextEditor.tsx
@@ -9,6 +9,7 @@ import schema from './constants/Schema';
 import deepEquals from 'fast-deep-equal';
 import Toolbar from './Toolbar';
 import StickyToolbarWrapper from './Toolbar/StickyToolbarWrapper';
+import { createPastePlugin } from './plugins/Paste';
 import { withListOptions } from './plugins/List';
 import {
   Plate,
@@ -71,6 +72,9 @@ const getPlugins = (sdk: FieldExtensionSDK, tracking: TrackingProvider) => {
     createReactPlugin(),
     createHistoryPlugin(),
 
+    // Behavior
+    createPastePlugin(),
+
     // Global shortcuts
     createNewLinePlugin(),
     createInsertBeforeFirstVoidBlockPlugin(),
@@ -123,7 +127,6 @@ const options = {
   ...withItalicOptions,
   ...withUnderlineOptions,
 };
-
 export const ConnectedRichTextEditor = (props: ConnectedProps) => {
   const tracking = useTrackingContext();
 

--- a/packages/rich-text/src/plugins/Paste/index.tsx
+++ b/packages/rich-text/src/plugins/Paste/index.tsx
@@ -1,0 +1,40 @@
+import { PlatePlugin, SPEditor } from '@udecode/plate-core';
+import * as sanitizers from './sanitizers';
+import flow from 'lodash/flow';
+
+const MIME_TYPE_HTML = 'text/html';
+
+// TODO: Upgrade tslib so we can just flow(...sanitizers);
+const sanitizeDocument = flow.apply(this, Object.values(sanitizers));
+
+const sanitizeHtml = (html: string, editor: SPEditor): string => {
+  const doc = new DOMParser().parseFromString(html, MIME_TYPE_HTML);
+  const [sanitizedDoc] = sanitizeDocument([doc, editor]);
+  const sanitizedData = new XMLSerializer().serializeToString(sanitizedDoc);
+  return sanitizedData;
+};
+
+const htmlToDataTransfer = (html: string): DataTransfer => {
+  const data = new DataTransfer();
+  data.setData(MIME_TYPE_HTML, html);
+  return data;
+};
+
+function withPasteHandling(editor: SPEditor) {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  return (_event: React.KeyboardEvent) => {
+    const { insertData } = editor;
+    editor.insertData = (data: DataTransfer) => {
+      const html = data.getData(MIME_TYPE_HTML);
+      if (html) {
+        const sanitized = sanitizeHtml(html, editor);
+        const newData = htmlToDataTransfer(sanitized);
+        insertData(newData);
+      }
+    };
+  };
+}
+
+export const createPastePlugin = (): PlatePlugin => ({
+  onKeyDown: withPasteHandling,
+});

--- a/packages/rich-text/src/plugins/Paste/sanitizers/helpers.tsx
+++ b/packages/rich-text/src/plugins/Paste/sanitizers/helpers.tsx
@@ -1,0 +1,24 @@
+import { SPEditor } from '@udecode/plate-core';
+
+export type SanitizerTuple = [Document, SPEditor];
+
+type Predicate = (node: ChildNode) => boolean;
+
+const removeChildNodes = (node: ChildNode, predicate: Predicate) =>
+  Array.from(node.childNodes)
+    .filter(predicate)
+    .forEach((table) => node.removeChild(table));
+
+export const removeChildNodesUsingPredicate =
+  (predicate: Predicate) =>
+  (nodeList: NodeList): Node[] => {
+    const nodes = Array.from(nodeList);
+    while (nodes.length > 0) {
+      const node = nodes.pop() as ChildNode;
+      removeChildNodes(node, predicate);
+      for (const childNode of Array.from(node.childNodes)) {
+        nodes.push(childNode);
+      }
+    }
+    return nodes;
+  };

--- a/packages/rich-text/src/plugins/Paste/sanitizers/index.tsx
+++ b/packages/rich-text/src/plugins/Paste/sanitizers/index.tsx
@@ -1,0 +1,2 @@
+export { removeComments } from './removeComments';
+export { sanitizeTables } from './sanitizeTables';

--- a/packages/rich-text/src/plugins/Paste/sanitizers/removeComments.tsx
+++ b/packages/rich-text/src/plugins/Paste/sanitizers/removeComments.tsx
@@ -1,0 +1,10 @@
+import { removeChildNodesUsingPredicate, SanitizerTuple } from './helpers';
+
+const isComment = (node: ChildNode): node is Comment => node.nodeType === Node.COMMENT_NODE;
+
+const removeCommentChildren = removeChildNodesUsingPredicate(isComment);
+
+export const removeComments = ([doc, editor]: SanitizerTuple): SanitizerTuple => {
+  removeCommentChildren(doc.childNodes);
+  return [doc, editor];
+};

--- a/packages/rich-text/src/plugins/Paste/sanitizers/sanitizeTables.tsx
+++ b/packages/rich-text/src/plugins/Paste/sanitizers/sanitizeTables.tsx
@@ -1,0 +1,38 @@
+import { BLOCKS } from '@contentful/rich-text-types';
+import { getNodeEntryFromSelection } from '../../../helpers/editor';
+import { removeChildNodesUsingPredicate, SanitizerTuple } from './helpers';
+
+const TAG_NAME_TABLE = 'TABLE';
+
+const isHTMLElement = (node: ChildNode): node is HTMLElement => node.nodeType === Node.ELEMENT_NODE;
+
+const isTableElement = (node: ChildNode): node is HTMLTableElement =>
+  isHTMLElement(node) && node.tagName === TAG_NAME_TABLE;
+
+const removeTableChildren = removeChildNodesUsingPredicate(isTableElement);
+
+const removeTableGrandchildren = (nodeList: NodeList) => {
+  const nodes = Array.from(nodeList);
+  while (nodes.length > 0) {
+    const node = nodes.pop() as ChildNode;
+    if (isTableElement(node)) {
+      removeTableChildren(node.childNodes);
+      continue;
+    }
+    for (const childNode of Array.from(node.childNodes)) {
+      nodes.push(childNode);
+    }
+  }
+  return nodes;
+};
+
+export const sanitizeTables = ([doc, editor]: SanitizerTuple): SanitizerTuple => {
+  const [node] = getNodeEntryFromSelection(editor, BLOCKS.TABLE);
+  const isTableInCurrentSelection = !!node;
+  if (isTableInCurrentSelection) {
+    removeTableChildren(doc.childNodes);
+  } else {
+    removeTableGrandchildren(doc.childNodes);
+  }
+  return [doc, editor];
+};


### PR DESCRIPTION
Fixes a couple of issues caused by the paste buffer being overly permissive in respect to HTML elements.

- [x] removes ability to paste tables within tables
- [x] strip comments from pasted HTML markup