### PR TITLE
fix: fix list field preventing commas after forma36 v4

### DIFF
--- a/packages/list/src/ListEditor.spec.tsx
+++ b/packages/list/src/ListEditor.spec.tsx
@@ -79,4 +79,26 @@ describe('ListEditor', () => {
     expect(field.removeValue).toHaveBeenCalledTimes(1);
     expect(field.setValue).toHaveBeenCalledTimes(2);
   });
+
+  it('keeps trailing commas', () => {
+    const [field] = createFakeFieldAPI(
+      (field) => {
+        jest.spyOn(field, 'setValue');
+        return {
+          ...field,
+          validations: [],
+        };
+      },
+      ['test1']
+    );
+
+    const renderResult = render(
+      <ListEditor field={field} locales={createFakeLocalesAPI()} isInitiallyDisabled={false} />
+    );
+
+    changeInputValue(renderResult, 'test1,');
+
+    expect(field.setValue).toHaveBeenLastCalledWith(['test1']);
+    expectInputValue(renderResult, 'test1,');
+  });
 });

--- a/packages/list/src/ListEditor.tsx
+++ b/packages/list/src/ListEditor.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { FieldAPI, FieldConnector, LocalesAPI } from '@contentful/field-editor-shared';
 import * as styles from './styles';
+import isEqual from 'lodash/isEqual';
 
 import { TextInput } from '@contentful/f36-components';
 import { FieldConnectorChildProps } from '@contentful/field-editor-shared/dist/FieldConnector';
@@ -57,13 +58,15 @@ function ListEditorInternal({
   const [valueState, setValueState] = React.useState(() => (value || []).join(', '));
 
   const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setValueState(e.target.value);
-
     const valueAsArray = e.target.value
       .split(',')
       .map((item) => item.trim())
       .filter((item) => item);
+    const changed = !isEqual(valueAsArray, value);
     setValue(valueAsArray);
+
+    const valueAsString = valueAsArray.join(', ');
+    setValueState(changed ? valueAsString : e.target.value);
   };
 
   return (

--- a/packages/list/src/ListEditor.tsx
+++ b/packages/list/src/ListEditor.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
-import { FieldAPI, LocalesAPI, FieldConnector } from '@contentful/field-editor-shared';
+import { FieldAPI, FieldConnector, LocalesAPI } from '@contentful/field-editor-shared';
 import * as styles from './styles';
 
 import { TextInput } from '@contentful/f36-components';
+import { FieldConnectorChildProps } from '@contentful/field-editor-shared/dist/FieldConnector';
 
 export interface ListEditorProps {
   /**
@@ -38,30 +39,43 @@ export function ListEditor(props: ListEditorProps) {
       isEmptyValue={isEmptyListValue}
       field={field}
       isInitiallyDisabled={props.isInitiallyDisabled}>
-      {({ setValue, value, errors, disabled }) => {
-        const valueAsString = (value || []).join(', ');
-
-        const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-          const valueAsArray = e.target.value
-            .split(',')
-            .map((item) => item.trim())
-            .filter((item) => item);
-          setValue(valueAsArray);
-        };
-
-        return (
-          <TextInput
-            testId="list-editor-input"
-            className={direction === 'rtl' ? styles.rightToLeft : ''}
-            isRequired={field.required}
-            isInvalid={errors.length > 0}
-            isDisabled={disabled}
-            value={valueAsString}
-            onChange={onChange}
-          />
-        );
-      }}
+      {(childProps) => (
+        <ListEditorInternal {...childProps} direction={direction} isRequired={field.required} />
+      )}
     </FieldConnector>
+  );
+}
+
+function ListEditorInternal({
+  setValue,
+  value,
+  errors,
+  disabled,
+  direction,
+  isRequired,
+}: FieldConnectorChildProps<ListValue> & { direction: 'rtl' | 'ltr'; isRequired: boolean }) {
+  const [valueState, setValueState] = React.useState(() => (value || []).join(', '));
+
+  const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setValueState(e.target.value);
+
+    const valueAsArray = e.target.value
+      .split(',')
+      .map((item) => item.trim())
+      .filter((item) => item);
+    setValue(valueAsArray);
+  };
+
+  return (
+    <TextInput
+      testId="list-editor-input"
+      className={direction === 'rtl' ? styles.rightToLeft : ''}
+      isRequired={isRequired}
+      isInvalid={errors.length > 0}
+      isDisabled={disabled}
+      value={valueState}
+      onChange={onChange}
+    />
   );
 }
 


### PR DESCRIPTION
The list field stopped accepting typed commas, that happened after the Forma36 update to version 4, where `TextInput` lost its internal state. When converting from array of values and back to the string, we lose the trailing commas.

This PR adds the `ListEditorInternal` component which implements the internal state allowing us to preserve the trailing commas.