### PR TITLE
chore: use cypress & mocha linting rules on next branch

### DIFF
--- a/cypress/.eslintrc.js
+++ b/cypress/.eslintrc.js
@@ -1,6 +1,12 @@
 module.exports = {
-  extends: '../.eslintrc.js',
+  extends: ['../.eslintrc.js', 'plugin:mocha/recommended', 'plugin:cypress/recommended'],
   plugins: ['cypress'],
+  rules: {
+    'cypress/no-unnecessary-waiting': 'warn',
+    'mocha/no-mocha-arrows': 'off',
+    'mocha/no-exclusive-tests': 'error',
+    'mocha/no-skipped-tests': 'error',
+  },
   env: {
     'cypress/globals': true,
   },

--- a/cypress/integration/LocationEditor.spec.ts
+++ b/cypress/integration/LocationEditor.spec.ts
@@ -63,6 +63,8 @@ describe('Location Editor', () => {
     cy.editorEvents().should('deep.equal', []);
   });
 
+  // TODO: Why are we skipping this test?
+  // eslint-disable-next-line mocha/no-skipped-tests
   it.skip('should set value after latitude and longitude change', () => {
     cy.editorEvents().should('deep.equal', []);
 

--- a/cypress/integration/rich-text/RichTextEditor.spec.ts
+++ b/cypress/integration/rich-text/RichTextEditor.spec.ts
@@ -1,3 +1,5 @@
+/* eslint-disable mocha/no-setup-in-describe */
+
 import { MARKS, BLOCKS, INLINES } from '@contentful/rich-text-types';
 import {
   document as doc,
@@ -263,6 +265,8 @@ describe('Rich Text Editor', { viewportHeight: 2000 }, () => {
         richText.expectValue(expectedValue);
       });
 
+      // TODO: Seems to be failing on CI
+      // eslint-disable-next-line mocha/no-skipped-tests
       it.skip('should add line if HR is the first void block', () => {
         richText.editor.click();
 

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "eslint-plugin-cypress": "^2.12.0",
     "eslint-plugin-jest": "^24.1.0",
     "eslint-plugin-jsx-a11y": "^6.2.3",
+    "eslint-plugin-mocha": "^9.0.0",
     "eslint-plugin-react": "^7.18.0",
     "eslint-plugin-react-hooks": "^4.0.0",
     "git-cz": "4.7.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10294,6 +10294,14 @@ eslint-plugin-jsx-a11y@^6.2.3, eslint-plugin-jsx-a11y@^6.3.1, eslint-plugin-jsx-
     jsx-ast-utils "^3.1.0"
     language-tags "^1.0.5"
 
+eslint-plugin-mocha@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-mocha/-/eslint-plugin-mocha-9.0.0.tgz#b4457d066941eecb070dc06ed301c527d9c61b60"
+  integrity sha512-d7knAcQj1jPCzZf3caeBIn3BnW6ikcvfz0kSqQpwPYcVGLoJV5sz0l0OJB2LR8I7dvTDbqq1oV6ylhSgzA10zg==
+  dependencies:
+    eslint-utils "^3.0.0"
+    ramda "^0.27.1"
+
 eslint-plugin-prettier@^3.1.0:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.2.tgz#432e5a667666ab84ce72f945c72f77d996a5c9ba"
@@ -18722,7 +18730,7 @@ raf@^3.4.1:
   dependencies:
     performance-now "^2.1.0"
 
-ramda@~0.27.1:
+ramda@^0.27.1, ramda@~0.27.1:
   version "0.27.1"
   resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.27.1.tgz#66fc2df3ef873874ffc2da6aa8984658abacf5c9"
   integrity sha512-PgIdVpn5y5Yns8vqb8FzBUEYn98V3xcPgawAkkgj0YJ0qDsnHCiNmZYfOGMgOvoB0eWFLpYbhxUR3mxfDIMvpw==


### PR DESCRIPTION
With the main motivation to fail linting when committing spec files with accidental `.only` or `.skip` test definitions.

https://github.com/contentful/field-editors/pull/940 does the same for `master`.