### PR TITLE
fix: pass a unique form-control id

### DIFF
--- a/packages/default-field-editors/src/FieldWrapper.tsx
+++ b/packages/default-field-editors/src/FieldWrapper.tsx
@@ -45,8 +45,11 @@ export const FieldWrapper: React.FC<FieldWrapperProps> = function (props: FieldW
     });
   }, [field]);
 
+  const fieldControlId = [field.id, field.locale].filter((item) => item).join('-');
+
   return (
     <FormControl
+      id={fieldControlId}
       testId="entity-field-controls"
       data-test-id="entity-field-controls"
       className={cx(showFocusBar && styles.withFocusBar, className)}
@@ -55,9 +58,7 @@ export const FieldWrapper: React.FC<FieldWrapperProps> = function (props: FieldW
       {renderHeading ? (
         renderHeading(name)
       ) : (
-        <FormControl.Label className={styles.label} htmlFor={field.id}>
-          {name}
-        </FormControl.Label>
+        <FormControl.Label className={styles.label}>{name}</FormControl.Label>
       )}
 
       {children}


### PR DESCRIPTION
Use sdk.field information to pass a unique field id