### PR TITLE
feat: create helper to filter out text as paragraphs from slate entries

### DIFF
--- a/packages/rich-text/src/helpers/editor.spec.ts
+++ b/packages/rich-text/src/helpers/editor.spec.ts
@@ -1,0 +1,269 @@
+import { createEditor as createSlateEditor } from '@udecode/plate-test-utils';
+import { PlateEditor } from '@udecode/plate';
+import { NodeEntry } from 'slate';
+import { BLOCKS, INLINES } from '@contentful/rich-text-types';
+import { slateNodeEntryToText } from './editor';
+import { CustomElement } from '../types';
+
+const createEditor = (children: CustomElement[]) =>
+  createSlateEditor('test-editor', {}, children) as PlateEditor;
+
+type Text = {
+  text: string;
+  bold?: boolean;
+  italic?: boolean;
+  underline?: boolean;
+  code?: boolean;
+  data?: Record<string, unknown>;
+};
+type Inline = {
+  children: Text[];
+  type: INLINES;
+  data: Record<string, unknown>;
+};
+type TextOrInline = Text | Inline;
+const buildParagraph = (children: TextOrInline[] = []) => ({
+  type: BLOCKS.PARAGRAPH,
+  data: {},
+  isVoid: false,
+  children: children.map((child) => ({ data: {}, ...child })),
+});
+const paragraph = (text = '', marks = {}) => buildParagraph([{ text, ...marks }]);
+
+describe('slateNodeEntryToText', () => {
+  it('table', () => {
+    const table: CustomElement = {
+      data: {},
+      isVoid: false,
+      type: BLOCKS.TABLE,
+      children: [
+        {
+          type: BLOCKS.TABLE_ROW,
+          data: {},
+          isVoid: false,
+          children: [
+            {
+              type: BLOCKS.TABLE_HEADER_CELL,
+              data: {},
+              isVoid: false,
+              children: [paragraph('header 1')],
+            },
+            {
+              type: BLOCKS.TABLE_HEADER_CELL,
+              data: {},
+              isVoid: false,
+              children: [paragraph('header 2')],
+            },
+          ],
+        },
+        {
+          type: BLOCKS.TABLE_ROW,
+          data: {},
+          isVoid: false,
+          children: [
+            {
+              type: BLOCKS.TABLE_CELL,
+              data: {},
+              isVoid: false,
+              children: [paragraph('cell 1')],
+            },
+            {
+              type: BLOCKS.TABLE_CELL,
+              data: {},
+              isVoid: false,
+              children: [paragraph('cell 2')],
+            },
+          ],
+        },
+      ],
+    };
+    const editor = createEditor([table]);
+    const entry: NodeEntry = [table, [0]];
+
+    expect(slateNodeEntryToText(editor, entry)).toEqual([
+      paragraph('header 1'),
+      paragraph('header 2'),
+      paragraph('cell 1'),
+      paragraph('cell 2'),
+    ]);
+  });
+
+  it('blockquote', () => {
+    const blockquote: CustomElement = {
+      data: {},
+      isVoid: false,
+      type: BLOCKS.QUOTE,
+      children: [paragraph('text 1'), paragraph('text 2')],
+    };
+    const editor = createEditor([blockquote]);
+    const entry: NodeEntry = [blockquote, [0]];
+
+    expect(slateNodeEntryToText(editor, entry)).toEqual([paragraph('text 1'), paragraph('text 2')]);
+  });
+
+  it('list - UL', () => {
+    const ul: CustomElement = {
+      data: {},
+      isVoid: false,
+      type: BLOCKS.UL_LIST,
+      children: [
+        {
+          data: {},
+          isVoid: false,
+          type: BLOCKS.LIST_ITEM,
+          children: [
+            {
+              type: BLOCKS.UL_LIST,
+              isVoid: false,
+              data: {},
+              children: [
+                {
+                  data: {},
+                  isVoid: false,
+                  type: BLOCKS.LIST_ITEM,
+                  children: [paragraph('text 1')],
+                },
+              ],
+            },
+          ],
+        },
+        {
+          data: {},
+          isVoid: false,
+          type: BLOCKS.LIST_ITEM,
+          children: [paragraph('text 2')],
+        },
+        {
+          data: {},
+          isVoid: false,
+          type: BLOCKS.LIST_ITEM,
+          children: [paragraph('text 3')],
+        },
+      ],
+    };
+    const editor = createEditor([ul]);
+    const entry: NodeEntry = [ul, [0]];
+
+    expect(slateNodeEntryToText(editor, entry)).toEqual([
+      paragraph('text 1'),
+      paragraph('text 2'),
+      paragraph('text 3'),
+    ]);
+  });
+
+  it('list - OL', () => {
+    const ol: CustomElement = {
+      data: {},
+      isVoid: false,
+      type: BLOCKS.OL_LIST,
+      children: [
+        {
+          data: {},
+          isVoid: false,
+          type: BLOCKS.LIST_ITEM,
+          children: [
+            {
+              type: BLOCKS.OL_LIST,
+              isVoid: false,
+              data: {},
+              children: [
+                {
+                  data: {},
+                  isVoid: false,
+                  type: BLOCKS.LIST_ITEM,
+                  children: [paragraph('text 1')],
+                },
+              ],
+            },
+          ],
+        },
+        {
+          data: {},
+          isVoid: false,
+          type: BLOCKS.LIST_ITEM,
+          children: [paragraph('text 2')],
+        },
+        {
+          data: {},
+          isVoid: false,
+          type: BLOCKS.LIST_ITEM,
+          children: [paragraph('text 3')],
+        },
+      ],
+    };
+    const editor = createEditor([ol]);
+    const entry: NodeEntry = [ol, [0]];
+
+    expect(slateNodeEntryToText(editor, entry)).toEqual([
+      paragraph('text 1'),
+      paragraph('text 2'),
+      paragraph('text 3'),
+    ]);
+  });
+
+  it('should preserve marks', () => {
+    const element: CustomElement = {
+      data: {},
+      isVoid: false,
+      type: BLOCKS.QUOTE,
+      children: [
+        paragraph('text 1', { bold: true, italic: true }),
+        paragraph('text 2', { underline: true, code: true }),
+      ],
+    };
+    const editor = createEditor([element]);
+    const entry: NodeEntry = [element, [0]];
+
+    expect(slateNodeEntryToText(editor, entry)).toEqual([
+      paragraph('text 1', { bold: true, italic: true }),
+      paragraph('text 2', { underline: true, code: true }),
+    ]);
+  });
+
+  it('should preserve hyperlinks', () => {
+    const paragraphWithLink = buildParagraph([
+      { text: 'text 1 ' },
+      {
+        type: INLINES.HYPERLINK,
+        children: [{ text: 'with link' }],
+        data: { uri: 'https://link.com' },
+      },
+    ]);
+
+    const element: CustomElement = {
+      data: {},
+      isVoid: false,
+      type: BLOCKS.QUOTE,
+      children: [paragraphWithLink, paragraph('text 2')],
+    };
+    const editor = createEditor([element]);
+    const entry: NodeEntry = [element, [0]];
+
+    expect(slateNodeEntryToText(editor, entry)).toEqual([paragraphWithLink, paragraph('text 2')]);
+  });
+
+  it('should preserve embedded inline entries', () => {
+    const paragraphWithEmbedded = buildParagraph([
+      { text: 'text 1 ' },
+      {
+        type: INLINES.EMBEDDED_ENTRY,
+        children: [{ text: '' }],
+        data: { target: { sys: { id: 'inline-id', linkType: 'Entry', type: 'Link' } } },
+      },
+    ]);
+
+    const element: CustomElement = {
+      data: {},
+      isVoid: false,
+      type: BLOCKS.QUOTE,
+      children: [paragraphWithEmbedded, paragraph('text 2')],
+    };
+    const editor = createEditor([element]);
+    const entry: NodeEntry = [element, [0]];
+
+    expect(slateNodeEntryToText(editor, entry)).toEqual([
+      paragraphWithEmbedded,
+      paragraph('text 2'),
+    ]);
+  });
+});

--- a/packages/rich-text/src/helpers/editor.spec.ts
+++ b/packages/rich-text/src/helpers/editor.spec.ts
@@ -1,6 +1,6 @@
 import { createEditor as createSlateEditor } from '@udecode/plate-test-utils';
 import { PlateEditor } from '@udecode/plate';
-import { NodeEntry } from 'slate';
+import { Path } from 'slate';
 import { BLOCKS, INLINES } from '@contentful/rich-text-types';
 import { slateNodeEntryToText } from './editor';
 import { CustomElement } from '../types';
@@ -29,6 +29,50 @@ const buildParagraph = (children: TextOrInline[] = []) => ({
   children: children.map((child) => ({ data: {}, ...child })),
 });
 const paragraph = (text = '', marks = {}) => buildParagraph([{ text, ...marks }]);
+
+type List = BLOCKS.OL_LIST | BLOCKS.UL_LIST;
+const buildList = (
+  type: List = BLOCKS.UL_LIST,
+  secondType: List = BLOCKS.UL_LIST
+): CustomElement => ({
+  data: {},
+  isVoid: false,
+  type,
+  children: [
+    {
+      data: {},
+      isVoid: false,
+      type: BLOCKS.LIST_ITEM,
+      children: [
+        {
+          type: secondType,
+          isVoid: false,
+          data: {},
+          children: [
+            {
+              data: {},
+              isVoid: false,
+              type: BLOCKS.LIST_ITEM,
+              children: [paragraph('text 1')],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      data: {},
+      isVoid: false,
+      type: BLOCKS.LIST_ITEM,
+      children: [paragraph('text 2')],
+    },
+    {
+      data: {},
+      isVoid: false,
+      type: BLOCKS.LIST_ITEM,
+      children: [paragraph('text 3')],
+    },
+  ],
+});
 
 describe('slateNodeEntryToText', () => {
   it('table', () => {
@@ -78,9 +122,9 @@ describe('slateNodeEntryToText', () => {
       ],
     };
     const editor = createEditor([table]);
-    const entry: NodeEntry = [table, [0]];
+    const path: Path = [0];
 
-    expect(slateNodeEntryToText(editor, entry)).toEqual([
+    expect(slateNodeEntryToText(editor, path)).toEqual([
       paragraph('header 1'),
       paragraph('header 2'),
       paragraph('cell 1'),
@@ -96,55 +140,17 @@ describe('slateNodeEntryToText', () => {
       children: [paragraph('text 1'), paragraph('text 2')],
     };
     const editor = createEditor([blockquote]);
-    const entry: NodeEntry = [blockquote, [0]];
+    const path: Path = [0];
 
-    expect(slateNodeEntryToText(editor, entry)).toEqual([paragraph('text 1'), paragraph('text 2')]);
+    expect(slateNodeEntryToText(editor, path)).toEqual([paragraph('text 1'), paragraph('text 2')]);
   });
 
   it('list - UL', () => {
-    const ul: CustomElement = {
-      data: {},
-      isVoid: false,
-      type: BLOCKS.UL_LIST,
-      children: [
-        {
-          data: {},
-          isVoid: false,
-          type: BLOCKS.LIST_ITEM,
-          children: [
-            {
-              type: BLOCKS.UL_LIST,
-              isVoid: false,
-              data: {},
-              children: [
-                {
-                  data: {},
-                  isVoid: false,
-                  type: BLOCKS.LIST_ITEM,
-                  children: [paragraph('text 1')],
-                },
-              ],
-            },
-          ],
-        },
-        {
-          data: {},
-          isVoid: false,
-          type: BLOCKS.LIST_ITEM,
-          children: [paragraph('text 2')],
-        },
-        {
-          data: {},
-          isVoid: false,
-          type: BLOCKS.LIST_ITEM,
-          children: [paragraph('text 3')],
-        },
-      ],
-    };
+    const ul: CustomElement = buildList(BLOCKS.UL_LIST, BLOCKS.OL_LIST);
     const editor = createEditor([ul]);
-    const entry: NodeEntry = [ul, [0]];
+    const path: Path = [0];
 
-    expect(slateNodeEntryToText(editor, entry)).toEqual([
+    expect(slateNodeEntryToText(editor, path)).toEqual([
       paragraph('text 1'),
       paragraph('text 2'),
       paragraph('text 3'),
@@ -152,49 +158,11 @@ describe('slateNodeEntryToText', () => {
   });
 
   it('list - OL', () => {
-    const ol: CustomElement = {
-      data: {},
-      isVoid: false,
-      type: BLOCKS.OL_LIST,
-      children: [
-        {
-          data: {},
-          isVoid: false,
-          type: BLOCKS.LIST_ITEM,
-          children: [
-            {
-              type: BLOCKS.OL_LIST,
-              isVoid: false,
-              data: {},
-              children: [
-                {
-                  data: {},
-                  isVoid: false,
-                  type: BLOCKS.LIST_ITEM,
-                  children: [paragraph('text 1')],
-                },
-              ],
-            },
-          ],
-        },
-        {
-          data: {},
-          isVoid: false,
-          type: BLOCKS.LIST_ITEM,
-          children: [paragraph('text 2')],
-        },
-        {
-          data: {},
-          isVoid: false,
-          type: BLOCKS.LIST_ITEM,
-          children: [paragraph('text 3')],
-        },
-      ],
-    };
+    const ol: CustomElement = buildList(BLOCKS.OL_LIST, BLOCKS.UL_LIST);
     const editor = createEditor([ol]);
-    const entry: NodeEntry = [ol, [0]];
+    const path: Path = [0];
 
-    expect(slateNodeEntryToText(editor, entry)).toEqual([
+    expect(slateNodeEntryToText(editor, path)).toEqual([
       paragraph('text 1'),
       paragraph('text 2'),
       paragraph('text 3'),
@@ -212,9 +180,9 @@ describe('slateNodeEntryToText', () => {
       ],
     };
     const editor = createEditor([element]);
-    const entry: NodeEntry = [element, [0]];
+    const path: Path = [0];
 
-    expect(slateNodeEntryToText(editor, entry)).toEqual([
+    expect(slateNodeEntryToText(editor, path)).toEqual([
       paragraph('text 1', { bold: true, italic: true }),
       paragraph('text 2', { underline: true, code: true }),
     ]);
@@ -237,9 +205,9 @@ describe('slateNodeEntryToText', () => {
       children: [paragraphWithLink, paragraph('text 2')],
     };
     const editor = createEditor([element]);
-    const entry: NodeEntry = [element, [0]];
+    const path: Path = [0];
 
-    expect(slateNodeEntryToText(editor, entry)).toEqual([paragraphWithLink, paragraph('text 2')]);
+    expect(slateNodeEntryToText(editor, path)).toEqual([paragraphWithLink, paragraph('text 2')]);
   });
 
   it('should preserve embedded inline entries', () => {
@@ -259,9 +227,9 @@ describe('slateNodeEntryToText', () => {
       children: [paragraphWithEmbedded, paragraph('text 2')],
     };
     const editor = createEditor([element]);
-    const entry: NodeEntry = [element, [0]];
+    const path: Path = [0];
 
-    expect(slateNodeEntryToText(editor, entry)).toEqual([
+    expect(slateNodeEntryToText(editor, path)).toEqual([
       paragraphWithEmbedded,
       paragraph('text 2'),
     ]);

--- a/packages/rich-text/src/helpers/editor.ts
+++ b/packages/rich-text/src/helpers/editor.ts
@@ -1,13 +1,4 @@
-import {
-  Text,
-  Editor,
-  Element,
-  Transforms,
-  Path,
-  Range,
-  Node,
-  NodeEntry as SlateNodeEntry,
-} from 'slate';
+import { Text, Editor, Element, Transforms, Path, Range, Node } from 'slate';
 import { BLOCKS, INLINES, TABLE_BLOCKS, TEXT_CONTAINERS } from '@contentful/rich-text-types';
 import { CustomElement } from '../types';
 import { Link } from '@contentful/field-editor-reference/dist/types';
@@ -296,14 +287,9 @@ export function currentSelectionPrecedesTableCell(editor: PlateEditor): boolean 
 }
 
 /**
- * It filters out all paragraphs and headings from a node entry (node + path) based on its path and convert them into paragraphs.
+ * It filters out all paragraphs and headings from a path and convert them into paragraphs.
  */
-export function slateNodeEntryToText(
-  editor: PlateEditor,
-  nodeEntry: SlateNodeEntry
-): CustomElement[] {
-  const [, path] = nodeEntry;
-
+export function slateNodeEntryToText(editor: PlateEditor, path: Path): CustomElement[] {
   const paragraphs: CustomElement[] = Array.from(
     Editor.nodes<CustomElement>(editor, {
       at: path,

--- a/packages/rich-text/src/helpers/editor.ts
+++ b/packages/rich-text/src/helpers/editor.ts
@@ -1,5 +1,14 @@
-import { Text, Editor, Element, Transforms, Path, Range, Node } from 'slate';
-import { BLOCKS, INLINES, TABLE_BLOCKS } from '@contentful/rich-text-types';
+import {
+  Text,
+  Editor,
+  Element,
+  Transforms,
+  Path,
+  Range,
+  Node,
+  NodeEntry as SlateNodeEntry,
+} from 'slate';
+import { BLOCKS, INLINES, TABLE_BLOCKS, TEXT_CONTAINERS } from '@contentful/rich-text-types';
 import { CustomElement } from '../types';
 import { Link } from '@contentful/field-editor-reference/dist/types';
 import { PlateEditor, getText } from '@udecode/plate';
@@ -284,4 +293,27 @@ export function currentSelectionPrecedesTableCell(editor: PlateEditor): boolean 
   return (
     !!nextNode && TABLE_BLOCKS.includes(nextNode.type as BLOCKS) && isAtEndOfTextSelection(editor)
   );
+}
+
+/**
+ * It filters out all paragraphs and headings from a node entry (node + path) based on its path and convert them into paragraphs.
+ */
+export function slateNodeEntryToText(
+  editor: PlateEditor,
+  nodeEntry: SlateNodeEntry
+): CustomElement[] {
+  const [, path] = nodeEntry;
+
+  const paragraphs: CustomElement[] = Array.from(
+    Editor.nodes<CustomElement>(editor, {
+      at: path,
+      match: (node) => TEXT_CONTAINERS.includes((node as CustomElement).type as BLOCKS),
+      mode: 'all',
+    })
+  ).map(([node]) => ({
+    ...node,
+    type: BLOCKS.PARAGRAPH,
+  }));
+
+  return paragraphs;
 }

--- a/packages/rich-text/src/plugins/Text/index.ts
+++ b/packages/rich-text/src/plugins/Text/index.ts
@@ -1,6 +1,6 @@
 import { Editor, Ancestor, Transforms } from 'slate';
 import { PlatePlugin, isAncestorEmpty } from '@udecode/plate';
-import { BLOCKS } from '@contentful/rich-text-types';
+import { TEXT_CONTAINERS, BLOCKS } from '@contentful/rich-text-types';
 import { CustomElement } from '../../types';
 
 export function createTextPlugin(): PlatePlugin {
@@ -8,21 +8,11 @@ export function createTextPlugin(): PlatePlugin {
     withOverrides: (editor) => {
       const { deleteForward } = editor;
 
-      const textTypes: string[] = [
-        BLOCKS.PARAGRAPH,
-        BLOCKS.HEADING_1,
-        BLOCKS.HEADING_2,
-        BLOCKS.HEADING_3,
-        BLOCKS.HEADING_4,
-        BLOCKS.HEADING_5,
-        BLOCKS.HEADING_6,
-      ];
-
       // When pressing delete instead of backspace
       editor.deleteForward = (unit) => {
         const [nodes] = Editor.nodes(editor, {
           at: editor.selection?.focus.path,
-          match: (node) => textTypes.includes((node as CustomElement).type),
+          match: (node) => TEXT_CONTAINERS.includes((node as CustomElement).type as BLOCKS),
         });
 
         if (nodes) {


### PR DESCRIPTION
We don't need to pass the node or a list of nodes as intended previously if we use the helpers provided by Slate/Plate. We only need the editor + path, in this case, I'm receiving the entry (node + path) but I'm not using the `node` at all. 

Question:

- For the developer experience, should we pass only `editor + entry` or `editor + path` as parameters to the helper?

That's how it's supposed to be used:

```ts
function CustomPlugin(): PlatePlugin {
  return {
    withOverrides: (editor) => {
      const { normalizeNode } = editor;

      editor.normalizeNode = (entry) => {
        const [node, path] = entry; // we use only path from entry

        if (isInvalidCase()) {
          const paragraphs = slateNodeEntryToText(editor, path);
          
          Transforms.insertNodes(editor, paragraphs);
        }

        normalizeNode(entry);
      };

      return editor;
    },
  };
}
```