### PR TITLE
feat: track tables with headers outside first row

### DIFF
--- a/packages/rich-text/src/plugins/Table/index.tsx
+++ b/packages/rich-text/src/plugins/Table/index.tsx
@@ -133,7 +133,10 @@ function addTableTrackingEvents(editor: SPEditor, { onViewportAction }: Tracking
       setTimeout(() => {
         if (hasTables(markupBefore)) return;
         if (hasTables(markupAfter)) {
-          onViewportAction('paste', { tablePasted: true });
+          onViewportAction('paste', {
+            tablePasted: true,
+            hasHeadersOutsideFirstRow: hasHeadersOutsideFirstRow(markupAfter)
+          });
         }
       }, 1);
     }
@@ -167,6 +170,14 @@ function hasTables(nodes: CustomElement[]) {
   return nodes.some(({ type }) => {
     return type === BLOCKS.TABLE;
   });
+}
+
+const isTableHeaderCell = ({ type }) => type === BLOCKS.TABLE_HEADER_CELL;
+function hasHeadersOutsideFirstRow(nodes: CustomElement[]) {
+  return nodes
+    .filter(({ type }) => type === BLOCKS.TABLE)
+    .flatMap(({ children }) => children.slice(1) as CustomElement[])
+    .some(({ children }) => (children as CustomElement[]).some(isTableHeaderCell))
 }
 
 function createWithTableEvents(tracking: TrackingProvider) {


### PR DESCRIPTION
Adds `hasHeadersOutsideFirstRow: boolean` as a property to the table paste tracking event to track instances in which tables with header cells outside the first row are pasted into the editor.

This comes with the usual caveat for table pasting events, which is that we do not capturing instances in which tables previously existed in the editor. This is for simplicity and performance's sake, and should not impede capturing a roughly equivalent percentage of "headers outside first row" occurrences _as a % of table paste events as a whole.