### PR TITLE
fix: handle 'failed' entity state

### DIFF
--- a/packages/reference/src/common/EntityStore.ts
+++ b/packages/reference/src/common/EntityStore.ts
@@ -196,6 +196,7 @@ function useEntitiesStore(props: { sdk: BaseExtensionSDK }) {
   return { getOrLoadEntry, getOrLoadAsset, loadEntityScheduledActions, ...state };
 }
 
+// TODO: These properties are not typed when exported elsewhere.
 const [EntityProvider, useEntities] = constate(useEntitiesStore);
 
 export { EntityProvider, useEntities };

--- a/packages/rich-text/src/plugins/EmbeddedEntityInline/FetchingWrappedInlineEntryCard.tsx
+++ b/packages/rich-text/src/plugins/EmbeddedEntityInline/FetchingWrappedInlineEntryCard.tsx
@@ -35,7 +35,7 @@ export function FetchingWrappedInlineEntryCard(props: FetchingWrappedInlineEntry
 
   const allContentTypes = props.sdk.space.getCachedContentTypes();
   const contentType = React.useMemo(() => {
-    if (!entry || !allContentTypes) return undefined;
+    if (!entry || entry === 'failed' || !allContentTypes) return undefined;
 
     return allContentTypes.find(
       (contentType) => contentType.sys.id === entry.sys.contentType.sys.id

--- a/packages/rich-text/src/plugins/shared/FetchingWrappedAssetCard.tsx
+++ b/packages/rich-text/src/plugins/shared/FetchingWrappedAssetCard.tsx
@@ -95,7 +95,7 @@ export function FetchingWrappedAssetCard(props: FetchingWrappedAssetCardProps) {
   const { getOrLoadAsset, assets } = useEntities();
   const asset = assets[props.assetId];
   const defaultLocaleCode = props.sdk.locales.default;
-  const entityFile: File | undefined = asset?.fields.file
+  const entityFile: File | undefined = asset?.fields?.file
     ? asset.fields.file[props.locale] || asset.fields.file[defaultLocaleCode]
     : undefined;
 

--- a/packages/rich-text/src/plugins/shared/FetchingWrappedEntryCard.tsx
+++ b/packages/rich-text/src/plugins/shared/FetchingWrappedEntryCard.tsx
@@ -54,17 +54,18 @@ export function FetchingWrappedEntryCard(props: FetchingWrappedEntryCardProps) {
   const { getOrLoadEntry, entries } = useEntities();
   const [file, setFile] = React.useState<File | null>(null);
   const entry = entries[props.entryId];
-  const contentType = React.useMemo(
-    () =>
-      props.sdk.space
-        .getCachedContentTypes()
-        .find((contentType) => contentType.sys.id === entry?.sys.contentType.sys.id),
-    [props.sdk, entry]
-  );
+  const contentType = React.useMemo(() => {
+    if (!entry || entry === 'failed') {
+      return undefined;
+    }
+    return props.sdk.space
+      .getCachedContentTypes()
+      .find((contentType) => contentType.sys.id === entry.sys.contentType.sys.id)
+  }, [props.sdk, entry]);
   const defaultLocaleCode = props.sdk.locales.default;
 
   React.useEffect(() => {
-    if (!entry) return;
+    if (!entry || entry === 'failed') return;
 
     entityHelpers
       .getEntryImage(


### PR DESCRIPTION
In our revised rich text entity card wrapper components we assume, wrongly, that an entity retrieved from the reference editor's `useEntities` constate will always be either an entity accessor API or `undefined`. Actually there's a third option: [`failed`](https://github.com/contentful/field-editors/blob/7e5940b963add53a73a1257221ce16e7e17cd49c/packages/reference/src/common/EntityStore.ts#L5-L11), which _should_ appear in our typespecs. But for whatever reason `useEntities` is appearing in my vscode as `any`.

So this PR addresses two defects:
- Cases in which an entry is `failed` are handled, and treated as though the entry object were `undefined`.
- A `TODO` is added to the reference editor's `EntityStore` to deal with the `constate` typing.

On that last point: ideally we'd also be typing/constantizing the semantically significant string `'failed`', redux-style, then referencing that elsewhere throughout the repo, accounting for it as a potential value in our `field-editor-shared` entity helpers, etc. But this changeset aims to be _very_ parsimonious with updates outside of the rich text package, as we want to reduce the surface area of changes outside this package prior to it being merged into `master`.