### PR TITLE
fix: internal copy and paste for firefox, chromium and safari []

### DIFF
--- a/packages/rich-text/src/helpers/environment.ts
+++ b/packages/rich-text/src/helpers/environment.ts
@@ -1,0 +1,23 @@
+// "modern" Edge was released at 79.x
+const IS_EDGE_LEGACY =
+  typeof navigator !== 'undefined' && /Edge?\/(?:[0-6][0-9]|[0-7][0-8])/i.test(navigator.userAgent);
+
+// Native `beforeInput` events don't work well with react on Chrome 75
+// and older, Chrome 76+ can use `beforeInput` though.
+const IS_CHROME_LEGACY =
+  typeof navigator !== 'undefined' &&
+  /Chrome?\/(?:[0-7][0-5]|[0-6][0-9])/i.test(navigator.userAgent);
+
+type CustomInputEvent = {
+  getTargetRanges?: (() => StaticRange[]) | undefined;
+} & InputEvent;
+
+// COMPAT: Firefox/Edge Legacy don't support the `beforeinput` event
+// Chrome Legacy doesn't support `beforeinput` correctly
+export const HAS_BEFORE_INPUT_SUPPORT =
+  !IS_CHROME_LEGACY &&
+  !IS_EDGE_LEGACY &&
+  // globalThis is undefined in older browsers
+  typeof globalThis !== 'undefined' &&
+  globalThis.InputEvent &&
+  typeof (globalThis.InputEvent.prototype as CustomInputEvent).getTargetRanges === 'function'; // The `getTargetRanges` property isn't recognized.

--- a/packages/rich-text/src/plugins/EmbeddedEntityBlock/LinkedEntityBlock.tsx
+++ b/packages/rich-text/src/plugins/EmbeddedEntityBlock/LinkedEntityBlock.tsx
@@ -7,6 +7,7 @@ import { CustomRenderElementProps } from '../../types';
 import { ReactEditor, useSelected, useReadOnly } from 'slate-react';
 import { Transforms } from 'slate';
 import { useContentfulEditor } from '../../ContentfulEditorProvider';
+import { HAS_BEFORE_INPUT_SUPPORT } from '../../helpers/environment';
 
 const styles = {
   root: css({
@@ -49,9 +50,13 @@ export function LinkedEntityBlock(props: LinkedEntityBlockProps) {
       className={styles.root}
       data-entity-type={entityType}
       data-entity-id={entityId}
-      draggable={true}
-      contentEditable={false}>
-      <div>
+      // COMPAT: This makes copy & paste work for Firefox
+      contentEditable={!HAS_BEFORE_INPUT_SUPPORT ? false : undefined}
+      draggable={!HAS_BEFORE_INPUT_SUPPORT ? true : undefined}>
+      <div
+        // COMPAT: This makes copy & paste work for Chromium/Blink browsers and Safari
+        contentEditable={HAS_BEFORE_INPUT_SUPPORT ? false : undefined}
+        draggable={HAS_BEFORE_INPUT_SUPPORT ? true : undefined}>
         {entityType === 'Entry' && (
           <FetchingWrappedEntryCard
             sdk={sdk}

--- a/packages/rich-text/src/plugins/EmbeddedEntityInline/index.tsx
+++ b/packages/rich-text/src/plugins/EmbeddedEntityInline/index.tsx
@@ -19,6 +19,7 @@ import { useSdkContext } from '../../SdkProvider';
 import { FetchingWrappedInlineEntryCard } from './FetchingWrappedInlineEntryCard';
 import { createInlineEntryNode } from './Util';
 import { useContentfulEditor } from '../../ContentfulEditorProvider';
+import { HAS_BEFORE_INPUT_SUPPORT } from '../../helpers/environment';
 
 const styles = {
   icon: css({
@@ -63,8 +64,13 @@ function EmbeddedEntityInline(props: EmbeddedEntityInlineProps) {
       {...props.attributes}
       className={styles.root}
       data-embedded-entity-inline-id={entryId}
-      draggable={true}>
-      <span contentEditable={false}>
+      // COMPAT: This makes copy & paste work for Firefox
+      contentEditable={!HAS_BEFORE_INPUT_SUPPORT ? false : undefined}
+      draggable={!HAS_BEFORE_INPUT_SUPPORT ? true : undefined}>
+      <span
+        // COMPAT: This makes copy & paste work for Chromium/Blink browsers and Safari
+        contentEditable={HAS_BEFORE_INPUT_SUPPORT ? false : undefined}
+        draggable={HAS_BEFORE_INPUT_SUPPORT ? true : undefined}>
         <FetchingWrappedInlineEntryCard
           sdk={sdk}
           entryId={entryId}


### PR DESCRIPTION
It seems Slate has compatibility issues with some browsers. Specially the ones that don't support the `beforeInput` event and this seems to affect the `contentEditable` attribute.

Their codebase has a lot of calls to browser detection, they even have a file with some [browser detection helpers](https://github.com/ianstormtaylor/slate/blob/main/packages/slate-react/src/utils/environment.ts).

I copied some from there and I tested on the following browsers on Mac OS:

- Latest Chrome
- Latest Opera
- Latest Safari
- Latest Edge
- Latest Firefox

They all worked fine as expected, even the command to cut & copy.