### PR TITLE
fix: cache content types for Hyperlink

### DIFF
--- a/packages/rich-text/src/plugins/Hyperlink/useRequestStatus.js
+++ b/packages/rich-text/src/plugins/Hyperlink/useRequestStatus.js
@@ -8,7 +8,7 @@ async function fetchAllData({ sdk, entityId, entityType, localeCode, defaultLoca
   const entity = await getEntity(entityId);
   if (entity.sys.contentType) {
     const contentTypeId = entity.sys.contentType.sys.id;
-    contentType = await sdk.space.getContentType(contentTypeId);
+    contentType = sdk.space.getCachedContentTypes().find((ct) => ct.sys.id === contentTypeId);
   }
 
   const entityTitle =


### PR DESCRIPTION
Hyperlink plugin in the Rich Text Editor requests a content type for each instance of a linked entity. This results in hundreds of requests when loading an editor with many links. We can make it better by at least caching the returned content types and getting them from cache.