### PR TITLE
fix: link data in safari

### DIFF
--- a/packages/rich-text/src/helpers/editor.ts
+++ b/packages/rich-text/src/helpers/editor.ts
@@ -38,11 +38,12 @@ type NodeEntry = [CustomElement, Path];
 type NodeType = BLOCKS | INLINES;
 export function getNodeEntryFromSelection(
   editor: RichTextEditor,
-  nodeTypeOrTypes: NodeType | NodeType[]
+  nodeTypeOrTypes: NodeType | NodeType[],
+  path?: Path
 ): NodeEntry | [] {
-  if (!editor.selection) return [];
+  path = path ?? editor.selection?.focus.path;
+  if (!path) return [];
   const nodeTypes = Array.isArray(nodeTypeOrTypes) ? nodeTypeOrTypes : [nodeTypeOrTypes];
-  const { path } = editor.selection.focus;
   for (let i = 0; i < path.length; i++) {
     const nodeEntry = Editor.node(editor, path.slice(0, i + 1)) as NodeEntry;
     if (nodeTypes.includes(nodeEntry[0].type as NodeType)) return nodeEntry;

--- a/packages/rich-text/src/plugins/Hyperlink/components/EntityHyperlink.tsx
+++ b/packages/rich-text/src/plugins/Hyperlink/components/EntityHyperlink.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import { FieldExtensionSDK, Link } from '@contentful/app-sdk';
 import { Tooltip, TextLink } from '@contentful/f36-components';
-import { useReadOnly } from 'slate-react';
+import { ReactEditor, useReadOnly } from 'slate-react';
 
 import { useContentfulEditor } from '../../../ContentfulEditorProvider';
 import { useSdkContext } from '../../../SdkProvider';
@@ -36,7 +36,11 @@ export function EntityHyperlink(props: HyperlinkElementProps) {
     event.preventDefault();
     event.stopPropagation();
     if (!editor) return;
-    addOrEditLink(editor, sdk, editor.tracking.onViewportAction);
+    const p = ReactEditor.toSlatePoint(editor, [event.target as Node, 0], {
+      exactMatch: false,
+      suppressThrow: false,
+    });
+    addOrEditLink(editor, sdk, editor.tracking.onViewportAction, p.path);
   }
 
   return (

--- a/packages/rich-text/src/plugins/Hyperlink/components/UrlHyperlink.tsx
+++ b/packages/rich-text/src/plugins/Hyperlink/components/UrlHyperlink.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import { FieldExtensionSDK, Link } from '@contentful/app-sdk';
 import { Tooltip, TextLink } from '@contentful/f36-components';
-import { useReadOnly } from 'slate-react';
+import { ReactEditor, useReadOnly } from 'slate-react';
 
 import { useContentfulEditor } from '../../../ContentfulEditorProvider';
 import { useSdkContext } from '../../../SdkProvider';
@@ -26,7 +26,11 @@ export function UrlHyperlink(props: HyperlinkElementProps) {
     event.preventDefault();
     event.stopPropagation();
     if (!editor) return;
-    addOrEditLink(editor, sdk, editor.tracking.onViewportAction);
+    const p = ReactEditor.toSlatePoint(editor, [event.target as Node, 0], {
+      exactMatch: false,
+      suppressThrow: false,
+    });
+    addOrEditLink(editor, sdk, editor.tracking.onViewportAction, p.path);
   }
 
   return (


### PR DESCRIPTION
Sometimes, more frequently in safari, the hyperlink modal fetches the editor selection before it's changed when clicking on an hyperlink, keeping it for example at the beginning of the editor.
This causes the hyperlink modal to not grab the correct link data and so to display empty or wrong inputs.

The pr ensures the clicked node isn't determined by the editor selection but by the clicked point in the editor.

![Kapture 2022-03-17 at 12 19 22](https://user-images.githubusercontent.com/71259950/158798755-b7c02894-0921-4e11-95e5-ccc78f531abb.gif)
