### PR TITLE
fix: links within safari

### DIFF
--- a/cypress/fixtures/map-search-address-reply.json
+++ b/cypress/fixtures/map-search-address-reply.json
@@ -1,0 +1,69 @@
+{
+  "results": [
+    {
+      "address_components": [
+        {
+          "long_name": "1",
+          "short_name": "1",
+          "types": ["street_number"]
+        },
+        {
+          "long_name": "Max-Urich-Straße",
+          "short_name": "Max-Urich-Straße",
+          "types": ["route"]
+        },
+        {
+          "long_name": "Mitte",
+          "short_name": "Mitte",
+          "types": ["political", "sublocality", "sublocality_level_1"]
+        },
+        {
+          "long_name": "Berlin",
+          "short_name": "Berlin",
+          "types": ["locality", "political"]
+        },
+        {
+          "long_name": "Kreisfreie Stadt Berlin",
+          "short_name": "Kreisfreie Stadt Berlin",
+          "types": ["administrative_area_level_3", "political"]
+        },
+        {
+          "long_name": "Berlin",
+          "short_name": "BE",
+          "types": ["administrative_area_level_1", "political"]
+        },
+        {
+          "long_name": "Germany",
+          "short_name": "DE",
+          "types": ["country", "political"]
+        },
+        {
+          "long_name": "13355",
+          "short_name": "13355",
+          "types": ["postal_code"]
+        }
+      ],
+      "formatted_address": "Max-Urich-Straße 1, 13355 Berlin, Germany",
+      "geometry": {
+        "location": {
+          "lat": 52.5388562,
+          "lng": 13.3838105
+        },
+        "location_type": "ROOFTOP",
+        "viewport": {
+          "south": 52.53750721970849,
+          "west": 13.3824615197085,
+          "north": 52.54020518029149,
+          "east": 13.3851594802915
+        }
+      },
+      "place_id": "ChIJwdjVuYxRqEcRmX3HOONUcU8",
+      "plus_code": {
+        "compound_code": "G9QM+GG Berlin, Germany",
+        "global_code": "9F4MG9QM+GG"
+      },
+      "types": ["street_address"]
+    }
+  ],
+  "status": "OK"
+}

--- a/cypress/integration/LocationEditor.spec.ts
+++ b/cypress/integration/LocationEditor.spec.ts
@@ -103,6 +103,7 @@ describe('Location Editor', () => {
   });
 
   it('should set value after using search input', () => {
+    cy.mockGoogleMapsResponse(require('../fixtures/map-search-address-reply.json'));
     cy.editorEvents().should('deep.equal', []);
 
     selectors.getSearchInput().type(LOCATION_2.address);

--- a/cypress/integration/rich-text/RichTextEditor.Pasting.spec.ts
+++ b/cypress/integration/rich-text/RichTextEditor.Pasting.spec.ts
@@ -242,5 +242,27 @@ describe(
         richText.expectSnapshotValue();
       });
     });
+
+    describe('copy from safari (no href in anchors)', () => {
+      it('recognizes entry hyperlink', () => {
+        richText.editor.click().paste({
+          'text/html':
+            '<meta charset="UTF-8"><span data-slate-node="text" style="caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0); font-style: normal; font-variant-caps: normal; font-weight: normal; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-size-adjust: auto; -webkit-text-stroke-width: 0px; text-decoration: none;"><span data-slate-leaf="true"><span data-slate-zero-width="z" data-slate-length="0"></span></span></span><span class="css-1wt9k1k" style="caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0); font-style: normal; font-variant-caps: normal; font-weight: normal; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-size-adjust: auto; -webkit-text-stroke-width: 0px; text-decoration: none;"><a class="css-1dcu81t" data-test-id="cf-ui-text-link" data-link-type="Entry" data-link-id="example-entity-id" aria-describedby="tooltip_5371"><span><span data-slate-node="text"><span data-slate-leaf="true"><span data-slate-string="true">a</span></span></span></span></a></span><span data-slate-node="text" data-slate-fragment="JTVCJTdCJTIydHlwZSUyMiUzQSUyMnBhcmFncmFwaCUyMiUyQyUyMmNoaWxkcmVuJTIyJTNBJTVCJTdCJTIydGV4dCUyMiUzQSUyMiUyMiUyQyUyMmRhdGElMjIlM0ElN0IlN0QlN0QlMkMlN0IlMjJ0eXBlJTIyJTNBJTIyZW50cnktaHlwZXJsaW5rJTIyJTJDJTIyZGF0YSUyMiUzQSU3QiUyMnRhcmdldCUyMiUzQSU3QiUyMnN5cyUyMiUzQSU3QiUyMmlkJTIyJTNBJTIyZXhhbXBsZS1lbnRpdHktaWQlMjIlMkMlMjJ0eXBlJTIyJTNBJTIyTGluayUyMiUyQyUyMmxpbmtUeXBlJTIyJTNBJTIyRW50cnklMjIlN0QlN0QlN0QlMkMlMjJjaGlsZHJlbiUyMiUzQSU1QiU3QiUyMnRleHQlMjIlM0ElMjJhJTIyJTdEJTVEJTdEJTJDJTdCJTIydGV4dCUyMiUzQSUyMiUyMGIlMjIlN0QlNUQlMkMlMjJpc1ZvaWQlMjIlM0FmYWxzZSUyQyUyMmRhdGElMjIlM0ElN0IlN0QlN0QlNUQ=" style="caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0); font-style: normal; font-variant-caps: normal; font-weight: normal; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-size-adjust: auto; -webkit-text-stroke-width: 0px; text-decoration: none;"><span data-slate-leaf="true"><span data-slate-string="true"><span class="Apple-converted-space">&nbsp;</span>b</span></span></span>',
+          'text/plain': 'a b',
+        });
+
+        richText.expectSnapshotValue();
+      });
+
+      it('recognizes asset hyperlink', () => {
+        richText.editor.click().paste({
+          'text/html':
+            '<meta charset="UTF-8"><span data-slate-node="text" style="caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0); font-style: normal; font-variant-caps: normal; font-weight: normal; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-size-adjust: auto; -webkit-text-stroke-width: 0px; text-decoration: none;"><span data-slate-leaf="true"><span data-slate-zero-width="z" data-slate-length="0"></span></span></span><span class="css-1wt9k1k" style="caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0); font-style: normal; font-variant-caps: normal; font-weight: normal; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-size-adjust: auto; -webkit-text-stroke-width: 0px; text-decoration: none;"><a class="css-1dcu81t" data-test-id="cf-ui-text-link" data-link-type="Asset" data-link-id="example-entity-id" aria-describedby="tooltip_4165"><span><span data-slate-node="text"><span data-slate-leaf="true"><span data-slate-string="true">a</span></span></span></span></a></span><span data-slate-node="text" data-slate-fragment="JTVCJTdCJTIydHlwZSUyMiUzQSUyMnBhcmFncmFwaCUyMiUyQyUyMmNoaWxkcmVuJTIyJTNBJTVCJTdCJTIydGV4dCUyMiUzQSUyMiUyMiU3RCUyQyU3QiUyMnR5cGUlMjIlM0ElMjJhc3NldC1oeXBlcmxpbmslMjIlMkMlMjJkYXRhJTIyJTNBJTdCJTIydGFyZ2V0JTIyJTNBJTdCJTIyc3lzJTIyJTNBJTdCJTIyaWQlMjIlM0ElMjJleGFtcGxlLWVudGl0eS1pZCUyMiUyQyUyMnR5cGUlMjIlM0ElMjJMaW5rJTIyJTJDJTIybGlua1R5cGUlMjIlM0ElMjJBc3NldCUyMiU3RCU3RCU3RCUyQyUyMmNoaWxkcmVuJTIyJTNBJTVCJTdCJTIydGV4dCUyMiUzQSUyMmElMjIlMkMlMjJkYXRhJTIyJTNBJTdCJTdEJTdEJTVEJTdEJTJDJTdCJTIydGV4dCUyMiUzQSUyMiUyMGIlMjIlN0QlNUQlMkMlMjJpc1ZvaWQlMjIlM0FmYWxzZSUyQyUyMmRhdGElMjIlM0ElN0IlN0QlN0QlNUQ=" style="caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0); font-style: normal; font-variant-caps: normal; font-weight: normal; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-size-adjust: auto; -webkit-text-stroke-width: 0px; text-decoration: none;"><span data-slate-leaf="true"><span data-slate-string="true"><span class="Apple-converted-space">&nbsp;</span>b</span></span></span>',
+          'text/plain': 'a b',
+        });
+
+        richText.expectSnapshotValue();
+      });
+    });
   }
 );

--- a/cypress/integration/rich-text/__snapshots__/RichTextEditor.Pasting.spec.ts.snap
+++ b/cypress/integration/rich-text/__snapshots__/RichTextEditor.Pasting.spec.ts.snap
@@ -2415,3 +2415,95 @@ exports[`Rich Text Editor > Microsoft Word (.docx) deserialization > tables #0`]
   "data": {},
   "nodeType": "document"
 };
+
+exports[`Rich Text Editor > copy from safari (no href in anchors) > recognizes entry hyperlink #0`] =
+{
+  "content": [
+    {
+      "content": [
+        {
+          "data": {},
+          "marks": [],
+          "nodeType": "text",
+          "value": ""
+        },
+        {
+          "content": [
+            {
+              "data": {},
+              "marks": [],
+              "nodeType": "text",
+              "value": "a"
+            }
+          ],
+          "data": {
+            "target": {
+              "sys": {
+                "id": "example-entity-id",
+                "linkType": "Entry",
+                "type": "Link"
+              }
+            }
+          },
+          "nodeType": "entry-hyperlink"
+        },
+        {
+          "data": {},
+          "marks": [],
+          "nodeType": "text",
+          "value": " b"
+        }
+      ],
+      "data": {},
+      "nodeType": "paragraph"
+    }
+  ],
+  "data": {},
+  "nodeType": "document"
+};
+
+exports[`Rich Text Editor > copy from safari (no href in anchors) > recognizes asset hyperlink #0`] =
+{
+  "content": [
+    {
+      "content": [
+        {
+          "data": {},
+          "marks": [],
+          "nodeType": "text",
+          "value": ""
+        },
+        {
+          "content": [
+            {
+              "data": {},
+              "marks": [],
+              "nodeType": "text",
+              "value": "a"
+            }
+          ],
+          "data": {
+            "target": {
+              "sys": {
+                "id": "example-entity-id",
+                "linkType": "Asset",
+                "type": "Link"
+              }
+            }
+          },
+          "nodeType": "asset-hyperlink"
+        },
+        {
+          "data": {},
+          "marks": [],
+          "nodeType": "text",
+          "value": " b"
+        }
+      ],
+      "data": {},
+      "nodeType": "paragraph"
+    }
+  ],
+  "data": {},
+  "nodeType": "document"
+};

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -34,7 +34,7 @@ Cypress.Commands.add('setValueExternal', (value) => {
 
 Cypress.Commands.add('setGoogleMapsKey', () => {
   return cy.window().then((win) => {
-    win.localStorage.setItem('googleMapsKey', Cypress.env('googleMapsKey'));
+    win.localStorage.setItem('googleMapsKey', Cypress.env('googleMapsKey') || '');
     return win;
   });
 });
@@ -125,4 +125,13 @@ Cypress.Commands.add('dragTo', { prevSubject: true }, (subject, target) => {
   cy.wrap(subject).trigger('dragstart', { dataTransfer });
 
   target().trigger('drop', { dataTransfer });
+});
+
+// https://frontend.irish/how-mock-google-places-cypress
+Cypress.Commands.add('mockGoogleMapsResponse', (mockData) => {
+  cy.intercept('https://maps.googleapis.com/maps/api/js/GeocodeService.Search*', (request) => {
+    const searchParams = new URLSearchParams(request.url);
+    const callbackParam = searchParams.get('callback');
+    request.reply(`${callbackParam} && ${callbackParam}(${JSON.stringify(mockData)})`);
+  });
 });

--- a/cypress/support/index.d.ts
+++ b/cypress/support/index.d.ts
@@ -4,6 +4,7 @@ declare namespace Cypress {
     editorActions(lastN?: number): Chainable<Array<any>>;
     setValueExternal(value: any): Chainable<void>;
     setGoogleMapsKey(): Chainable<void>;
+    mockGoogleMapsResponse(mockData: unknown): void;
     setInitialValue(initialValue: any): void;
     setInitialDisabled(value: boolean | undefined): void;
     setFieldValidations(value: Object[]): void;

--- a/packages/rich-text/src/plugins/Hyperlink/index.tsx
+++ b/packages/rich-text/src/plugins/Hyperlink/index.tsx
@@ -182,9 +182,7 @@ export function ToolbarHyperlinkButton(props: ToolbarHyperlinkButtonProps) {
 }
 
 const isAnchor = (element: HTMLElement) =>
-  element.nodeName === 'A' &&
-  !!element.getAttribute('href') &&
-  element.getAttribute('href') !== '#';
+  element.nodeName === 'A' && element.getAttribute('href') !== '#';
 
 const isEntryAnchor = (element: HTMLElement) =>
   isAnchor(element) && element.getAttribute('data-link-type') === 'Entry';

--- a/packages/rich-text/src/plugins/Hyperlink/index.tsx
+++ b/packages/rich-text/src/plugins/Hyperlink/index.tsx
@@ -182,13 +182,13 @@ export function ToolbarHyperlinkButton(props: ToolbarHyperlinkButtonProps) {
 }
 
 const isAnchor = (element: HTMLElement) =>
-  element.nodeName === 'A' && element.getAttribute('href') !== '#';
+  element.nodeName === 'A' &&
+  !!element.getAttribute('href') &&
+  element.getAttribute('href') !== '#';
 
-const isEntryAnchor = (element: HTMLElement) =>
-  isAnchor(element) && element.getAttribute('data-link-type') === 'Entry';
+const isEntryAnchor = (element: HTMLElement) => element.getAttribute('data-link-type') === 'Entry';
 
-const isAssetAnchor = (element: HTMLElement) =>
-  isAnchor(element) && element.getAttribute('data-link-type') === 'Asset';
+const isAssetAnchor = (element: HTMLElement) => element.getAttribute('data-link-type') === 'Asset';
 
 const buildHyperlinkEventHandler =
   (sdk: FieldExtensionSDK): KeyboardHandler<{}, HotkeyPlugin> =>

--- a/packages/rich-text/src/plugins/Hyperlink/index.tsx
+++ b/packages/rich-text/src/plugins/Hyperlink/index.tsx
@@ -186,9 +186,11 @@ const isAnchor = (element: HTMLElement) =>
   !!element.getAttribute('href') &&
   element.getAttribute('href') !== '#';
 
-const isEntryAnchor = (element: HTMLElement) => element.getAttribute('data-link-type') === 'Entry';
+const isEntryAnchor = (element: HTMLElement) =>
+  element.nodeName === 'A' && element.getAttribute('data-link-type') === 'Entry';
 
-const isAssetAnchor = (element: HTMLElement) => element.getAttribute('data-link-type') === 'Asset';
+const isAssetAnchor = (element: HTMLElement) =>
+  element.nodeName === 'A' && element.getAttribute('data-link-type') === 'Asset';
 
 const buildHyperlinkEventHandler =
   (sdk: FieldExtensionSDK): KeyboardHandler<{}, HotkeyPlugin> =>


### PR DESCRIPTION
Recognizes entity hyperlinks copied from safari, which don't have an `href` attribute 