### PR TITLE
perf(rich-text): avoid using Editor.nodes

### DIFF
--- a/packages/rich-text/src/plugins/Hyperlink/index.tsx
+++ b/packages/rich-text/src/plugins/Hyperlink/index.tsx
@@ -70,7 +70,7 @@ function UrlHyperlink(props: HyperlinkElementProps) {
   const sdk: FieldExtensionSDK = useSdkContext();
   const { uri } = props.element.data;
 
-  async function handleClick(event: React.MouseEvent<HTMLAnchorElement>) {
+  function handleClick(event: React.MouseEvent<HTMLAnchorElement>) {
     event.preventDefault();
     event.stopPropagation();
     if (!editor) return;
@@ -104,7 +104,7 @@ function EntityHyperlink(props: HyperlinkElementProps) {
 
   if (!target) return null;
 
-  async function handleClick(event: React.MouseEvent<HTMLButtonElement>) {
+  function handleClick(event: React.MouseEvent<HTMLAnchorElement>) {
     event.preventDefault();
     event.stopPropagation();
     if (!editor) return;
@@ -126,7 +126,7 @@ function EntityHyperlink(props: HyperlinkElementProps) {
       placement="bottom"
       maxWidth="auto">
       <TextLink
-        as="button"
+        as="a"
         onClick={handleClick}
         isDisabled={isReadOnly}
         className={styles.hyperlink}

--- a/packages/rich-text/src/plugins/Table/helpers.ts
+++ b/packages/rich-text/src/plugins/Table/helpers.ts
@@ -1,5 +1,5 @@
 import { BLOCKS } from '@contentful/rich-text-types';
-import { getParent, PlateEditor } from '@udecode/plate-core';
+import { getNode, getParent, PlateEditor } from '@udecode/plate-core';
 import { getAbove, getChildren, isFirstChild, isAncestorEmpty } from '@udecode/plate-core';
 import {
   ELEMENT_TABLE,
@@ -9,7 +9,7 @@ import {
   insertTable,
 } from '@udecode/plate-table';
 import { Node, NodeEntry } from 'slate';
-import { Transforms, Path, Editor, Ancestor } from 'slate';
+import { Transforms, Path, Ancestor } from 'slate';
 
 import { isBlockSelected, getAncestorPathFromSelection } from '../../helpers/editor';
 import { CustomElement } from '../../types';
@@ -53,13 +53,12 @@ export function replaceEmptyParagraphWithTable(editor: PlateEditor) {
   const previousPath = Path.previous(tablePath);
   if (!previousPath) return;
 
-  const [nodes] = Editor.nodes(editor, {
-    at: previousPath,
-    match: (node) => (node as CustomElement).type === BLOCKS.PARAGRAPH,
-  });
-  if (!nodes) return;
+  const previousNode = getNode(editor, previousPath);
 
-  const [previousNode] = nodes;
+  if (!previousNode || (previousNode as CustomElement).type !== BLOCKS.PARAGRAPH) {
+    return;
+  }
+
   const isPreviousNodeTextEmpty = isAncestorEmpty(editor, previousNode as Ancestor);
   if (isPreviousNodeTextEmpty) {
     // Switch table with previous empty paragraph


### PR DESCRIPTION
Replaced any use of `Editor.nodes` with `getAbove` or `getNode` ..etc. Basically, `Editor.nodes` iterates over all nodes in the document. We don't need/want that.

