### PR TITLE
fix: pressing enter on multi-item list

### DIFF
--- a/packages/rich-text/src/helpers/editor.ts
+++ b/packages/rich-text/src/helpers/editor.ts
@@ -38,13 +38,15 @@ type NodeEntry = [CustomElement, Path];
 type NodeType = BLOCKS | INLINES;
 export function getNodeEntryFromSelection(
   editor,
-  nodeTypeOrTypes: NodeType | NodeType[]
+  nodeTypeOrTypes: NodeType | NodeType[],
+  { reverse }: { reverse?: boolean } = {}
 ): NodeEntry | [] {
   if (!editor.selection) return [];
   const nodeTypes = Array.isArray(nodeTypeOrTypes) ? nodeTypeOrTypes : [nodeTypeOrTypes];
   const { path } = editor.selection.focus;
   for (let i = 0; i < path.length; i++) {
-    const nodeEntry = Editor.node(editor, path.slice(0, i + 1)) as NodeEntry;
+    const sliceIndex = reverse ? path.length + 1 - i : i + 1;
+    const nodeEntry = Editor.node(editor, path.slice(0, sliceIndex)) as NodeEntry;
     if (nodeTypes.includes(nodeEntry[0].type as NodeType)) return nodeEntry;
   }
   return [];

--- a/packages/rich-text/src/plugins/List/createListPlugin.ts
+++ b/packages/rich-text/src/plugins/List/createListPlugin.ts
@@ -1,5 +1,4 @@
 import { BLOCKS, LIST_ITEM_BLOCKS } from '@contentful/rich-text-types';
-import { HotkeyPlugin, KeyboardHandler } from '@udecode/plate-core';
 import {
   createListPlugin as createPlateListPlugin,
   ELEMENT_LI,
@@ -7,13 +6,12 @@ import {
   ELEMENT_OL,
   ELEMENT_LIC,
 } from '@udecode/plate-list';
-import { Node, Path, Transforms } from 'slate';
 
-import { getNodeEntryFromSelection } from '../../helpers/editor';
 import { transformParagraphs, transformWrapIn } from '../../helpers/transformers';
 import { RichTextPlugin } from '../../types';
 import { ListOL, ListUL } from './components/List';
 import { ListItem } from './components/ListItem';
+// import { handleKeyDown } from './handleKeyDown';
 import {
   isNonEmptyListItem,
   hasListAsDirectParent,
@@ -21,43 +19,6 @@ import {
   normalizeOrphanedListItem,
 } from './utils';
 import { withList } from './withList';
-
-const onKeyDown: KeyboardHandler<{}, HotkeyPlugin> =
-  (editor) =>
-  (event: React.KeyboardEvent): void => {
-    if (!editor.selection) return;
-    const [, pathToListItem] = getNodeEntryFromSelection(editor, BLOCKS.LIST_ITEM, {
-      reverse: true,
-    });
-
-    if (pathToListItem) {
-      const isEvent = event.key === 'Enter';
-
-      if (isEvent) {
-        const children = Array.from(Node.children(editor, pathToListItem));
-        const pivot = editor.selection.focus.path[pathToListItem.length];
-        const siblingsBelowCurrentListItem = children.slice(pivot + 1);
-        const lastListItemIndex = pathToListItem.length - 1;
-        const nodePathsToRemove: Path[] = [];
-        for (let i = 0; i < siblingsBelowCurrentListItem.length; i++) {
-          const [node, path] = siblingsBelowCurrentListItem[i];
-          nodePathsToRemove.unshift(path);
-          const nextListItemIndex = pathToListItem[lastListItemIndex] + i + 1;
-          const nextListItemPath = pathToListItem
-            .slice(0, lastListItemIndex)
-            .concat(nextListItemIndex);
-          Transforms.insertNodes(
-            editor,
-            { type: BLOCKS.LIST_ITEM, data: {}, children: [node] },
-            { at: nextListItemPath }
-          );
-        }
-        for (const path of nodePathsToRemove) {
-          Transforms.removeNodes(editor, { at: path });
-        }
-      }
-    }
-  };
 
 export const createListPlugin = (): RichTextPlugin =>
   createPlateListPlugin({
@@ -70,7 +31,7 @@ export const createListPlugin = (): RichTextPlugin =>
         transform: transformWrapIn(BLOCKS.LIST_ITEM),
       },
     ],
-    handlers: { onKeyDown },
+    // handlers: { onKeyDown: handleKeyDown },
     overrideByKey: {
       [ELEMENT_UL]: {
         type: BLOCKS.UL_LIST,

--- a/packages/rich-text/src/plugins/List/getListInsertBreak.ts
+++ b/packages/rich-text/src/plugins/List/getListInsertBreak.ts
@@ -1,0 +1,183 @@
+import {
+  ELEMENT_DEFAULT,
+  getAbove,
+  getParent,
+  getPluginType,
+  insertNodes,
+  isBlockAboveEmpty,
+  isBlockTextEmptyAfterSelection,
+  mockPlugin,
+  PlateEditor,
+  TElement,
+  wrapNodes,
+} from '@udecode/plate-core';
+import {
+  ELEMENT_LI,
+  ELEMENT_LIC,
+  getListItemEntry,
+  moveListItemUp,
+  unwrapList,
+} from '@udecode/plate-list';
+import { onKeyDownResetNode, ResetNodePlugin, SIMULATE_BACKSPACE } from '@udecode/plate-reset-node';
+import { Editor, Path, Range, Transforms } from 'slate';
+
+/**
+ * Insert list item if selection in li>p.
+ */
+export const insertListItem = (editor: PlateEditor): boolean => {
+  const liType = getPluginType(editor, ELEMENT_LI);
+  const licType = getPluginType(editor, ELEMENT_LIC);
+
+  if (!editor.selection) {
+    return false;
+  }
+
+  const licEntry = getAbove(editor, { match: { type: licType } });
+  if (!licEntry) return false;
+  const [, paragraphPath] = licEntry;
+
+  const listItemEntry = getParent(editor, paragraphPath);
+  if (!listItemEntry) return false;
+  const [listItemNode, listItemPath] = listItemEntry;
+
+  if (listItemNode.type !== liType) return false;
+
+  let success = false;
+
+  Editor.withoutNormalizing(editor, () => {
+    if (!Range.isCollapsed(editor.selection!)) {
+      Transforms.delete(editor);
+    }
+
+    const isStart = Editor.isStart(editor, editor.selection!.focus, paragraphPath);
+    const isEnd = isBlockTextEmptyAfterSelection(editor);
+
+    const nextParagraphPath = Path.next(paragraphPath);
+    const nextListItemPath = Path.next(listItemPath);
+
+    /**
+     * If start, insert a list item before
+     */
+    if (isStart) {
+      console.log('isStart');
+      insertNodes<TElement>(
+        editor,
+        {
+          type: liType,
+          children: [{ type: licType, children: [{ text: '' }], data: {} }],
+          data: {},
+        },
+        { at: listItemPath }
+      );
+
+      success = true;
+
+      return;
+    }
+
+    /**
+     * If not end, split nodes, wrap a list item on the new paragraph and move it to the next list item
+     */
+    if (!isEnd) {
+      console.log('isEnd');
+      Editor.withoutNormalizing(editor, () => {
+        Transforms.splitNodes(editor);
+        wrapNodes(
+          editor,
+          {
+            type: liType,
+            children: [],
+            data: {},
+          },
+          { at: nextParagraphPath }
+        );
+        Transforms.moveNodes(editor, {
+          at: nextParagraphPath,
+          to: nextListItemPath,
+        });
+        Transforms.select(editor, nextListItemPath);
+        Transforms.collapse(editor, {
+          edge: 'start',
+        });
+      });
+    } else {
+      console.log('neither isStart nor !isEnd');
+      /**
+       * If end, insert a list item after and select it
+       */
+      const marks = Editor.marks(editor) || {};
+      insertNodes<TElement>(
+        editor,
+        {
+          type: liType,
+          children: [{ type: licType, children: [{ text: '', ...marks }], data: {} }],
+          data: {},
+        },
+        { at: nextListItemPath }
+      );
+      Transforms.select(editor, nextListItemPath);
+    }
+
+    /**
+     * If there is a list in the list item, move it to the next list item
+     */
+    if (listItemNode.children.length > 1) {
+      console.log('if (listItemNode.children.length > 1) {');
+      Transforms.moveNodes(editor, {
+        at: nextParagraphPath,
+        to: nextListItemPath.concat(1),
+      });
+    }
+
+    success = true;
+  });
+
+  return success;
+};
+
+export const getListInsertBreak = (editor: PlateEditor) => {
+  if (!editor.selection) return;
+
+  const res = getListItemEntry(editor, {});
+  let moved: boolean | undefined;
+
+  // If selection is in a li
+  if (res) {
+    const { list, listItem } = res;
+
+    // If selected li is empty, move it up.
+    if (isBlockAboveEmpty(editor)) {
+      moved = moveListItemUp(editor, {
+        list,
+        listItem,
+      });
+
+      if (moved) return true;
+    }
+  }
+
+  const didReset = onKeyDownResetNode(
+    editor,
+    mockPlugin<ResetNodePlugin>({
+      options: {
+        rules: [
+          {
+            types: [getPluginType(editor, ELEMENT_LI)],
+            defaultType: getPluginType(editor, ELEMENT_DEFAULT),
+            predicate: () => !moved && isBlockAboveEmpty(editor),
+            onReset: (_editor) => unwrapList(_editor as PlateEditor),
+          },
+        ],
+      },
+    })
+  )(SIMULATE_BACKSPACE as any);
+  if (didReset) return true;
+
+  /**
+   * If selection is in li > p, insert li.
+   */
+  if (!moved) {
+    const inserted = insertListItem(editor);
+    if (inserted) return true;
+  }
+};

--- a/packages/rich-text/src/plugins/List/handleKeyDown.ts
+++ b/packages/rich-text/src/plugins/List/handleKeyDown.ts
@@ -1,0 +1,51 @@
+// import { BLOCKS } from '@contentful/rich-text-types';
+// import { HotkeyPlugin, KeyboardHandler } from '@udecode/plate-core';
+// import { getListItemEntry } from '@udecode/plate-list';
+// import { Node, Path, Transforms } from 'slate';
+
+// /**
+//  * Handles an 'entry' keydown event within a list item
+//  * by moving the sibling list node below that list item
+//  * to the next line below that list.
+//  *
+//  * e.g.
+//  * - foo
+//  *   bar
+//  *   qux
+//  *
+//  * Hitting enter between the o's of "foo" should result in
+//  * - fo
+//  * - o
+//  * - bar
+//  * - qux
+//  *
+//  * This works out of the box
+//  */
+// const handleEntryEvent = (editor, pathToList, pathToListItem) => {
+//   const children = Array.from(Node.children(editor, pathToListItem));
+//   const pivot = editor.selection.focus.path[pathToListItem.length];
+//   const siblingsBelowCurrentListItem = children.slice(pivot + 1);
+//   Transforms.insertNodes(
+//     editor,
+//     { type: BLOCKS.LIST_ITEM, data: {}, children: siblingsBelowCurrentListItem.map(([node]) => node) },
+//     { at: pathToListItem }
+//   );
+//   for (const [, path] of siblingsBelowCurrentListItem) {
+//     Transforms.removeNodes(editor, { at: path });
+//   }
+// };
+
+// export const handleKeyDown: KeyboardHandler<{}, HotkeyPlugin> =
+//   (editor) =>
+//   (event: React.KeyboardEvent): void => {
+//     if (!editor.selection || event.key !== 'Enter') return;
+//     const { list, listItem } = getListItemEntry(editor) || {};
+//     if (list && listItem) {
+//       const isEntryEvent = event.key === 'Enter';
+//       if (isEntryEvent) {
+//         const [, pathToList] = list;
+//         const [, pathToListItem] = listItem;
+//         handleEntryEvent(editor, pathToList, pathToListItem)
+//       }
+//     }
+//   };

--- a/packages/rich-text/src/plugins/List/withList.ts
+++ b/packages/rich-text/src/plugins/List/withList.ts
@@ -2,6 +2,7 @@ import { LIST_ITEM_BLOCKS } from '@contentful/rich-text-types';
 import { WithOverride } from '@udecode/plate-core';
 import { withList as withDefaultList, ListPlugin } from '@udecode/plate-list';
 
+import { getListInsertBreak } from './getListInsertBreak';
 import { getListInsertFragment } from './getListInsertFragment';
 
 const options: ListPlugin = {
@@ -9,7 +10,7 @@ const options: ListPlugin = {
 };
 
 export const withList: WithOverride<{}, ListPlugin> = (editor, plugin) => {
-  const { insertFragment } = editor;
+  const { insertBreak, insertFragment } = editor;
 
   withDefaultList(editor, { ...plugin, options });
 
@@ -18,6 +19,13 @@ export const withList: WithOverride<{}, ListPlugin> = (editor, plugin) => {
 
   // Use our custom getListInsertFragment
   editor.insertFragment = getListInsertFragment(editor);
+
+  editor.insertBreak = insertBreak;
+
+  editor.insertBreak = () => {
+    if (getListInsertBreak(editor)) return;
+    insertBreak();
+  };
 
   return editor;
 };


### PR DESCRIPTION
Fixes a bug in which pressing enter on a list item with multiple children behaves unintuitively.

Logic works fine, still needs tests and cleanup (naming, etc -- this required some fairly hairy imperative node traversal).