### PR TITLE
fix: render invalid table children as text

### DIFF
--- a/packages/rich-text/src/plugins/Paste/sanitizers/sanitizeTables.tsx
+++ b/packages/rich-text/src/plugins/Paste/sanitizers/sanitizeTables.tsx
@@ -5,12 +5,9 @@ import { removeChildNodesUsingPredicate, SanitizerTuple } from './helpers';
 const TAG_NAME_TABLE = 'TABLE';
 const TAG_NAME_TABLE_CAPTION = 'CAPTION';
 const DISALLOWED_TABLE_CHILD_ELEMENTS: Element['tagName'][] = [
-  TAG_NAME_TABLE,
   TAG_NAME_TABLE_CAPTION,
 ];
-type DisallowedTableChildElement
-  = HTMLTableElement
-  | HTMLTableCaptionElement;
+type DisallowedTableChildElement = HTMLTableCaptionElement;
 
 const isHTMLElement = (node: ChildNode): node is HTMLElement => node.nodeType === Node.ELEMENT_NODE;
 


### PR DESCRIPTION
Accomplishes this in the `normalizeNode` step definition for tables.

If an incoming child node is invalid, we:
- convert it to a contentful node
- gets the plain text value of the contentful node, as we would we with a document (using `@contentful/rich-text-plain-text-renderer`
- renders the plain text value inside a paragraph in place of the invalid node

This works well with insertion in empty table cells as well as within text selections from table cells.