### PR TITLE
fix: list toolbar state when selection is a range

### DIFF
--- a/packages/rich-text/src/plugins/List/utils.ts
+++ b/packages/rich-text/src/plugins/List/utils.ts
@@ -1,6 +1,6 @@
 import { BLOCKS } from '@contentful/rich-text-types';
 import { getAbove, getBlockAbove, getParent } from '@udecode/plate-core';
-import { NodeEntry, Transforms, Path, Node, Text } from 'slate';
+import { NodeEntry, Transforms, Path, Node, Text, Range } from 'slate';
 
 import { CustomElement, RichTextEditor } from '../../types';
 
@@ -60,7 +60,22 @@ export const replaceNodeWithListItems = (editor, entry) => {
   Transforms.insertNodes(editor, node.children[0].children, { at: path });
 };
 
-export const isListTypeActive = (editor: RichTextEditor, type: BLOCKS) => {
+export const isListTypeActive = (editor: RichTextEditor, type: BLOCKS): boolean => {
+  const { selection } = editor;
+
+  if (!selection) {
+    return false;
+  }
+
+  if (Range.isExpanded(selection)) {
+    const [start, end] = Range.edges(selection);
+    const node = Node.common(editor, start.path, end.path);
+
+    if ((node[0] as CustomElement).type === type) {
+      return true;
+    }
+  }
+
   // Lists can be nested. Here, we take the list type at the lowest level
   const listNode = getBlockAbove(editor, {
     match: {


### PR DESCRIPTION
Fixes two cases where the toolbar doesn't show an active state even though the selection range is a list

#### Case 1:
![image](https://user-images.githubusercontent.com/12673605/159433618-fc0abd11-c2fe-4f0f-850c-25442e25bdf0.png)

#### Case 2
![image](https://user-images.githubusercontent.com/12673605/159433667-61d5b06e-bece-4741-b171-6c350ecbd2e3.png)
