### PR TITLE
fix(rich-text): fix entity cards alignment in <li>

### DIFF
--- a/packages/rich-text/src/plugins/EmbeddedEntityBlock/LinkedEntityBlock.tsx
+++ b/packages/rich-text/src/plugins/EmbeddedEntityBlock/LinkedEntityBlock.tsx
@@ -14,6 +14,10 @@ import { FetchingWrappedEntryCard } from '../shared/FetchingWrappedEntryCard';
 const styles = {
   root: css({
     marginBottom: '1.25rem !important',
+    // The next 2 properties ensure Entity card won't be aligned above
+    // a list item marker (i.e. bullet)
+    display: 'inline-block',
+    verticalAlign: 'text-top',
   }),
 };
 


### PR DESCRIPTION
### Before

![image](https://user-images.githubusercontent.com/12673605/158949317-6d8ba90c-a746-47b3-a398-3a8f20be131b.png)


### After

![image](https://user-images.githubusercontent.com/12673605/158949224-2a02c45f-6952-4e77-9c61-93887a321f49.png)
