### PR TITLE
fix(reference): consistent ordering of link actions

### DIFF
--- a/packages/reference/src/components/LinkActions/CombinedLinkActions.tsx
+++ b/packages/reference/src/components/LinkActions/CombinedLinkActions.tsx
@@ -154,20 +154,20 @@ function CombinedAssetLinkActions(props: LinkActionsProps) {
       }>
       <DropdownList testId={testIds.dropdown}>
         <DropdownListItem
-          testId={testIds.createAndLink}
-          onClick={() => {
-            setOpen(false);
-            props.onCreate();
-          }}>
-          Add new media
-        </DropdownListItem>
-        <DropdownListItem
           testId={testIds.linkExisting}
           onClick={() => {
             setOpen(false);
             props.onLinkExisting();
           }}>
           Add existing media
+        </DropdownListItem>
+        <DropdownListItem
+          testId={testIds.createAndLink}
+          onClick={() => {
+            setOpen(false);
+            props.onCreate();
+          }}>
+          Add new media
         </DropdownListItem>
       </DropdownList>
     </Dropdown>


### PR DESCRIPTION
The Git diff looks confusing but I basically switched the order of [these two items](https://github.com/contentful/field-editors/blob/936effe63f3bb5fcabb5baadb1f716dc7582c4bd/packages/reference/src/components/LinkActions/CombinedLinkActions.tsx#L156-L171).