### PR TITLE
fix(rte): triple selection selecting the next element instead

### DIFF
--- a/cypress/integration/LocationEditor.spec.ts
+++ b/cypress/integration/LocationEditor.spec.ts
@@ -4,7 +4,7 @@ const LOCATION_1 = {
 };
 const LOCATION_2 = {
   address: 'Max-Urich-Straße 1, 13355 Berlin, Germany',
-  value: { lon: 13.38381, lat: 52.53885 },
+  value: { lon: 13.38372, lat: 52.53926 },
 };
 
 describe('Location Editor', () => {

--- a/packages/rich-text/src/helpers/editor.ts
+++ b/packages/rich-text/src/helpers/editor.ts
@@ -67,6 +67,11 @@ export function getElementFromCurrentSelection(editor) {
 
   return Array.from(
     Editor.nodes(editor, {
+      /**
+       * editor.select is a Range, which includes anchor and focus, the beginning and the end of a selection
+       * when using only editor.selection.focus, we might get only the end of the selection, or where the text cursor is
+       * and in some cases getting the next element instead of the one we want
+       **/
       at: editor.selection,
       match: (node) => Element.isElement(node),
     })

--- a/packages/rich-text/src/helpers/editor.ts
+++ b/packages/rich-text/src/helpers/editor.ts
@@ -67,7 +67,7 @@ export function getElementFromCurrentSelection(editor) {
 
   return Array.from(
     Editor.nodes(editor, {
-      at: editor.selection.focus,
+      at: editor.selection,
       match: (node) => Element.isElement(node),
     })
   ).flat();


### PR DESCRIPTION
Any idea on how to test that on Cypress? I've tried something like:

```js
richText.editor.type('heading 1');

richText.toolbar.toggleHeading(BLOCKS.HEADING_1);

richText.editor.type('{enter}');

richText.editor.type('heading 2');

richText.toolbar.toggleHeading(BLOCKS.HEADING_2);

richText.editor.type('{uparrow}');

richText.editor.get('[data-slate-editor] h1').click().click().click();
```

But it does not work. Any ideas?