### PR TITLE
test: fix flaky test

### DIFF
--- a/cypress/integration/rich-text/RichTextEditor.Pasting.spec.ts
+++ b/cypress/integration/rich-text/RichTextEditor.Pasting.spec.ts
@@ -306,6 +306,10 @@ describe(
         cy.window().then((win) => {
           const selection = win.getSelection();
           cy.wrap(selection).its('focusNode.data').should('equal', 'abc');
+          // slate throttles the handling of selection changes
+          // so the editor might be unaware of the new selection at the time we paste
+          // eslint-disable-next-line cypress/no-unnecessary-waiting
+          cy.wait(200);
         });
         richText.editor.paste({
           'text/html':


### PR DESCRIPTION
This is a workaround that waits a bit for the selection to be registered by slate. The throttle time is currently 100ms so doubling that time should be enough.