### PR TITLE
chore: bump rte next to 0.26.4-next

### DIFF
--- a/apps/rich-text-app/package.json
+++ b/apps/rich-text-app/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@contentful/app-sdk": "^3.36.0",
-    "@contentful/field-editor-rich-text": "^0.26.3-next",
+    "@contentful/field-editor-rich-text": "^0.26.4-next",
     "@contentful/field-editor-single-line": "^0.14.1",
     "@contentful/forma-36-fcss": "^0.3.3",
     "@contentful/forma-36-react-components": "^3.93.4",

--- a/packages/default-field-editors/package.json
+++ b/packages/default-field-editors/package.json
@@ -34,7 +34,7 @@
     "@contentful/field-editor-radio": "^0.13.2",
     "@contentful/field-editor-rating": "^0.12.2",
     "@contentful/field-editor-reference": "^2.20.6",
-    "@contentful/field-editor-rich-text": "^0.26.3-next",
+    "@contentful/field-editor-rich-text": "^0.26.4-next",
     "@contentful/field-editor-shared": "^0.22.1",
     "@contentful/field-editor-single-line": "^0.15.2",
     "@contentful/field-editor-slug": "^0.12.1",

--- a/packages/rich-text/package.json
+++ b/packages/rich-text/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contentful/field-editor-rich-text",
-  "version": "0.26.3-next",
+  "version": "0.26.4-next",
   "publishConfig": {
     "tag": "next"
   },


### PR DESCRIPTION
It contains fixes for:

- Embedded asset details