### PR TITLE
refactor: refactor HelpText to Text from Forma36 v4 [BAU-104]

### DIFF
--- a/apps/entry-app-collapsible/src/CollapsibleFieldGroup.tsx
+++ b/apps/entry-app-collapsible/src/CollapsibleFieldGroup.tsx
@@ -3,7 +3,8 @@ import { LocalesAPI } from '@contentful/field-editor-shared';
 import { Field } from './Field';
 import { FieldGroupType, FieldType } from './types';
 import styles from './styles';
-import { Icon, HelpText } from '@contentful/forma-36-react-components';
+import { Icon } from '@contentful/forma-36-react-components';
+import { Text } from '@contentful/f36-components';
 import { EntryFieldAPI } from '@contentful/app-sdk';
 
 interface CollapsibleFieldGroupProps {
@@ -29,7 +30,9 @@ export const CollapsibleFieldGroup: React.FC<CollapsibleFieldGroupProps> = ({
               <Icon className={styles.icon} icon={isOpen ? 'ChevronDown' : 'ChevronRight'} />
               <h3>{fieldGroup.name}</h3>
             </div>
-            <HelpText>{fieldGroup.fields.length} fields</HelpText>
+            <Text as="p" fontColor="gray500" marginTop="spacingXs">
+              {fieldGroup.fields.length} fields
+            </Text>
           </button>
         </div>
       </div>

--- a/apps/entry-app-collapsible/src/FieldGroupsEditor.tsx
+++ b/apps/entry-app-collapsible/src/FieldGroupsEditor.tsx
@@ -3,7 +3,6 @@ import {
   Dropdown,
   DropdownList,
   DropdownListItem,
-  HelpText,
   TextField,
   FormLabel,
   FieldGroup,
@@ -11,7 +10,7 @@ import {
   IconButton,
   CardDragHandle,
 } from '@contentful/forma-36-react-components';
-import { ModalContent } from '@contentful/f36-components';
+import { ModalContent, Text } from '@contentful/f36-components';
 import { findUnassignedFields, AppContext, SDKContext } from './shared';
 import { FieldType, FieldGroupType } from './types';
 import { ActionTypes } from './types';
@@ -81,7 +80,9 @@ export class FieldGroupsEditor extends React.Component<FieldGroupsEditorProps> {
     return (
       <React.Fragment>
         <div className={styles.controls}>
-          <HelpText>Group fields to seperate concerns in the entry editor</HelpText>
+          <Text as="p" fontColor="gray500" marginTop="spacingXs">
+            Group fields to seperate concerns in the entry editor
+          </Text>
           <div>
             <Button variant="primary" onClick={this.props.addGroup}>Add Group</Button>
             <Button

--- a/packages/default-field-editors/package.json
+++ b/packages/default-field-editors/package.json
@@ -42,6 +42,7 @@
     "@contentful/field-editor-url": "^0.12.2",
     "@contentful/field-editor-validation-errors": "^0.6.2",
     "@contentful/forma-36-react-components": "^3.93.4",
+    "@contentful/f36-components": "next-v4",
     "emotion": "^10.0.27"
   },
   "devDependencies": {

--- a/packages/default-field-editors/src/DefaultFieldEditors.mdx
+++ b/packages/default-field-editors/src/DefaultFieldEditors.mdx
@@ -13,7 +13,8 @@ import {
   createFakeSpaceAPI,
 } from '@contentful/field-editor-test-utils';
 import { BooleanEditor } from '@contentful/field-editor-boolean';
-import { HelpText, Icon } from '@contentful/forma-36-react-components';
+import { Icon } from '@contentful/forma-36-react-components';
+import { Text } from '@contentful/f36-components';
 import { Field } from './Field.tsx';
 import { FieldWrapper } from './FieldWrapper.tsx';
 
@@ -62,10 +63,10 @@ import { FieldWrapper } from './FieldWrapper.tsx';
             </div>
           )}
           renderHelpText={(helpText) => (
-            <HelpText>
+            <Text as="p" fontColor="gray500" marginTop="spacingXs">
               <Icon icon="HelpCircle" size="tiny" /> Custom help text:{" "}
               {helpText}
-            </HelpText>
+            </Text>
           )}
         >
           <Field sdk={sdk} widgetId="datePicker" />
@@ -88,11 +89,12 @@ import { FieldWrapper } from './FieldWrapper.tsx';
             }}
           />
         </FieldWrapper>
-
+        
         <ActionsPlayground mitt={mitt} />
       </div>
     );
-  }}
+}}
+
 </Playground>
 
 ## FieldWrapper props

--- a/packages/default-field-editors/src/FieldWrapper.tsx
+++ b/packages/default-field-editors/src/FieldWrapper.tsx
@@ -74,6 +74,7 @@ export const FieldWrapper: React.FC<FieldWrapperProps> = function (props: FieldW
       {renderHelpText ? (
         renderHelpText(helpText)
       ) : (
+        // TODO: Refactor to FormControl.HelpText when FormControl is used as a wrapper
         <Text
           as="p"
           fontColor="gray500"

--- a/packages/default-field-editors/src/FieldWrapper.tsx
+++ b/packages/default-field-editors/src/FieldWrapper.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { cx } from 'emotion';
-import { HelpText, FieldGroup, FormLabel } from '@contentful/forma-36-react-components';
+import { FieldGroup, FormLabel } from '@contentful/forma-36-react-components';
+import { Text } from '@contentful/f36-components';
 import { ValidationErrors } from '@contentful/field-editor-validation-errors';
 import type { FieldExtensionSDK, Entry } from '@contentful/field-editor-shared';
 import { styles } from './FieldWrapper.styles';
@@ -73,9 +74,14 @@ export const FieldWrapper: React.FC<FieldWrapperProps> = function (props: FieldW
       {renderHelpText ? (
         renderHelpText(helpText)
       ) : (
-        <HelpText className={styles.helpText} testId="field-hint">
+        <Text
+          as="p"
+          fontColor="gray500"
+          marginTop="spacingXs"
+          testId="field-hint"
+          className={styles.helpText}>
           {helpText}
-        </HelpText>
+        </Text>
       )}
     </FieldGroup>
   );

--- a/packages/markdown/src/dialogs/EmdebExternalContentDialog.tsx
+++ b/packages/markdown/src/dialogs/EmdebExternalContentDialog.tsx
@@ -3,8 +3,8 @@ import { css } from 'emotion';
 import tokens from '@contentful/forma-36-tokens';
 import { DialogsAPI } from '@contentful/app-sdk';
 import { MarkdownDialogType, MarkdownDialogsParams } from '../types';
-import { ModalContent, ModalControls } from '@contentful/f36-components';
-import { HelpText, TextField, RadioButtonField, CheckboxField, Form } from '@contentful/forma-36-react-components';
+import { ModalContent, ModalControls, Text } from '@contentful/f36-components';
+import { TextField, RadioButtonField, CheckboxField, Form } from '@contentful/forma-36-react-components';
 import { isValidUrl } from '../utils/isValidUrl';
 
 import { TextLink, Button } from '@contentful/f36-components';
@@ -142,7 +142,7 @@ export const EmbedExternalContentModal = ({ onClose }: EmbedExternalContentModal
           labelText="Attach social sharing links to this element"
           labelIsLight
         />
-        <HelpText>
+        <Text as="p" fontColor="gray500" marginTop="spacingXs">
           To enable this embedded content in your application make sure to add the&nbsp;
           <TextLink
             href="http://embed.ly/docs/products/cards"
@@ -151,7 +151,7 @@ export const EmbedExternalContentModal = ({ onClose }: EmbedExternalContentModal
             Embedly&apos;s platform.js
           </TextLink>
           &nbsp;on your development environment
-        </HelpText>
+        </Text>
         {/* <EmbedlyPreview previewUrl={url} /> */}
       </Form>
     </ModalContent>


### PR DESCRIPTION
## Open question

I'm not sure if it's 100% correct decision to refactor the `HelpText` to simple `Text` in the places where it's actually used in pair with form fields. But from other side using `FormControl.HelpText` without `FormControl` itself will bring even more confusion. 🤷‍♂️ 
For example `FieldWrapper` component seems like a bit customised `FormControl` component from our forma36 components.
