### PR TITLE
test: use click again to unfocus block embeds

### DIFF
--- a/cypress/integration/rich-text/RichTextEditor.spec.ts
+++ b/cypress/integration/rich-text/RichTextEditor.spec.ts
@@ -1144,7 +1144,7 @@ describe('Rich Text Editor', { viewportHeight: 2000 }, () => {
         it('adds paragraph between two blocks when pressing enter', () => {
           function addEmbeddedEntry() {
             richText.editor.click('bottom').then(triggerEmbeddedEntry);
-            richText.editor.type('{rightarrow}');
+            richText.editor.click('bottom');
           }
 
           function selectAndPressEnter() {
@@ -1305,7 +1305,7 @@ describe('Rich Text Editor', { viewportHeight: 2000 }, () => {
         it('adds paragraph between two blocks when pressing enter', () => {
           function addEmbeddedEntry() {
             richText.editor.click('bottom').then(triggerEmbeddedAsset);
-            richText.editor.type('{rightarrow}');
+            richText.editor.click('bottom');
           }
 
           function selectAndPressEnter() {


### PR DESCRIPTION
It seems to unfocus block elements we can use a simple `editor.click('bottom')` again instead of using right arrow key to move focus away.

Also note that changes in 1b52fe1, using `.type()` instead of triggering a `keydown` event didn't work locally but only on CI.