### PR TITLE
fix: enter new line in list item after entity block

### DIFF
--- a/cypress/integration/rich-text/RichTextEditor.spec.ts
+++ b/cypress/integration/rich-text/RichTextEditor.spec.ts
@@ -676,32 +676,51 @@ describe('Rich Text Editor', { viewportHeight: 2000 }, () => {
       richText.expectValue(expectedValue);
     });
 
-    it('should add a new line on a list', () => {
-      richText.editor.click();
+    describe('in a list', () => {
+      it('should add a new line', () => {
+        richText.editor.click();
 
-      richText.toolbar.ul.click();
+        richText.toolbar.ul.click();
 
-      richText.editor
-        .type('some text 1')
-        .type('{shift+enter}')
-        .type('some text 2')
-        .type('{shift+enter}')
-        .type('some text 3');
+        richText.editor
+          .type('some text 1')
+          .type('{shift+enter}')
+          .type('some text 2')
+          .type('{shift+enter}')
+          .type('some text 3');
 
-      const expectedValue = doc(
-        block(
-          BLOCKS.UL_LIST,
-          {},
+        const expectedValue = doc(
           block(
-            BLOCKS.LIST_ITEM,
+            BLOCKS.UL_LIST,
             {},
-            block(BLOCKS.PARAGRAPH, {}, text('some text 1\nsome text 2\nsome text 3', []))
-          )
-        ),
-        emptyParagraph()
-      );
+            block(
+              BLOCKS.LIST_ITEM,
+              {},
+              block(BLOCKS.PARAGRAPH, {}, text('some text 1\nsome text 2\nsome text 3', []))
+            )
+          ),
+          emptyParagraph()
+        );
 
-      richText.expectValue(expectedValue);
+        richText.expectValue(expectedValue);
+      });
+
+      it('should add a new line after entity block in same list item', () => {
+        richText.editor.click();
+
+        richText.toolbar.ul.click();
+
+        richText.editor
+          .type('some text 1')
+          .type('{enter}')
+          .type(`{${mod}+shift+e}`)
+          .type('{enter}')
+          .type('some more text')
+          .type(`{${mod}+shift+e}`)
+          .type('{enter}');
+
+        richText.expectSnapshotValue();
+      });
     });
   });
 

--- a/cypress/integration/rich-text/__snapshots__/RichTextEditor.spec.ts.snap
+++ b/cypress/integration/rich-text/__snapshots__/RichTextEditor.spec.ts.snap
@@ -395,3 +395,103 @@ exports[`Rich Text Editor > invalid document structure > normalizable errors > d
   "data": {},
   "nodeType": "document"
 };
+
+exports[`Rich Text Editor > New Line > in a list > should add a new line after entity block in same list item #0`] =
+{
+  "content": [
+    {
+      "content": [
+        {
+          "content": [
+            {
+              "content": [
+                {
+                  "data": {},
+                  "marks": [],
+                  "nodeType": "text",
+                  "value": "some text 1"
+                }
+              ],
+              "data": {},
+              "nodeType": "paragraph"
+            }
+          ],
+          "data": {},
+          "nodeType": "list-item"
+        },
+        {
+          "content": [
+            {
+              "content": [],
+              "data": {
+                "target": {
+                  "sys": {
+                    "id": "example-entity-id",
+                    "linkType": "Entry",
+                    "type": "Link"
+                  }
+                }
+              },
+              "nodeType": "embedded-entry-block"
+            },
+            {
+              "content": [
+                {
+                  "data": {},
+                  "marks": [],
+                  "nodeType": "text",
+                  "value": "some more text"
+                }
+              ],
+              "data": {},
+              "nodeType": "paragraph"
+            },
+            {
+              "content": [],
+              "data": {
+                "target": {
+                  "sys": {
+                    "id": "example-entity-id",
+                    "linkType": "Entry",
+                    "type": "Link"
+                  }
+                }
+              },
+              "nodeType": "embedded-entry-block"
+            },
+            {
+              "content": [
+                {
+                  "data": {},
+                  "marks": [],
+                  "nodeType": "text",
+                  "value": ""
+                }
+              ],
+              "data": {},
+              "nodeType": "paragraph"
+            }
+          ],
+          "data": {},
+          "nodeType": "list-item"
+        }
+      ],
+      "data": {},
+      "nodeType": "unordered-list"
+    },
+    {
+      "content": [
+        {
+          "data": {},
+          "marks": [],
+          "nodeType": "text",
+          "value": ""
+        }
+      ],
+      "data": {},
+      "nodeType": "paragraph"
+    }
+  ],
+  "data": {},
+  "nodeType": "document"
+};

--- a/packages/rich-text/src/RichTextEditor.styles.ts
+++ b/packages/rich-text/src/RichTextEditor.styles.ts
@@ -31,6 +31,7 @@ export const styles = {
     // We need to reset LIC style due to conflicts between PARAGRAPH styles
     'ul > li > div': {
       margin: 0,
+      marginBottom: '1.25rem !important',
     },
   }),
   hiddenToolbar: css({

--- a/packages/rich-text/src/RichTextEditor.styles.ts
+++ b/packages/rich-text/src/RichTextEditor.styles.ts
@@ -31,7 +31,6 @@ export const styles = {
     // We need to reset LIC style due to conflicts between PARAGRAPH styles
     'ul > li > div': {
       margin: 0,
-      marginBottom: '1.25rem !important',
     },
   }),
   hiddenToolbar: css({

--- a/packages/rich-text/src/plugins/EmbeddedEntityBlock/LinkedEntityBlock.tsx
+++ b/packages/rich-text/src/plugins/EmbeddedEntityBlock/LinkedEntityBlock.tsx
@@ -13,7 +13,7 @@ import { FetchingWrappedEntryCard } from '../shared/FetchingWrappedEntryCard';
 
 const styles = {
   root: css({
-    marginBottom: '1.25rem',
+    marginBottom: '1.25rem !important',
   }),
 };
 

--- a/packages/rich-text/src/plugins/Voids/createVoidsPlugin.ts
+++ b/packages/rich-text/src/plugins/Voids/createVoidsPlugin.ts
@@ -20,8 +20,11 @@ export const createVoidsPlugin = (): RichTextPlugin => ({
     {
       // Inserts a new paragraph on enter when a void element is focused
       hotkey: 'enter',
+      // exploit the internal use of Array.slice(0, level + 1) by the exitBreak plugin
+      // to stay in the parent element
+      level: -2,
       query: {
-        filter: ([node, path]) => !isFirstChild(path) && !!node.isVoid,
+        filter: ([node, path]) => !(isRootLevel(path) && isFirstChild(path)) && !!node.isVoid,
       },
     },
   ],


### PR DESCRIPTION
This fixes the behavior of RTE when a user has an entity block selected within a list. Before the block was removed and the cursor moved out of the list.
Instead we want to add a new paragraph to the same list item the block is in 