### PR TITLE
fix: entity block paste

### DIFF
--- a/packages/rich-text/src/plugins/Paste/sanitizers/helpers.tsx
+++ b/packages/rich-text/src/plugins/Paste/sanitizers/helpers.tsx
@@ -4,7 +4,10 @@ export type SanitizerTuple = [Document, SPEditor];
 
 type Predicate = (node: ChildNode) => boolean;
 
-const removeChildNodes = (node: ChildNode, predicate: Predicate) =>
+export const isHTMLElement = (node: ChildNode): node is HTMLElement =>
+  node.nodeType === Node.ELEMENT_NODE;
+
+export const removeChildNodes = (node: ChildNode, predicate: Predicate = Boolean) =>
   Array.from(node.childNodes)
     .filter(predicate)
     .forEach((table) => node.removeChild(table));

--- a/packages/rich-text/src/plugins/Paste/sanitizers/index.tsx
+++ b/packages/rich-text/src/plugins/Paste/sanitizers/index.tsx
@@ -1,2 +1,3 @@
 export { removeComments } from './removeComments';
 export { sanitizeTables } from './sanitizeTables';
+export { sanitizeEntityBlocks } from './sanitizeEntityBlocks';

--- a/packages/rich-text/src/plugins/Paste/sanitizers/sanitizeEntityBlocks.tsx
+++ b/packages/rich-text/src/plugins/Paste/sanitizers/sanitizeEntityBlocks.tsx
@@ -1,0 +1,20 @@
+import { isHTMLElement, removeChildNodes, SanitizerTuple } from './helpers';
+
+/**
+ * Ensures the text selection from entity block elements is
+ * not included in the paste buffer.
+ */
+export const sanitizeEntityBlocks = ([doc, editor]: SanitizerTuple): SanitizerTuple => {
+  const nodes = Array.from(doc.childNodes);
+  while (nodes.length > 0) {
+    const node = nodes.pop() as ChildNode;
+    if (isHTMLElement(node) && node.getAttribute('data-entity-type')) {
+      removeChildNodes(node);
+      continue;
+    }
+    for (const childNode of Array.from(node.childNodes)) {
+      nodes.push(childNode);
+    }
+  }
+  return [doc, editor];
+};

--- a/packages/rich-text/src/plugins/Paste/sanitizers/sanitizeTables.tsx
+++ b/packages/rich-text/src/plugins/Paste/sanitizers/sanitizeTables.tsx
@@ -1,15 +1,11 @@
 import { BLOCKS } from '@contentful/rich-text-types';
 import { getNodeEntryFromSelection } from '../../../helpers/editor';
-import { removeChildNodesUsingPredicate, SanitizerTuple } from './helpers';
+import { isHTMLElement, removeChildNodesUsingPredicate, SanitizerTuple } from './helpers';
 
 const TAG_NAME_TABLE = 'TABLE';
 const TAG_NAME_TABLE_CAPTION = 'CAPTION';
-const DISALLOWED_TABLE_CHILD_ELEMENTS: Element['tagName'][] = [
-  TAG_NAME_TABLE_CAPTION,
-];
+const DISALLOWED_TABLE_CHILD_ELEMENTS: Element['tagName'][] = [TAG_NAME_TABLE_CAPTION];
 type DisallowedTableChildElement = HTMLTableCaptionElement;
-
-const isHTMLElement = (node: ChildNode): node is HTMLElement => node.nodeType === Node.ELEMENT_NODE;
 
 const isTableElement = (node: ChildNode): node is HTMLTableElement =>
   isHTMLElement(node) && node.tagName === TAG_NAME_TABLE;
@@ -17,7 +13,9 @@ const isTableElement = (node: ChildNode): node is HTMLTableElement =>
 const isDisallowedTableChildElement = (node: ChildNode): node is DisallowedTableChildElement =>
   isHTMLElement(node) && DISALLOWED_TABLE_CHILD_ELEMENTS.includes(node.tagName);
 
-const removeDisallowedTableChildElements = removeChildNodesUsingPredicate(isDisallowedTableChildElement);
+const removeDisallowedTableChildElements = removeChildNodesUsingPredicate(
+  isDisallowedTableChildElement
+);
 
 const removeTableGrandchildren = (nodeList: NodeList) => {
   const nodes = Array.from(nodeList);


### PR DESCRIPTION
Fixes a bug in which the text selection from entity block embeds could be included in the paste buffer as children of the slate block element, which in turn would break the editor.

Ideally we'd solve this via `normalizeNode` -> `removeNodes`; I was not able to solve the problem with this approach after much experimentation.