### PR TITLE
feat: show the disable state on fields

### DIFF
--- a/packages/_shared/src/FieldConnector.ts
+++ b/packages/_shared/src/FieldConnector.ts
@@ -1,7 +1,8 @@
 import React from 'react';
+
+import { FieldAPI, ValidationError } from '@contentful/app-sdk';
 import isEqual from 'lodash/isEqual';
 import throttle from 'lodash/throttle';
-import { FieldAPI, ValidationError } from '@contentful/app-sdk';
 
 type Nullable = null | undefined;
 

--- a/packages/json/src/JsonEditoField.tsx
+++ b/packages/json/src/JsonEditoField.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import { Controlled as CodeMirror } from 'react-codemirror2';
+
 import tokens from '@contentful/f36-tokens';
 import { css } from 'emotion';
-import { Controlled as CodeMirror } from 'react-codemirror2';
 
 const CODE_MIRROR_CONFIG = {
   autoCloseBrackets: true,
@@ -38,12 +39,31 @@ const styles = {
     '.CodeMirror-scroll': {
       minHeight: '6rem',
     },
+    '&.disabled': {
+      cursor: 'auto',
+      '.CodeMirror-scroll ': {
+        minHeight: '6rem',
+        backgroundColor: tokens.gray100,
+        cursor: 'not-allowed',
+      },
+      '.react-codemirror2': {
+        border: `1px solid ${tokens.gray200}`,
+      },
+      '.CodeMirror-line': {
+        cursor: 'not-allowed',
+      },
+      '.CodeMirror-lines': {
+        cursor: 'not-allowed',
+      },
+    },
   }),
 };
 
 export function JsonEditorField(props: JsonEditorFieldProps) {
   return (
-    <div className={styles.root} data-test-id="json-editor-code-mirror">
+    <div
+      className={`${styles.root} ${props.isDisabled ? 'disabled' : ''}`}
+      data-test-id="json-editor-code-mirror">
       <CodeMirror
         value={props.value}
         onBeforeChange={(_editor, _data, value) => {
@@ -51,7 +71,7 @@ export function JsonEditorField(props: JsonEditorFieldProps) {
         }}
         options={{
           ...CODE_MIRROR_CONFIG,
-          readOnly: props.isDisabled,
+          readOnly: props.isDisabled ? 'nocursor' : false,
         }}
       />
     </div>

--- a/packages/location/src/GoogleMapView.tsx
+++ b/packages/location/src/GoogleMapView.tsx
@@ -1,8 +1,10 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import React from 'react';
+
 import { css } from 'emotion';
 import GoogleMapReact from 'google-map-react';
+
 import { Coords } from './types';
 
 const styles = {
@@ -48,6 +50,8 @@ export class GoogleMapView extends React.Component<GoogleMapViewProps, GoogleMap
       } else {
         this.state.marker.setVisible(false);
       }
+      this.state.marker.setDraggable(!this.props.disabled);
+      this.state.marker.setCursor(this.props.disabled ? 'not-allowed' : 'auto');
     }
   }
 
@@ -56,7 +60,8 @@ export class GoogleMapView extends React.Component<GoogleMapViewProps, GoogleMap
     const marker = new maps.Marker({
       map,
       position: map.getCenter(),
-      draggable: true,
+      cursor: this.props.disabled ? 'not-allowed' : 'auto',
+      draggable: !this.props.disabled,
       visible: Boolean(this.props.location),
     });
 

--- a/packages/markdown/src/components/MarkdownTextarea/MarkdownTextarea.tsx
+++ b/packages/markdown/src/components/MarkdownTextarea/MarkdownTextarea.tsx
@@ -1,8 +1,10 @@
 import React, { useRef, useEffect, useState } from 'react';
+
 import tokens from '@contentful/f36-tokens';
 import { css, cx } from 'emotion';
-import { createMarkdownEditor } from './createMarkdownEditor';
+
 import { EditorDirection } from '../../types';
+import { createMarkdownEditor } from './createMarkdownEditor';
 
 export type InitializedEditorType = ReturnType<typeof createMarkdownEditor>;
 
@@ -102,9 +104,15 @@ const styles = {
   disabled: css`
     .CodeMirror {
       background: ${tokens.gray100};
+      cursor: 'not-allowed';
     }
     .CodeMirror-cursors {
       visibility: hidden !important;
+    }
+    .CodeMirror-scroll,
+    .CodeMirror-sizer,
+    .CodeMirror-lines {
+      cursor: not-allowed;
     }
   `,
 };

--- a/packages/radio/src/RadioEditor.tsx
+++ b/packages/radio/src/RadioEditor.tsx
@@ -1,15 +1,17 @@
 import * as React from 'react';
-import { cx } from 'emotion';
+
+import { TextLink, Flex, Radio, Form } from '@contentful/f36-components';
+import { getOptions, parseValue } from '@contentful/field-editor-dropdown';
 import {
   FieldAPI,
   FieldConnector,
   PredefinedValuesError,
   LocalesAPI,
 } from '@contentful/field-editor-shared';
-import { getOptions, parseValue } from '@contentful/field-editor-dropdown';
+import { cx } from 'emotion';
+
 import * as styles from './styles';
 
-import { TextLink, Flex, Radio, Form } from '@contentful/f36-components';
 
 export interface RadioEditorProps {
   /**
@@ -75,7 +77,11 @@ export function RadioEditor(props: RadioEditorProps) {
                     {item.label}
                   </Radio>
                   {checked && (
-                    <TextLink as="button" className={styles.clearBtn} onClick={clearOption}>
+                    <TextLink
+                      as="button"
+                      isDisabled={disabled}
+                      className={styles.clearBtn}
+                      onClick={clearOption}>
                       Clear
                     </TextLink>
                   )}

--- a/packages/rich-text/src/RichTextEditor.styles.ts
+++ b/packages/rich-text/src/RichTextEditor.styles.ts
@@ -49,5 +49,6 @@ export const styles = {
   }),
   disabled: css({
     background: tokens.gray100,
+    cursor: 'not-allowed',
   }),
 };


### PR DESCRIPTION
There are "issues" when you disable a field using the `isInitiallyDisabled` prop

 - Some fields will be disabled but the UI does not reflect that ( JSON/Rich Text/ Markdown ).
 - The user can still edit them in a way (Map/Radio).


This PR is to fix that

