### PR TITLE
fix: [SHE-521] rich text plain-text paste

### DIFF
--- a/packages/rich-text/src/plugins/Paste/index.tsx
+++ b/packages/rich-text/src/plugins/Paste/index.tsx
@@ -30,6 +30,8 @@ function withPasteHandling(editor: SPEditor) {
         const sanitized = sanitizeHtml(html, editor);
         const newData = htmlToDataTransfer(sanitized);
         insertData(newData);
+      } else {
+        insertData(data);
       }
     };
   };

--- a/packages/rich-text/src/plugins/Table/index.tsx
+++ b/packages/rich-text/src/plugins/Table/index.tsx
@@ -147,6 +147,8 @@ function addTableTrackingEvents(editor: SPEditor, { onViewportAction }: Tracking
           });
         }
       }, 1);
+    } else {
+      insertData(data);
     }
   };
 }


### PR DESCRIPTION
Fixes paste events in the alpha rich text editor for cases where plain text (or otherwise - CSV, etc) is intercepted by the [`insertData` callback](https://docs.slatejs.org/libraries/slate-react#insertdata-editor-reacteditor-data-datatransfer).

Very simply, we're overriding the property as is conventional with Slate >0.5 plugins to sanitize HTML `DataTransfer` payloads and doing nothing when there is no such payload in a couple of places. We should always fall back to the original `insertData` callback in such cases.