### PR TITLE
fix: allow LIST_ITEM_BLOCKS inside list items

### DIFF
--- a/cypress/integration/rich-text/RichTextEditor.spec.ts
+++ b/cypress/integration/rich-text/RichTextEditor.spec.ts
@@ -663,6 +663,86 @@ describe('Rich Text Editor', { viewportHeight: 2000 }, () => {
 
           richText.expectValue(expectedValue);
         });
+
+        it('should allow heading as direct child of <li>', () => {
+          richText.editor.click();
+          test.getList().click();
+
+          richText.toolbar.toggleHeading(BLOCKS.HEADING_1);
+          richText.editor.type('heading');
+
+          const expectedValue = doc(
+            block(
+              test.listType,
+              {},
+              block(BLOCKS.LIST_ITEM, {}, block(BLOCKS.HEADING_1, {}, text('heading')))
+            ),
+            emptyParagraph()
+          );
+
+          richText.expectValue(expectedValue);
+        });
+
+        it('should allow HR as direct child of <li>', () => {
+          richText.editor.click();
+          test.getList().click();
+
+          richText.toolbar.hr.click();
+
+          const expectedValue = doc(
+            block(test.listType, {}, block(BLOCKS.LIST_ITEM, {}, block(BLOCKS.HR, {}))),
+            emptyParagraph()
+          );
+
+          richText.expectValue(expectedValue);
+        });
+
+        it('should allow embedded entry as direct child of <li>', () => {
+          richText.editor.click();
+          test.getList().click();
+
+          richText.toolbar.embed('entry-block');
+
+          const expectedValue = doc(
+            block(test.listType, {}, block(BLOCKS.LIST_ITEM, {}, entryBlock())),
+            emptyParagraph()
+          );
+
+          richText.expectValue(expectedValue);
+        });
+
+        it('should allow embedded asset as direct child of <li>', () => {
+          richText.editor.click();
+          test.getList().click();
+
+          richText.toolbar.embed('asset-block');
+
+          const expectedValue = doc(
+            block(test.listType, {}, block(BLOCKS.LIST_ITEM, {}, assetBlock())),
+            emptyParagraph()
+          );
+
+          richText.expectValue(expectedValue);
+        });
+
+        it('should allow block quotes as direct child of <li>', () => {
+          richText.editor.click();
+          test.getList().click();
+
+          richText.toolbar.quote.click();
+          richText.editor.type('quote');
+
+          const expectedValue = doc(
+            block(
+              test.listType,
+              {},
+              block(BLOCKS.LIST_ITEM, {}, block(BLOCKS.QUOTE, {}, paragraphWithText('quote')))
+            ),
+            emptyParagraph()
+          );
+
+          richText.expectValue(expectedValue);
+        });
       });
     });
   });

--- a/packages/rich-text/src/plugins/List/createListPlugin.ts
+++ b/packages/rich-text/src/plugins/List/createListPlugin.ts
@@ -21,9 +21,6 @@ import { withList } from './withList';
 
 export const createListPlugin = (): RichTextPlugin =>
   createPlateListPlugin({
-    options: {
-      validLiChildrenTypes: LIST_ITEM_BLOCKS,
-    },
     normalizer: [
       {
         match: {
@@ -67,5 +64,5 @@ export const createListPlugin = (): RichTextPlugin =>
           },
         ],
       },
-    } as Record<string, Partial<RichTextPlugin>>,
+    },
   } as Partial<RichTextPlugin>);

--- a/packages/rich-text/src/plugins/List/withList.ts
+++ b/packages/rich-text/src/plugins/List/withList.ts
@@ -1,12 +1,17 @@
+import { LIST_ITEM_BLOCKS } from '@contentful/rich-text-types';
 import { WithOverride } from '@udecode/plate-core';
 import { withList as withDefaultList, ListPlugin } from '@udecode/plate-list';
 
 import { getListInsertFragment } from './getListInsertFragment';
 
+const options: ListPlugin = {
+  validLiChildrenTypes: LIST_ITEM_BLOCKS,
+};
+
 export const withList: WithOverride<{}, ListPlugin> = (editor, plugin) => {
   const { insertFragment } = editor;
 
-  withDefaultList(editor, plugin);
+  withDefaultList(editor, { ...plugin, options });
 
   // Reverts any overrides to insertFragment
   editor.insertFragment = insertFragment;


### PR DESCRIPTION
A regression caused by the Plate upgrade. We were incorrectly passing the `validLiChildrenTypes` option which caused Plate's list plugin to remove valid items e.g. blockquotes.