### PR TITLE
fix(rte-list): backspace with multiple list items []

### DIFF
--- a/packages/rich-text/src/plugins/List/__tests__/createListPlugin.test.tsx
+++ b/packages/rich-text/src/plugins/List/__tests__/createListPlugin.test.tsx
@@ -104,4 +104,72 @@ describe('normalization', () => {
 
     assertOutput({ input, expected });
   });
+
+  it('replaces list items without paragraphs with nested list items', () => {
+    const input = (
+      <editor>
+        <hul>
+          <hli>
+            <hp>Item 1</hp>
+            <hul>
+              <hli>
+                <hp>Item 1.1</hp>
+              </hli>
+            </hul>
+          </hli>
+
+          <hli>
+            <hul>
+              <hli>
+                <hp>Item 2.1</hp>
+                <hul>
+                  <hli>
+                    <hp>Item 2.1.1</hp>
+                  </hli>
+                </hul>
+              </hli>
+              <hli>
+                <hp>Item 2.2</hp>
+              </hli>
+            </hul>
+          </hli>
+        </hul>
+        <hp>
+          <htext />
+        </hp>
+      </editor>
+    );
+
+    const expected = (
+      <editor>
+        <hul>
+          <hli>
+            <hp>Item 1</hp>
+            <hul>
+              <hli>
+                <hp>Item 1.1</hp>
+              </hli>
+            </hul>
+          </hli>
+          <hli>
+            <hp>Item 2.1</hp>
+            <hul>
+              <hli>
+                <hp>Item 2.1.1</hp>
+              </hli>
+            </hul>
+          </hli>
+          <hli>
+            <hp>Item 2.2</hp>
+          </hli>
+        </hul>
+
+        <hp>
+          <htext />
+        </hp>
+      </editor>
+    );
+
+    assertOutput({ input, expected });
+  });
 });

--- a/packages/rich-text/src/plugins/List/__tests__/createListPlugin.test.tsx
+++ b/packages/rich-text/src/plugins/List/__tests__/createListPlugin.test.tsx
@@ -105,7 +105,7 @@ describe('normalization', () => {
     assertOutput({ input, expected });
   });
 
-  it('replaces list items without paragraphs with nested list items', () => {
+  it('replaces list items with nested lists as a first child', () => {
     const input = (
       <editor>
         <hul>

--- a/packages/rich-text/src/plugins/List/createListPlugin.ts
+++ b/packages/rich-text/src/plugins/List/createListPlugin.ts
@@ -16,6 +16,8 @@ import {
   hasListAsDirectParent,
   insertParagraphAsChild,
   normalizeOrphanedListItem,
+  firstNodeIsNotList,
+  replaceNodeWithListItems,
 } from './utils';
 import { withList } from './withList';
 
@@ -61,6 +63,10 @@ export const createListPlugin = (): RichTextPlugin =>
           {
             validChildren: LIST_ITEM_BLOCKS,
             transform: transformParagraphs,
+          },
+          {
+            validNode: firstNodeIsNotList,
+            transform: replaceNodeWithListItems,
           },
         ],
       },

--- a/packages/rich-text/src/plugins/List/utils.ts
+++ b/packages/rich-text/src/plugins/List/utils.ts
@@ -38,9 +38,13 @@ export const isNonEmptyListItem = (editor: PlateEditor, [, path]: NodeEntry) => 
 };
 
 export const firstNodeIsNotList = (_editor: PlateEditor, [node]: NodeEntry<CustomElement>) => {
-  const firstNode = node.children?.[0];
+  if (node.children.length === 1) {
+    const firstNode = node.children[0];
 
-  return !!firstNode && !Text.isText(firstNode) && !isList(firstNode);
+    return !Text.isText(firstNode) && !isList(firstNode);
+  }
+
+  return true;
 };
 
 export const insertParagraphAsChild = (editor: PlateEditor, [, path]: NodeEntry) => {

--- a/packages/rich-text/src/plugins/List/utils.ts
+++ b/packages/rich-text/src/plugins/List/utils.ts
@@ -1,6 +1,6 @@
 import { BLOCKS } from '@contentful/rich-text-types';
 import { PlateEditor, getAbove, getParent } from '@udecode/plate-core';
-import { NodeEntry, Transforms, Path, Node } from 'slate';
+import { NodeEntry, Transforms, Path, Node, Text } from 'slate';
 
 import { CustomElement } from '../../types';
 
@@ -37,8 +37,21 @@ export const isNonEmptyListItem = (editor: PlateEditor, [, path]: NodeEntry) => 
   return listItemChildren.length !== 0;
 };
 
+export const firstNodeIsNotList = (_editor: PlateEditor, [node]: NodeEntry<CustomElement>) => {
+  const firstNode = node.children?.[0];
+
+  return !!firstNode && !Text.isText(firstNode) && !isList(firstNode);
+};
+
 export const insertParagraphAsChild = (editor: PlateEditor, [, path]: NodeEntry) => {
   Transforms.insertNodes(editor, [{ type: BLOCKS.PARAGRAPH, data: {}, children: [{ text: '' }] }], {
     at: path.concat([0]),
   });
+};
+
+export const replaceNodeWithListItems = (editor, entry) => {
+  const [node, path] = entry;
+
+  Transforms.removeNodes(editor, { at: path });
+  Transforms.insertNodes(editor, node.children[0].children, { at: path });
 };


### PR DESCRIPTION
Pressing backspace on a list with multiple items was causing the deleting to not work properly.

Example: 
![e1a2918e-65cb-437c-a662-b6ff2d50dc82](https://user-images.githubusercontent.com/954889/152804981-51741243-bf2f-49a3-a0e6-0dc0182050fe.gif)
![ba1ef19d-b8d4-44c0-a43d-d2afe7d4e1ff](https://user-images.githubusercontent.com/954889/152804983-bb81b60f-eae1-4774-af04-1b19719576f8.gif)

How it is now:

![image](https://user-images.githubusercontent.com/954889/152805034-063c5883-a5f8-4aab-8749-1baf850ebded.png)
![image](https://user-images.githubusercontent.com/954889/152805058-67e00d13-4a9a-4d68-acbd-01b91e998ad7.png)

---

![image](https://user-images.githubusercontent.com/954889/152805199-ae0ac7ee-88c4-4079-a960-bc142b4df8da.png)
![image](https://user-images.githubusercontent.com/954889/152805219-2dc7db9b-3e1a-4259-97e9-c9501718e4b3.png)
