### PR TITLE
feat: make embedded blocks draggable []

### DIFF
--- a/cypress/integration/rich-text/RichTextEditor.spec.ts
+++ b/cypress/integration/rich-text/RichTextEditor.spec.ts
@@ -27,6 +27,7 @@ describe('Rich Text Editor', { viewportHeight: 2000 }, () => {
 
   const keys = {
     enter: { keyCode: 13, which: 13, key: 'Enter' },
+    rightArrow: { keyCode: 39, which: 39, key: 'ArrowRight' },
     backspace: { keyCode: 8, which: 8, key: 'Backspace' },
   };
 
@@ -1117,16 +1118,17 @@ describe('Rich Text Editor', { viewportHeight: 2000 }, () => {
         it('adds paragraph between two blocks when pressing enter', () => {
           function addEmbeddedEntry() {
             editor().click('bottom').then(triggerEmbeddedEntry);
+            editor().click().trigger('keydown', keys.rightArrow);
           }
 
           function selectAndPressEnter() {
-            editor().click().get('[data-entity-id="example-entity-id"]').first().click();
+            editor().get('[data-entity-id="example-entity-id"]').first().click();
             editor().trigger('keydown', keys.enter);
           }
 
           addEmbeddedEntry();
-          selectAndPressEnter(); // Inserts paragraph before embed because it's in the first line.
           addEmbeddedEntry();
+          selectAndPressEnter(); // Inserts paragraph before embed because it's in the first line.
           selectAndPressEnter(); // inserts paragraph in-between embeds.
 
           expectRichTextFieldValue(
@@ -1277,6 +1279,7 @@ describe('Rich Text Editor', { viewportHeight: 2000 }, () => {
         it('adds paragraph between two blocks when pressing enter', () => {
           function addEmbeddedEntry() {
             editor().click('bottom').then(triggerEmbeddedAsset);
+            editor().click().trigger('keydown', keys.rightArrow);
           }
 
           function selectAndPressEnter() {

--- a/cypress/integration/rich-text/RichTextEditor.spec.ts
+++ b/cypress/integration/rich-text/RichTextEditor.spec.ts
@@ -1125,10 +1125,9 @@ describe('Rich Text Editor', { viewportHeight: 2000 }, () => {
           }
 
           addEmbeddedEntry();
+          selectAndPressEnter(); // Inserts paragraph before embed because it's in the first line.
           addEmbeddedEntry();
-
-          selectAndPressEnter();
-          selectAndPressEnter();
+          selectAndPressEnter(); // inserts paragraph in-between embeds.
 
           expectRichTextFieldValue(
             doc(

--- a/packages/rich-text/src/RichTextEditor.tsx
+++ b/packages/rich-text/src/RichTextEditor.tsx
@@ -53,6 +53,7 @@ import { ContentfulEditorProvider, getContentfulEditorId } from './ContentfulEdi
 import { FieldExtensionSDK } from '@contentful/app-sdk';
 import { FieldConnector } from '@contentful/field-editor-shared';
 import { createTrailingParagraphPlugin } from './plugins/TrailingParagraph';
+import { createDragAndDropPlugin } from './plugins/DragAndDrop';
 
 type ConnectedProps = {
   sdk: FieldExtensionSDK;
@@ -77,6 +78,7 @@ const getPlugins = (sdk: FieldExtensionSDK, tracking: TrackingProvider) => {
     // Global shortcuts
     createNewLinePlugin(),
     createInsertBeforeFirstVoidBlockPlugin(),
+    createDragAndDropPlugin(),
 
     // Block Elements
     createParagraphPlugin(),

--- a/packages/rich-text/src/plugins/DragAndDrop/index.tsx
+++ b/packages/rich-text/src/plugins/DragAndDrop/index.tsx
@@ -1,0 +1,67 @@
+import { Node as SlateNode, Transforms } from 'slate';
+import { PlatePlugin } from '@udecode/plate-core';
+import { CustomElement } from '../../types';
+import { BLOCKS, CONTAINERS } from '@contentful/rich-text-types';
+
+export function createDragAndDropPlugin(): PlatePlugin {
+  // Elements that don't allow other elements to be dragged into them and which callback should be used
+  const DND_BLOCKED_ELEMENTS = {
+    [BLOCKS.TABLE]: Transforms.removeNodes,
+    [BLOCKS.QUOTE]: Transforms.liftNodes,
+  };
+
+  // DND_BLOCKED_ELEMENTS callbacks will run on those elements only
+  const DRAGGABLE_TYPES: string[] = [BLOCKS.EMBEDDED_ENTRY, BLOCKS.EMBEDDED_ASSET];
+
+  // HTML node names where dropping should be disabled, usually when using `Transforms.removeNodes` callback
+  const ON_DROP_BLOCKED_TYPES = ['TABLE'];
+
+  return {
+    withOverrides: (editor) => {
+      const { normalizeNode } = editor;
+
+      editor.normalizeNode = (entry) => {
+        const [node, path] = entry;
+
+        Object.keys(DND_BLOCKED_ELEMENTS).forEach((blockedElementType) => {
+          const nodeType = (node as CustomElement).type;
+
+          if (SlateNode.isNode(node) && nodeType === blockedElementType) {
+            for (const [child, childPath] of SlateNode.children(editor, path)) {
+              const childType = (child as CustomElement).type;
+
+              if (!CONTAINERS[blockedElementType]) return;
+              if (!CONTAINERS[blockedElementType].includes(childType)) {
+                const callback = DND_BLOCKED_ELEMENTS[blockedElementType];
+                callback(editor, {
+                  at: childPath,
+                  match: (matchNode) =>
+                    SlateNode.isNode(matchNode) &&
+                    DRAGGABLE_TYPES.includes((matchNode as CustomElement).type),
+                });
+
+                return;
+              }
+            }
+          }
+        });
+
+        normalizeNode(entry);
+      };
+
+      return editor;
+    },
+    onDrop: () => (event) => {
+      /**
+       * If true, the next handlers will be skipped.
+       * In this case, the element that is being dragged will be copied,
+       * two versions of the same element on the document,
+       * so we need to remove it above on `normalizeNode`.
+       */
+      // @ts-expect-error
+      return event.nativeEvent.path.some((node) => {
+        return ON_DROP_BLOCKED_TYPES.includes(node.nodeName);
+      });
+    },
+  };
+}

--- a/packages/rich-text/src/plugins/DragAndDrop/index.tsx
+++ b/packages/rich-text/src/plugins/DragAndDrop/index.tsx
@@ -73,13 +73,26 @@ export function createDragAndDropPlugin(): PlatePlugin {
 
       const [draggingNode] = draggingBlock;
 
+      if (!event.nativeEvent.target) return false;
+
       // TODO: looking up for html nodes is not the best solution and it won't scale, we need to find a way to know the dropping target slate element
-      // @ts-expect-error
-      return event.nativeEvent.path.some((node) => {
+      return getParents(event.nativeEvent.target as Node).some((node) => {
         return ON_DROP_ALLOWED_TYPES[node.nodeName]
           ? !ON_DROP_ALLOWED_TYPES[node.nodeName]?.includes(draggingNode.type)
           : false;
       });
     },
   };
+}
+
+function getParents(el: Node): Node[] {
+  const parents: Node[] = [];
+
+  parents.push(el);
+  while (el.parentNode) {
+    parents.unshift(el.parentNode);
+    el = el.parentNode;
+  }
+
+  return parents;
 }

--- a/packages/rich-text/src/plugins/EmbeddedEntityBlock/LinkedEntityBlock.tsx
+++ b/packages/rich-text/src/plugins/EmbeddedEntityBlock/LinkedEntityBlock.tsx
@@ -49,8 +49,9 @@ export function LinkedEntityBlock(props: LinkedEntityBlockProps) {
       className={styles.root}
       data-entity-type={entityType}
       data-entity-id={entityId}
-      draggable={true}>
-      <div contentEditable={false}>
+      draggable={true}
+      contentEditable={false}>
+      <div>
         {entityType === 'Entry' && (
           <FetchingWrappedEntryCard
             sdk={sdk}

--- a/packages/rich-text/src/plugins/EmbeddedEntityBlock/LinkedEntityBlock.tsx
+++ b/packages/rich-text/src/plugins/EmbeddedEntityBlock/LinkedEntityBlock.tsx
@@ -48,7 +48,8 @@ export function LinkedEntityBlock(props: LinkedEntityBlockProps) {
       {...attributes}
       className={styles.root}
       data-entity-type={entityType}
-      data-entity-id={entityId}>
+      data-entity-id={entityId}
+      draggable={true}>
       <div contentEditable={false}>
         {entityType === 'Entry' && (
           <FetchingWrappedEntryCard

--- a/packages/rich-text/src/plugins/EmbeddedEntityInline/index.tsx
+++ b/packages/rich-text/src/plugins/EmbeddedEntityInline/index.tsx
@@ -59,7 +59,11 @@ function EmbeddedEntityInline(props: EmbeddedEntityInlineProps) {
   }
 
   return (
-    <span {...props.attributes} className={styles.root} data-embedded-entity-inline-id={entryId}>
+    <span
+      {...props.attributes}
+      className={styles.root}
+      data-embedded-entity-inline-id={entryId}
+      draggable={true}>
       <span contentEditable={false}>
         <FetchingWrappedInlineEntryCard
           sdk={sdk}
@@ -148,6 +152,7 @@ export function createEmbeddedEntityInlinePlugin(sdk): PlatePlugin {
     renderElement: getRenderElement(INLINES.EMBEDDED_ENTRY),
     pluginKeys: INLINES.EMBEDDED_ENTRY,
     inlineTypes: getPlatePluginTypes(INLINES.EMBEDDED_ENTRY),
+    voidTypes: getPlatePluginTypes(INLINES.EMBEDDED_ENTRY),
     onKeyDown: getWithEmbeddedEntryInlineEvents(sdk),
     deserialize: (editor) => {
       const options = getPlatePluginOptions(editor, INLINES.EMBEDDED_ENTRY);


### PR DESCRIPTION
Any HTML element become interactive  when adding `draggable="true"`. I found that by adding this attribute the whole block becomes draggable and Slate kind of take care of the rest.

I can drag:

- Embedded blocks
- Embedded inlines

Where:

- After, before and in the middle of paragraphs
- After and before other embedded blocks
- Inside blockquote elements
- Inside tables (only embedded inline elements)