### PR TITLE
chore: bump next version to 2.0.0-next.1 []

### DIFF
--- a/apps/entry-app-collapsible/package.json
+++ b/apps/entry-app-collapsible/package.json
@@ -8,7 +8,7 @@
     "@contentful/f36-components": "beta",
     "@contentful/f36-icons": "beta",
     "@contentful/f36-tokens": "beta",
-    "@contentful/field-editor-rich-text": "2.0.0-next.0",
+    "@contentful/field-editor-rich-text": "2.0.0-next.1",
     "@contentful/field-editor-shared": "^1.0.0",
     "@contentful/field-editor-single-line": "^1.0.0",
     "emotion": "^10.0.17",

--- a/apps/rich-text-app/package.json
+++ b/apps/rich-text-app/package.json
@@ -6,7 +6,7 @@
     "@contentful/app-sdk": "^4.3.0",
     "@contentful/f36-components": "beta",
     "@contentful/f36-tokens": "beta",
-    "@contentful/field-editor-rich-text": "2.0.0-next.0",
+    "@contentful/field-editor-rich-text": "2.0.0-next.1",
     "@contentful/field-editor-single-line": "^1.0.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"

--- a/packages/default-field-editors/package.json
+++ b/packages/default-field-editors/package.json
@@ -35,7 +35,7 @@
     "@contentful/field-editor-radio": "^1.0.0",
     "@contentful/field-editor-rating": "^1.0.0",
     "@contentful/field-editor-reference": "^4.0.0",
-    "@contentful/field-editor-rich-text": "2.0.0-next.0",
+    "@contentful/field-editor-rich-text": "2.0.0-next.1",
     "@contentful/field-editor-shared": "^1.0.0",
     "@contentful/field-editor-single-line": "^1.0.0",
     "@contentful/field-editor-slug": "^1.0.0",

--- a/packages/rich-text/package.json
+++ b/packages/rich-text/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contentful/field-editor-rich-text",
-  "version": "2.0.0-next.0",
+  "version": "2.0.0-next.1",
   "publishConfig": {
     "tag": "next"
   },


### PR DESCRIPTION
Highlights of `2.0.0-next.1`:

- Internal drag & drop of embedded blocks and embedded inlines
- Internal copy & paste of embedded blocks and embedded inlines