### PR TITLE
fix: safari lost of editor selection

### DIFF
--- a/packages/rich-text/src/ContentfulEditorProvider.ts
+++ b/packages/rich-text/src/ContentfulEditorProvider.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import constate from 'constate';
 import { FieldExtensionSDK } from '@contentful/app-sdk';
 import { useStoreEditorRef } from '@udecode/plate-core';
@@ -16,6 +17,17 @@ interface useContentfulEditorHookProps {
 function useContentfulEditorHook({ sdk }: useContentfulEditorHookProps) {
   const editorId = getContentfulEditorId(sdk);
   const editor = useStoreEditorRef(editorId);
+  const [selection, setSelection] = React.useState(editor?.selection ?? null);
+
+  React.useEffect(() => {
+    if (!editor?.selection) return;
+
+    setSelection(editor.selection);
+  }, [editor?.selection]);
+
+  if (editor && !editor?.selection && selection) {
+    editor.selection = selection;
+  }
 
   return editor;
 }

--- a/packages/rich-text/src/RichTextEditor.tsx
+++ b/packages/rich-text/src/RichTextEditor.tsx
@@ -187,15 +187,15 @@ const RichTextEditor = (props: Props) => {
   return (
     <EntityProvider sdk={sdk}>
       <SdkProvider sdk={sdk}>
-        <ContentfulEditorProvider sdk={sdk}>
-          <TrackingProvider onAction={onAction || noop}>
-            <FieldConnector
-              throttle={0}
-              field={sdk.field}
-              isInitiallyDisabled={isInitiallyDisabled}
-              isEmptyValue={isEmptyValue}
-              isEqualValues={deepEquals}>
-              {({ lastRemoteValue, disabled, setValue, externalReset }) => (
+        <TrackingProvider onAction={onAction || noop}>
+          <FieldConnector
+            throttle={0}
+            field={sdk.field}
+            isInitiallyDisabled={isInitiallyDisabled}
+            isEmptyValue={isEmptyValue}
+            isEqualValues={deepEquals}>
+            {({ lastRemoteValue, disabled, setValue, externalReset }) => (
+              <ContentfulEditorProvider sdk={sdk}>
                 <ConnectedRichTextEditor
                   {...otherProps}
                   key={`rich-text-editor-${externalReset}`}
@@ -205,10 +205,10 @@ const RichTextEditor = (props: Props) => {
                   isDisabled={disabled}
                   onChange={setValue}
                 />
-              )}
-            </FieldConnector>
-          </TrackingProvider>
-        </ContentfulEditorProvider>
+              </ContentfulEditorProvider>
+            )}
+          </FieldConnector>
+        </TrackingProvider>
       </SdkProvider>
     </EntityProvider>
   );

--- a/packages/rich-text/src/plugins/Bold/index.tsx
+++ b/packages/rich-text/src/plugins/Bold/index.tsx
@@ -15,7 +15,9 @@ interface ToolbarBoldButtonProps {
 export function ToolbarBoldButton(props: ToolbarBoldButtonProps) {
   const editor = useContentfulEditor();
 
-  function handleClick() {
+  function handleClick(event: React.MouseEvent<HTMLButtonElement>) {
+    event.preventDefault();
+
     if (!editor?.selection) return;
 
     toggleMark(editor, MARKS.BOLD);
@@ -31,7 +33,8 @@ export function ToolbarBoldButton(props: ToolbarBoldButtonProps) {
       tooltipPlace="bottom"
       label="Bold"
       testId="bold-toolbar-button"
-      onClick={handleClick}
+      // @ts-expect-error
+      onMouseDown={handleClick}
       isActive={isMarkActive(editor, MARKS.BOLD)}
       disabled={props.isDisabled}
     />

--- a/packages/rich-text/src/plugins/Code/index.tsx
+++ b/packages/rich-text/src/plugins/Code/index.tsx
@@ -16,7 +16,9 @@ interface ToolbarCodeButtonProps {
 export function ToolbarCodeButton(props: ToolbarCodeButtonProps) {
   const editor = useContentfulEditor();
 
-  function handleClick() {
+  function handleClick(event: React.MouseEvent<HTMLButtonElement>) {
+    event.preventDefault();
+
     if (!editor?.selection) return;
 
     toggleMark(editor, MARKS.CODE);
@@ -32,7 +34,8 @@ export function ToolbarCodeButton(props: ToolbarCodeButtonProps) {
       tooltipPlace="bottom"
       label="Code"
       testId="code-toolbar-button"
-      onClick={handleClick}
+      // @ts-expect-error
+      onMouseDown={handleClick}
       isActive={isMarkActive(editor, MARKS.CODE)}
       disabled={props.isDisabled}
     />

--- a/packages/rich-text/src/plugins/EmbeddedEntityBlock/ToolbarIcon.tsx
+++ b/packages/rich-text/src/plugins/EmbeddedEntityBlock/ToolbarIcon.tsx
@@ -31,7 +31,9 @@ export function EmbeddedEntityBlockToolbarIcon({
   const editor = useContentfulEditor();
   const sdk: FieldExtensionSDK = useSdkContext();
 
-  const handleClick = async () => {
+  const handleClick = async (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+
     onClose();
     await selectEntityAndInsert(nodeType, sdk, editor, logAction || noop);
   };
@@ -43,7 +45,8 @@ export function EmbeddedEntityBlockToolbarIcon({
       disabled={isDisabled}
       className={`${baseClass}-button`}
       size="small"
-      onClick={handleClick}
+      // @ts-expect-error
+      onMouseDown={handleClick}
       icon={type === 'Asset' ? 'Asset' : 'EmbeddedEntryBlock'}
       buttonType="muted"
       testId={`toolbar-toggle-${nodeType}`}>
@@ -53,7 +56,7 @@ export function EmbeddedEntityBlockToolbarIcon({
     <DropdownListItem
       isDisabled={isDisabled}
       className={`${baseClass}-list-item`}
-      onClick={handleClick}
+      onMouseDown={handleClick}
       testId={`toolbar-toggle-${nodeType}`}>
       <Flex alignItems="center" flexDirection="row">
         <Icon

--- a/packages/rich-text/src/plugins/EmbeddedEntityBlock/index.tsx
+++ b/packages/rich-text/src/plugins/EmbeddedEntityBlock/index.tsx
@@ -44,6 +44,7 @@ const createEmbeddedEntityPlugin =
 
               return {
                 type: nodeType,
+                isVoid: true,
                 data: {
                   target: {
                     sys: {

--- a/packages/rich-text/src/plugins/Heading/index.tsx
+++ b/packages/rich-text/src/plugins/Heading/index.tsx
@@ -192,18 +192,22 @@ export function ToolbarHeadingButton(props: ToolbarHeadingButtonProps) {
     return [nodeTypesByEnablement, someHeadingsEnabled];
   }, [sdk.field]);
 
-  function handleOnSelectItem(type: BLOCKS): void {
-    if (!editor?.selection) return;
+  function handleOnSelectItem(type: BLOCKS): (event: React.MouseEvent<HTMLButtonElement>) => void {
+    return (event: React.MouseEvent<HTMLButtonElement>) => {
+      event.preventDefault();
 
-    setSelected(type);
-    setOpen(false);
+      if (!editor?.selection) return;
 
-    if (shouldUnwrapBlockquote(editor, type)) {
-      unwrapFromRoot(editor);
-    }
+      setSelected(type);
+      setOpen(false);
 
-    toggleNodeType(editor, { activeType: type, inactiveType: type });
-    Slate.ReactEditor.focus(editor);
+      if (shouldUnwrapBlockquote(editor, type)) {
+        unwrapFromRoot(editor);
+      }
+
+      toggleNodeType(editor, { activeType: type, inactiveType: type });
+      Slate.ReactEditor.focus(editor);
+    };
   }
 
   if (!editor) return null;
@@ -230,7 +234,7 @@ export function ToolbarHeadingButton(props: ToolbarHeadingButtonProps) {
                 <DropdownListItem
                   key={nodeType}
                   isActive={selected === nodeType}
-                  onClick={() => handleOnSelectItem(nodeType as BLOCKS)}
+                  onMouseDown={handleOnSelectItem(nodeType as BLOCKS)}
                   testId={`dropdown-option-${nodeType}`}
                   isDisabled={props.isDisabled}>
                   <span className={cx(styles.dropdown.root, styles.dropdown[nodeType])}>

--- a/packages/rich-text/src/plugins/Hr/index.tsx
+++ b/packages/rich-text/src/plugins/Hr/index.tsx
@@ -80,7 +80,9 @@ export function withHrEvents(editor: SPEditor) {
 export function ToolbarHrButton(props: ToolbarHrButtonProps) {
   const editor = useContentfulEditor();
 
-  function handleOnClick() {
+  function handleOnClick(event: React.MouseEvent<HTMLButtonElement>) {
+    event.preventDefault();
+
     if (!editor?.selection) return;
 
     if (shouldUnwrapBlockquote(editor, BLOCKS.HR)) {
@@ -112,7 +114,8 @@ export function ToolbarHrButton(props: ToolbarHrButtonProps) {
       tooltipPlace="bottom"
       label="HR"
       disabled={props.isDisabled}
-      onClick={handleOnClick}
+      // @ts-expect-error
+      onMouseDown={handleOnClick}
       testId="hr-toolbar-button"
       isActive={isBlockSelected(editor, BLOCKS.HR)}
     />

--- a/packages/rich-text/src/plugins/Hyperlink/index.tsx
+++ b/packages/rich-text/src/plugins/Hyperlink/index.tsx
@@ -243,6 +243,7 @@ export function ToolbarHyperlinkButton(props: ToolbarHyperlinkButtonProps) {
 
   async function handleClick(event: React.MouseEvent<HTMLButtonElement>) {
     event.preventDefault();
+
     if (!editor) return;
 
     if (isActive) {
@@ -261,7 +262,8 @@ export function ToolbarHyperlinkButton(props: ToolbarHyperlinkButtonProps) {
       tooltipPlace="bottom"
       label="Hyperlink"
       testId="hyperlink-toolbar-button"
-      onClick={handleClick}
+      // @ts-expect-error
+      onMouseDown={handleClick}
       isActive={isActive}
       disabled={props.isDisabled}
     />

--- a/packages/rich-text/src/plugins/Italic/index.tsx
+++ b/packages/rich-text/src/plugins/Italic/index.tsx
@@ -16,7 +16,9 @@ interface ToolbarItalicButtonProps {
 export function ToolbarItalicButton(props: ToolbarItalicButtonProps) {
   const editor = useContentfulEditor();
 
-  function handleClick() {
+  function handleClick(event: React.MouseEvent<HTMLButtonElement>) {
+    event.preventDefault();
+
     if (!editor?.selection) return;
 
     toggleMark(editor, MARKS.ITALIC);
@@ -32,7 +34,8 @@ export function ToolbarItalicButton(props: ToolbarItalicButtonProps) {
       tooltipPlace="bottom"
       label="Italic"
       testId="italic-toolbar-button"
-      onClick={handleClick}
+      // @ts-expect-error
+      onMouseDown={handleClick}
       isActive={isMarkActive(editor, MARKS.ITALIC)}
       disabled={props.isDisabled}
     />

--- a/packages/rich-text/src/plugins/List/index.tsx
+++ b/packages/rich-text/src/plugins/List/index.tsx
@@ -19,16 +19,20 @@ export function ToolbarListButton(props: ToolbarListButtonProps) {
   const sdk = useSdkContext();
   const editor = useContentfulEditor();
 
-  function handleClick(type: BLOCKS): void {
-    if (!editor?.selection) return;
+  function handleClick(type: BLOCKS): (event: React.MouseEvent<HTMLButtonElement>) => void {
+    return (event: React.MouseEvent<HTMLButtonElement>) => {
+      event.preventDefault();
 
-    if (shouldUnwrapBlockquote(editor, type)) {
-      unwrapFromRoot(editor);
-    }
+      if (!editor?.selection) return;
 
-    toggleList(editor, { type });
+      if (shouldUnwrapBlockquote(editor, type)) {
+        unwrapFromRoot(editor);
+      }
 
-    Slate.ReactEditor.focus(editor);
+      toggleList(editor, { type });
+
+      Slate.ReactEditor.focus(editor);
+    };
   }
 
   if (!editor) return null;
@@ -42,7 +46,8 @@ export function ToolbarListButton(props: ToolbarListButtonProps) {
           tooltipPlace="bottom"
           label="UL"
           testId="ul-toolbar-button"
-          onClick={() => handleClick(BLOCKS.UL_LIST)}
+          // @ts-expect-error
+          onMouseDown={handleClick(BLOCKS.UL_LIST)}
           isActive={isBlockSelected(editor, BLOCKS.UL_LIST)}
           disabled={props.isDisabled}
         />
@@ -54,7 +59,8 @@ export function ToolbarListButton(props: ToolbarListButtonProps) {
           tooltipPlace="bottom"
           label="OL"
           testId="ol-toolbar-button"
-          onClick={() => handleClick(BLOCKS.OL_LIST)}
+          // @ts-expect-error
+          onMouseDown={handleClick(BLOCKS.OL_LIST)}
           isActive={isBlockSelected(editor, BLOCKS.OL_LIST)}
           disabled={props.isDisabled}
         />

--- a/packages/rich-text/src/plugins/Quote/index.tsx
+++ b/packages/rich-text/src/plugins/Quote/index.tsx
@@ -104,7 +104,9 @@ export function withQuoteEvents(editor: SPEditor) {
 export function ToolbarQuoteButton(props: ToolbarQuoteButtonProps) {
   const editor = useContentfulEditor();
 
-  function handleOnClick() {
+  function handleOnClick(event: React.MouseEvent<HTMLButtonElement>) {
+    event.preventDefault();
+
     if (!editor) return;
 
     createBlockQuote(editor);
@@ -119,7 +121,8 @@ export function ToolbarQuoteButton(props: ToolbarQuoteButtonProps) {
       tooltip="Blockquote"
       tooltipPlace="bottom"
       label="Blockquote"
-      onClick={handleOnClick}
+      // @ts-expect-error
+      onMouseDown={handleOnClick}
       testId="quote-toolbar-button"
       disabled={props.isDisabled}
       isActive={isBlockSelected(editor, BLOCKS.QUOTE)}

--- a/packages/rich-text/src/plugins/Table/index.tsx
+++ b/packages/rich-text/src/plugins/Table/index.tsx
@@ -141,7 +141,7 @@ function addTableTrackingEvents(editor: SPEditor, { onViewportAction }: Tracking
 }
 
 function addTableNormalization(editor) {
-  const { normalizeNode } = editor
+  const { normalizeNode } = editor;
 
   editor.normalizeNode = (entry) => {
     const [node, path] = entry;
@@ -159,8 +159,8 @@ function addTableNormalization(editor) {
       }
     }
 
-    normalizeNode(entry)
-  }
+    normalizeNode(entry);
+  };
 }
 
 function hasTables(nodes: CustomElement[]) {
@@ -193,6 +193,7 @@ export function ToolbarTableButton(props: ToolbarTableButtonProps) {
 
   async function handleClick(event: React.MouseEvent<HTMLButtonElement>) {
     event.preventDefault();
+
     if (!editor) return;
 
     onViewportAction('insertTable');
@@ -209,7 +210,8 @@ export function ToolbarTableButton(props: ToolbarTableButtonProps) {
       tooltipPlace="bottom"
       label="Table"
       testId="table-toolbar-button"
-      onClick={handleClick}
+      // @ts-expect-error
+      onMouseDown={handleClick}
       // TODO: active state looks off since the button will be disabled. Do we still need it?
       isActive={isActive}
       disabled={props.isDisabled}

--- a/packages/rich-text/src/plugins/Underline/index.tsx
+++ b/packages/rich-text/src/plugins/Underline/index.tsx
@@ -15,7 +15,9 @@ interface ToolbarUnderlineButtonProps {
 export function ToolbarUnderlineButton(props: ToolbarUnderlineButtonProps) {
   const editor = useContentfulEditor();
 
-  function handleClick() {
+  function handleClick(event: React.MouseEvent<HTMLButtonElement>) {
+    event.preventDefault();
+
     if (!editor?.selection) return;
 
     toggleMark(editor, MARKS.UNDERLINE);
@@ -31,7 +33,8 @@ export function ToolbarUnderlineButton(props: ToolbarUnderlineButtonProps) {
       tooltipPlace="bottom"
       label="Underline"
       testId="underline-toolbar-button"
-      onClick={handleClick}
+      // @ts-expect-error
+      onMouseDown={handleClick}
       isActive={isMarkActive(editor, MARKS.UNDERLINE)}
       disabled={props.isDisabled}
     />


### PR DESCRIPTION
It seems [`EditorToolbarButton`](https://github.com/contentful/forma-36/blob/master/packages/forma-36-react-components/src/components/EditorToolbar/EditorToolbarButton/EditorToolbarButton.tsx#L56) accepts `onMouseDown`, just its TypeScript is not configured correctly. 

On the other hand, [`DropdownListItem`](https://github.com/contentful/forma-36/blob/master/packages/forma-36-react-components/src/components/Dropdown/DropdownListItem/DropdownListItem.tsx#L62) also accepts `onMouseDown` but its TypeScript has correct types. 