### PR TITLE
fix: no cell deletion via keyboard

### DIFF
--- a/cypress/integration/rich-text/RichTextEditor.spec.ts
+++ b/cypress/integration/rich-text/RichTextEditor.spec.ts
@@ -673,6 +673,54 @@ describe('Rich Text Editor', { viewportHeight: 2000 }, () => {
       ].map((type) => getDropdownItem(type).get('button').should('not.be.disabled'));
     });
 
+    describe('Deleting text', () => {
+      describe('Backward deletion', () => {
+        it('removes the text, not the cell', () => {
+          insertTableWithExampleData();
+          cy.get('table > tbody > tr:last-child > td:last-child').click();
+          editor()
+            .type('{backspace}{backspace}{backspace}{backspace}{backspace}')
+            // .type('{backspace}') does not work on non-typable elements.(contentEditable=false)
+            .trigger('keydown', { keyCode: 8, which: 8, key: 'Backspace' }); // 8 = delete/backspace
+
+          expectTable(
+            row(headerWithText('foo'), headerWithText('bar')),
+            row(cellWithText('baz'), emptyCell())
+          );
+
+          // make sure it works for table header cells, too
+          cy.get('table > tbody > tr:first-child > th:first-child').click();
+          editor()
+            .type('{backspace}{backspace}{backspace}{backspace}{backspace}')
+            // .type('{backspace}') does not work on non-typable elements.(contentEditable=false)
+            .trigger('keydown', { keyCode: 8, which: 8, key: 'Backspace' }); // 8 = delete/backspace
+
+          expectTable(
+            row(emptyHeader(), headerWithText('bar')),
+            row(cellWithText('baz'), emptyCell())
+          );
+        });
+      });
+
+      describe('Forward deletion', () => {
+        it('removes the text, not the cell', () => {
+          insertTableWithExampleData();
+          cy.get('table > tbody > tr:first-child > th:first-child').click();
+          editor()
+            .type('{leftarrow}{leftarrow}{leftarrow}{del}{del}{del}{del}')
+            // .type('{backspace}') does not work on non-typable elements.(contentEditable=false)
+            .trigger('keydown', { keyCode: 8, which: 8, key: 'Delete' }) // 8 = delete/backspace
+            // try forward-deleting from outside the table for good measure
+            .type('{leftarrow}{del}')
+            .trigger('keydown', { keyCode: 8, which: 8, key: 'Delete' });
+          expectTable(
+            row(headerWithText(''), headerWithText('bar')),
+            row(cellWithText('baz'), cellWithText('quux'))
+          );
+        });
+      });
+    });
+
     describe('Table Actions', () => {
       const findAction = (action: string) => {
         cy.findByTestId('cf-table-actions-button').click();

--- a/packages/rich-text/src/helpers/editor.ts
+++ b/packages/rich-text/src/helpers/editor.ts
@@ -1,8 +1,9 @@
-import { Text, Editor, Element, Transforms, Path, Range } from 'slate';
-import { BLOCKS, INLINES } from '@contentful/rich-text-types';
+import { Text, Editor, Element, Transforms, Path, Range, Node } from 'slate';
+import { BLOCKS, INLINES, TABLE_BLOCKS } from '@contentful/rich-text-types';
 import { CustomElement } from '../types';
 import { Link } from '@contentful/field-editor-reference/dist/types';
 import { SPEditor } from '@udecode/plate-core';
+import { getText } from '@udecode/plate-common';
 
 export const LINK_TYPES: INLINES[] = [
   INLINES.HYPERLINK,
@@ -243,4 +244,45 @@ export function shouldUnwrapBlockquote(editor: SPEditor, type: BLOCKS) {
 export function unwrapFromRoot(editor: SPEditor) {
   const ancestorPath = getAncestorPathFromSelection(editor);
   Transforms.unwrapNodes(editor, { at: ancestorPath });
+}
+
+export const isAtEndOfTextSelection = (editor: SPEditor) =>
+  editor.selection?.focus.offset === getText(editor, editor.selection?.focus.path).length;
+
+export function currentSelectionStartsTableCell(editor: SPEditor): boolean {
+  const [tableCellNode, path] = getNodeEntryFromSelection(editor, [
+    BLOCKS.TABLE_CELL,
+    BLOCKS.TABLE_HEADER_CELL,
+  ]);
+  return !!tableCellNode && (!getText(editor, path) || editor.selection?.focus.offset === 0);
+}
+
+/**
+ * This traversal strategy is unfortunately necessary because Slate doesn't
+ * expose something like Node.next(editor).
+ */
+export function getNextNode(editor: SPEditor): CustomElement | null {
+  if (!editor.selection) {
+    return null;
+  }
+  const descendants = Node.descendants(editor, { from: editor.selection.focus.path });
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const { done, value } = descendants.next();
+    if (done) {
+      return null;
+    }
+    const [node, path] = value as NodeEntry;
+    if (Path.isCommon(path, editor.selection.focus.path)) {
+      continue;
+    }
+    return node as CustomElement;
+  }
+}
+
+export function currentSelectionPrecedesTableCell(editor: SPEditor): boolean {
+  const nextNode = getNextNode(editor);
+  return (
+    !!nextNode && TABLE_BLOCKS.includes(nextNode.type as BLOCKS) && isAtEndOfTextSelection(editor)
+  );
 }


### PR DESCRIPTION
This solves an issue in which deleting via the backspace or delete keys within or before a table would delete the current or forthcoming table cell.