### PR TITLE
fix: forbid embed entries in links

### DIFF
--- a/packages/rich-text/src/Toolbar/EmbedEntityWidget.tsx
+++ b/packages/rich-text/src/Toolbar/EmbedEntityWidget.tsx
@@ -6,6 +6,8 @@ import { BLOCKS, INLINES } from '@contentful/rich-text-types';
 import { isNodeTypeEnabled } from '../helpers/validations';
 import { ToolbarEmbeddedEntityInlineButton } from '../plugins/EmbeddedEntityInline';
 import { useSdkContext } from '../SdkProvider';
+import { isLinkActive } from '../helpers/editor';
+import { useContentfulEditor } from '../ContentfulEditorProvider';
 
 export interface EmbedEntityWidgetProps {
   isDisabled?: boolean;
@@ -14,6 +16,8 @@ export interface EmbedEntityWidgetProps {
 
 export const EmbedEntityWidget = ({ isDisabled, canInsertBlocks }: EmbedEntityWidgetProps) => {
   const sdk = useSdkContext();
+  const editor = useContentfulEditor();
+
   const [isEmbedDropdownOpen, setEmbedDropdownOpen] = useState(false);
   const onCloseEntityDropdown = () => setEmbedDropdownOpen(false);
   const onToggleEntityDropdown = () => setEmbedDropdownOpen(!isEmbedDropdownOpen);
@@ -57,7 +61,7 @@ export const EmbedEntityWidget = ({ isDisabled, canInsertBlocks }: EmbedEntityWi
       )}
       {inlineEntryEmbedEnabled && (
         <ToolbarEmbeddedEntityInlineButton
-          isDisabled={!!isDisabled}
+          isDisabled={!!isDisabled || isLinkActive(editor)}
           onClose={onCloseEntityDropdown}
           isButton={!shouldDisplayDropdown}
         />


### PR DESCRIPTION

Disable inline entry in embedding dropdown.

The `next` logic was missing a similar check to `canInsertInline` [here](https://github.com/contentful/field-editors/blob/526bde6e10e0ee3789705ec10fb31489af7ca59e/packages/rich-text/src/plugins/EmbeddedEntryInline/ToolbarIcon.js#L47).
The old logic seems more generic that the one used in this PR, but I didn't find an easy way to do the same operations with the new editor object.