### PR TITLE
fix: markdown upload asset domain url to ctfassets.net []

### DIFF
--- a/cypress/integration/MarkdownEditorInsertAssets.spec.ts
+++ b/cypress/integration/MarkdownEditorInsertAssets.spec.ts
@@ -1,0 +1,44 @@
+describe('Markdown Editor / Insert Assets', () => {
+  const selectors = {
+    getInput: () => {
+      return cy.get('[data-test-id="markdown-textarea"] textarea');
+    },
+    getInsertMediaDropdown: () => {
+      return cy.findByTestId('markdownEditor.insertMediaDropdownTrigger');
+    },
+    getInsertNewAssetButton: () => {
+      return cy.findByTestId('markdownEditor.uploadAssetsAndLink');
+    },
+    getInsertExistingAssetButton: () => {
+      return cy.findByTestId('markdownEditor.linkExistingAssets');
+    },
+  };
+
+  const checkValue = (value) => {
+    cy.getMarkdownInstance().then((markdown) => {
+      expect(markdown.getContent()).eq(value);
+    });
+  };
+
+  beforeEach(() => {
+    cy.visit('/markdown');
+    cy.wait(500);
+    cy.findByTestId('markdown-editor').should('be.visible');
+  });
+
+  it('should insert a new asset', () => {
+    selectors.getInsertMediaDropdown().click();
+    selectors.getInsertNewAssetButton().click();
+    checkValue(
+      '![dog](//images.ctfassets.net/b04hhmxrptgr/6oYURL50Ddai6jRCboSB7u/b1a3768d6d987f3f6110a41175f4d7d3/dog.jpg)'
+    );
+  });
+
+  it('should insert an existing asset', () => {
+    selectors.getInsertMediaDropdown().click();
+    selectors.getInsertExistingAssetButton().click();
+    checkValue(
+      '![test](//images.ctfassets.net/5uld3crqmsuo/12XMPLSTs2vmmjw6xTlCDg/a7099dad14319e0f2908e99c9a2d6c62/Terrier_mixed-breed_dog.jpg)'
+    );
+  });
+});

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -25,6 +25,7 @@
     "@contentful/f36-icons": "^4.0.1-beta.2527",
     "@contentful/f36-tokens": "^4.0.1-beta.2527",
     "@contentful/field-editor-shared": "^1.0.1",
+    "@contentful/hostname-transformer": "^1.4.10",
     "@types/codemirror": "0.0.108",
     "@types/markdown-to-jsx": "6.11.3",
     "codemirror": "^5.48.0",

--- a/packages/markdown/src/MarkdownEditor.mdx
+++ b/packages/markdown/src/MarkdownEditor.mdx
@@ -14,6 +14,8 @@ import { Notification } from '@contentful/f36-components';
 import { MarkdownEditorConnected as MarkdownEditor } from './MarkdownEditor';
 import { openMarkdownDialog } from './dialogs/openMarkdownDialog'
 import { createFakeFieldAPI, ActionsPlayground } from '@contentful/field-editor-test-utils';
+import newAsset from '../../reference/src/__fixtures__/new_asset.json';
+import publishedAsset from '../../reference/src/__fixtures__/published_asset.json';
 
 ## In Action
 
@@ -40,7 +42,9 @@ import { createFakeFieldAPI, ActionsPlayground } from '@contentful/field-editor-
       dialogs: {
         openCurrent: openMarkdownDialog(sdk),
         selectMultipleAssets: () => {
-          alert('select multiple assets dialog')
+          alert('select multiple assets dialog');
+
+          return [publishedAsset];
         }
       },
       notifier: {
@@ -48,8 +52,12 @@ import { createFakeFieldAPI, ActionsPlayground } from '@contentful/field-editor-
         error: (text) => Notification.error(text)
       },
       navigator: {
-        openNewAsset: () => {
+        openNewAsset: async () => {
           alert('open new asset');
+
+          return {
+            entity: newAsset
+          }
         }
       },
       window: {

--- a/packages/markdown/src/utils/insertAssetLinks.ts
+++ b/packages/markdown/src/utils/insertAssetLinks.ts
@@ -1,5 +1,6 @@
 import get from 'lodash/get';
 import isObject from 'lodash/isObject';
+import { toExternal } from '@contentful/hostname-transformer';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type Asset = any;
@@ -56,10 +57,18 @@ function makeAssetLink(
       get(asset, ['fields', 'title', defaultLocaleCode]) ||
       fileNameToTitle(file.fileName);
 
+    const assetDomainMap = {
+      images: 'images.ctfassets.net',
+      assets: 'assets.ctfassets.net',
+      downloads: 'downloads.ctfassets.net',
+      videos: 'videos.ctfassets.net',
+    };
+    const fileUrl = toExternal(file.url, assetDomainMap);
+
     return {
       title,
       asset,
-      url: file.url,
+      url: fileUrl,
       // is normally localized and we should not warn about this file
       isLocalized: Boolean(localizedFile),
       // was fallback value used
@@ -67,7 +76,7 @@ function makeAssetLink(
       // it means we used a default locale - we filter empty values
       isFallback: Boolean(fallbackFile),
       // todo: tranform using fromHostname
-      asMarkdown: `![${title}](${file.url})`,
+      asMarkdown: `![${title}](${fileUrl})`,
     };
   } else {
     return null;

--- a/packages/reference/src/__fixtures__/new_asset.json
+++ b/packages/reference/src/__fixtures__/new_asset.json
@@ -1,0 +1,63 @@
+{
+  "sys": {
+    "space": {
+      "sys": {
+        "type": "Link",
+        "linkType": "Space",
+        "id": "my-test-space"
+      }
+    },
+    "id": "new_asset",
+    "type": "Asset",
+    "createdAt": "2021-12-01T13:16:32.452Z",
+    "updatedAt": "2021-12-01T13:16:48.836Z",
+    "environment": {
+      "sys": {
+        "id": "master",
+        "type": "Link",
+        "linkType": "Environment"
+      }
+    },
+    "createdBy": {
+      "sys": {
+        "type": "Link",
+        "linkType": "User",
+        "id": "1n6JeO5hWTbMwlazefu4ux"
+      }
+    },
+    "updatedBy": {
+      "sys": {
+        "type": "Link",
+        "linkType": "User",
+        "id": "1n6JeO5hWTbMwlazefu4ux"
+      }
+    },
+    "publishedCounter": 0,
+    "version": 3
+  },
+  "fields": {
+    "title": {
+      "en-US": "dog"
+    },
+    "description": {
+      "en-US": ""
+    },
+    "file": {
+      "en-US": {
+        "url": "//images.contentful.com/b04hhmxrptgr/6oYURL50Ddai6jRCboSB7u/b1a3768d6d987f3f6110a41175f4d7d3/dog.jpg",
+        "details": {
+          "size": 149870,
+          "image": {
+            "width": 800,
+            "height": 800
+          }
+        },
+        "fileName": "dog.jpg",
+        "contentType": "image/jpeg"
+      }
+    }
+  },
+  "metadata": {
+    "tags": []
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2222,6 +2222,14 @@
   resolved "https://registry.yarnpkg.com/@contentful/forma-36-tokens/-/forma-36-tokens-0.11.1.tgz#0baafc1edaa3766fc471bf0073f1bcb9acb64e6b"
   integrity sha512-VETMW/VV6Hzy1Jd3Q0evy3U5qmxDAqm/p0+B9Byo+N+PuNOgIuvB8U3+915TWT4BCJqxig0K/safJCEvwaZvAA==
 
+"@contentful/hostname-transformer@^1.4.10":
+  version "1.4.10"
+  resolved "https://registry.yarnpkg.com/@contentful/hostname-transformer/-/hostname-transformer-1.4.10.tgz#66f2ecd2e69263fda3b41d17474ea4d6db6e2b78"
+  integrity sha512-KDUCqIjtF4+P9c18y0VXFokotn+DmbYfDrtvqqL6jxy7vTlieqDb41cXmDjL9/DSfQ8gdMqz/MYmBrDYZDofTw==
+  dependencies:
+    fast-copy "^2.0.4"
+    lodash "^4.17.15"
+
 "@contentful/mimetype@^1.4.0":
   version "1.4.40"
   resolved "https://registry.yarnpkg.com/@contentful/mimetype/-/mimetype-1.4.40.tgz#9e11a37a9a3b35c8831af4f2b34af82f671fd0f6"
@@ -10709,6 +10717,11 @@ falafel@^2.1.0:
     foreach "^2.0.5"
     isarray "0.0.1"
     object-keys "^1.0.6"
+
+fast-copy@^2.0.4:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/fast-copy/-/fast-copy-2.1.1.tgz#f5cbcf2df64215e59b8e43f0b2caabc19848083a"
+  integrity sha512-Qod3DdRgFZ8GUIM6ygeoZYpQ0QLW9cf/FS9KhhjlYggcSZXWAemAw8BOCO5LuYCrR3Uj3qXDVTUzOUwG8C7beQ==
 
 fast-copy@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
We want to guarantee that new asset uploads will use `ctfassets.net` as a domain instead of `contentful.com` 