### PR TITLE
fix: allow linking assets on permission rule with tags

### DIFF
--- a/packages/reference/src/common/useEditorPermissions.ts
+++ b/packages/reference/src/common/useEditorPermissions.ts
@@ -48,7 +48,9 @@ export function useEditorPermissions(props: EditorPermissionsProps) {
 
     async function checkLinkAccess() {
       if (entityType === 'Asset') {
-        const canRead = await canPerformAction('read', 'Asset');
+        // Hardcoded `true` value following https://contentful.atlassian.net/browse/DANTE-486
+        // TODO: refine permissions check in order to account for tags in rules
+        const canRead = (await canPerformAction('read', 'Asset')) || true;
         setCanLinkEntity(canRead);
       }
       if (entityType === 'Entry') {


### PR DESCRIPTION
Always show the option to link existing assets on a reference field. This prevents, in case of an `allow` permission based on tags, the impossibility to see assets the users have access to.

It is meant as a quick, yet effective, workaround in the wait for a refined permission evaluation