### PR TITLE
chore: use cypress & mocha linting rules

### DIFF
--- a/cypress/.eslintrc.js
+++ b/cypress/.eslintrc.js
@@ -1,6 +1,12 @@
 module.exports = {
-  extends: '../.eslintrc.js',
+  extends: ['../.eslintrc.js', 'plugin:mocha/recommended', 'plugin:cypress/recommended'],
   plugins: ['cypress'],
+  rules: {
+    'cypress/no-unnecessary-waiting': 'warn',
+    'mocha/no-mocha-arrows': 'off',
+    'mocha/no-exclusive-tests': 'error',
+    'mocha/no-skipped-tests': 'error',
+  },
   env: {
     'cypress/globals': true,
   },

--- a/cypress/integration/LocationEditor.spec.ts
+++ b/cypress/integration/LocationEditor.spec.ts
@@ -63,6 +63,8 @@ describe('Location Editor', () => {
     cy.editorEvents().should('deep.equal', []);
   });
 
+  // TODO: Why are we skipping this test?
+  // eslint-disable-next-line mocha/no-skipped-tests
   it.skip('should set value after latitude and longitude change', () => {
     cy.editorEvents().should('deep.equal', []);
 

--- a/cypress/integration/RichTextEditor.spec.ts
+++ b/cypress/integration/RichTextEditor.spec.ts
@@ -1,3 +1,5 @@
+/* eslint-disable mocha/no-setup-in-describe */
+
 import { MARKS, BLOCKS } from '@contentful/rich-text-types';
 import { document as doc, block, text } from '../../packages/rich-text/src/helpers/nodeFactory';
 
@@ -19,8 +21,11 @@ describe('Rich Text Editor', () => {
 
   beforeEach(() => {
     cy.visit('/rich-text');
-    const wrapper = cy.findByTestId('rich-text-editor-integration-test').should('be.visible');
-    editor = wrapper.find('[data-slate-editor=true]').should('be.visible');
+    editor = cy
+      .findByTestId('rich-text-editor-integration-test')
+      .should('be.visible')
+      .find('[data-slate-editor=true]')
+      .should('be.visible');
   });
 
   it('is empty by default', () => {

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "eslint-plugin-cypress": "^2.7.0",
     "eslint-plugin-jest": "^24.1.0",
     "eslint-plugin-jsx-a11y": "^6.2.3",
+    "eslint-plugin-mocha": "^9.0.0",
     "eslint-plugin-react": "^7.18.0",
     "eslint-plugin-react-hooks": "^4.0.0",
     "git-cz": "4.7.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9934,6 +9934,14 @@ eslint-plugin-jsx-a11y@^6.2.3, eslint-plugin-jsx-a11y@^6.3.1, eslint-plugin-jsx-
     jsx-ast-utils "^3.1.0"
     language-tags "^1.0.5"
 
+eslint-plugin-mocha@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-mocha/-/eslint-plugin-mocha-9.0.0.tgz#b4457d066941eecb070dc06ed301c527d9c61b60"
+  integrity sha512-d7knAcQj1jPCzZf3caeBIn3BnW6ikcvfz0kSqQpwPYcVGLoJV5sz0l0OJB2LR8I7dvTDbqq1oV6ylhSgzA10zg==
+  dependencies:
+    eslint-utils "^3.0.0"
+    ramda "^0.27.1"
+
 eslint-plugin-prettier@^3.1.0:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.2.tgz#432e5a667666ab84ce72f945c72f77d996a5c9ba"
@@ -18321,6 +18329,11 @@ railroad-diagrams@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz#eb7e6267548ddedfb899c1b90e57374559cddb7e"
   integrity sha1-635iZ1SN3t+4mcG5Dlc3RVnN234=
+
+ramda@^0.27.1:
+  version "0.27.1"
+  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.27.1.tgz#66fc2df3ef873874ffc2da6aa8984658abacf5c9"
+  integrity sha512-PgIdVpn5y5Yns8vqb8FzBUEYn98V3xcPgawAkkgj0YJ0qDsnHCiNmZYfOGMgOvoB0eWFLpYbhxUR3mxfDIMvpw==
 
 ramda@~0.26.1:
   version "0.26.1"


### PR DESCRIPTION
With the main motivation to fail linting when commiting spec files with accidental `.only` or `.skip` tests definitoins.