### PR TITLE
fix(rte): pressing enter before a table

### DIFF
--- a/cypress/integration/rich-text/RichTextEditor.spec.ts
+++ b/cypress/integration/rich-text/RichTextEditor.spec.ts
@@ -767,34 +767,37 @@ describe('Rich Text Editor', { viewportHeight: 2000 }, () => {
     };
     const expectTable = (...tableElements) => expectDocumentStructure(table(...tableElements));
 
-    it('inserts new line before table', () => {
-      // prevent expected error `Cannot resolve a Slate point from DOM point` from failing this test
-      Cypress.on('uncaught:exception', (err) => {
-        if (
-          err.message.includes(
-            'Cannot resolve a Slate point from DOM point: [object HTMLDivElement],0'
+    // We know this feature doesn't work on firefox, we skip it
+    if (Cypress.browser.family !== 'firefox') {
+      it('inserts new line before table', () => {
+        // prevent expected error `Cannot resolve a Slate point from DOM point` from failing this test
+        Cypress.on('uncaught:exception', (err) => {
+          if (
+            err.message.includes(
+              'Cannot resolve a Slate point from DOM point: [object HTMLDivElement],0'
+            )
+          ) {
+            return false;
+          }
+
+          // we still want the test to fail in case there's any other error
+          return true;
+        });
+
+        insertTable();
+
+        richText.editor.type('{uparrow}{enter}');
+
+        richText.expectValue(
+          doc(
+            emptyParagraph(),
+
+            table(row(emptyHeader(), emptyHeader()), row(emptyCell(), emptyCell())),
+            emptyParagraph()
           )
-        ) {
-          return false;
-        }
-
-        // we still want the test to fail in case there's any other error
-        return true;
+        );
       });
-
-      insertTable();
-
-      richText.editor.type('{uparrow}{enter}');
-
-      richText.expectValue(
-        doc(
-          emptyParagraph(),
-
-          table(row(emptyHeader(), emptyHeader()), row(emptyCell(), emptyCell())),
-          emptyParagraph()
-        )
-      );
-    });
+    }
 
     it('disables block element toolbar buttons when selected', () => {
       insertTable();

--- a/cypress/integration/rich-text/RichTextEditor.spec.ts
+++ b/cypress/integration/rich-text/RichTextEditor.spec.ts
@@ -767,6 +767,35 @@ describe('Rich Text Editor', { viewportHeight: 2000 }, () => {
     };
     const expectTable = (...tableElements) => expectDocumentStructure(table(...tableElements));
 
+    it('inserts new line before table', () => {
+      // prevent expected error `Cannot resolve a Slate point from DOM point` from failing this test
+      Cypress.on('uncaught:exception', (err) => {
+        if (
+          err.message.includes(
+            'Cannot resolve a Slate point from DOM point: [object HTMLDivElement],0'
+          )
+        ) {
+          return false;
+        }
+
+        // we still want the test to fail in case there's any other error
+        return true;
+      });
+
+      insertTable();
+
+      richText.editor.type('{uparrow}{enter}');
+
+      richText.expectValue(
+        doc(
+          emptyParagraph(),
+
+          table(row(emptyHeader(), emptyHeader()), row(emptyCell(), emptyCell())),
+          emptyParagraph()
+        )
+      );
+    });
+
     it('disables block element toolbar buttons when selected', () => {
       insertTable();
 

--- a/packages/rich-text/src/helpers/editor.ts
+++ b/packages/rich-text/src/helpers/editor.ts
@@ -65,14 +65,14 @@ export function moveToTheNextChar(editor: RichTextEditor) {
   Transforms.move(editor, { distance: 1, unit: 'character' });
 }
 
-export function insertEmptyParagraph(editor: RichTextEditor) {
+export function insertEmptyParagraph(editor: RichTextEditor, options?) {
   const emptyParagraph: CustomElement = {
     type: BLOCKS.PARAGRAPH,
     children: [{ text: '' }],
     data: {},
     isVoid: false,
   };
-  Transforms.insertNodes(editor, emptyParagraph);
+  Transforms.insertNodes(editor, emptyParagraph, options);
 }
 
 export function getElementFromCurrentSelection(editor: RichTextEditor) {

--- a/packages/rich-text/src/plugins/Table/components/Table.tsx
+++ b/packages/rich-text/src/plugins/Table/components/Table.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
 import tokens from '@contentful/f36-tokens';
+import { BLOCKS } from '@contentful/rich-text-types';
 import { css } from 'emotion';
 import * as Slate from 'slate-react';
 
@@ -15,8 +16,12 @@ const style = css`
   overflow: hidden;
 `;
 
-export const Table = (props: Slate.RenderElementProps) => (
-  <table {...props.attributes} className={style}>
-    <tbody>{props.children}</tbody>
-  </table>
-);
+export const Table = (props: Slate.RenderElementProps) => {
+  return (
+    <div data-block-type={BLOCKS.TABLE}>
+      <table className={style} {...props.attributes}>
+        <tbody>{props.children}</tbody>
+      </table>
+    </div>
+  );
+};

--- a/packages/rich-text/src/plugins/Table/createTablePlugin.ts
+++ b/packages/rich-text/src/plugins/Table/createTablePlugin.ts
@@ -7,6 +7,7 @@ import {
   getLastChildPath,
   WithPlatePlugin,
   getText,
+  getAbove,
 } from '@udecode/plate-core';
 import {
   createTablePlugin as createDefaultTablePlugin,
@@ -53,6 +54,30 @@ const createTableOnKeyDown: KeyboardHandler<RichTextEditor, HotkeyPlugin> = (edi
       event.preventDefault();
       event.stopPropagation();
       return;
+    }
+
+    if (event.key === 'Enter') {
+      const windowSelection = window.getSelection();
+
+      if (windowSelection) {
+        // @ts-expect-error
+        const blockType = windowSelection.anchorNode.attributes?.['data-block-type']?.value; // this attribute comes from `plugins/Table/components/Table.tsx`
+        const isBeforeTable = blockType === BLOCKS.TABLE;
+
+        if (isBeforeTable) {
+          const above = getAbove(editor, { match: { type: BLOCKS.TABLE } });
+
+          if (!above) return;
+
+          const [, tablePath] = above;
+
+          insertEmptyParagraph(editor, { at: tablePath, select: true });
+
+          event.preventDefault();
+          event.stopPropagation();
+          return;
+        }
+      }
     }
 
     defaultHandler(event);

--- a/packages/rich-text/src/plugins/Table/createTablePlugin.ts
+++ b/packages/rich-text/src/plugins/Table/createTablePlugin.ts
@@ -56,15 +56,15 @@ const createTableOnKeyDown: KeyboardHandler<RichTextEditor, HotkeyPlugin> = (edi
       return;
     }
 
-    if (event.key === 'Enter') {
-      const windowSelection = window.getSelection();
+    // This fixes `Cannot resolve a Slate point from DOM point: [object HTMLDivElement]` when typing while the cursor is before table
+    const windowSelection = window.getSelection();
+    if (windowSelection) {
+      // @ts-expect-error
+      const blockType = windowSelection.anchorNode.attributes?.['data-block-type']?.value; // this attribute comes from `plugins/Table/components/Table.tsx`
+      const isBeforeTable = blockType === BLOCKS.TABLE;
 
-      if (windowSelection) {
-        // @ts-expect-error
-        const blockType = windowSelection.anchorNode.attributes?.['data-block-type']?.value; // this attribute comes from `plugins/Table/components/Table.tsx`
-        const isBeforeTable = blockType === BLOCKS.TABLE;
-
-        if (isBeforeTable) {
+      if (isBeforeTable) {
+        if (event.key === 'Enter') {
           const above = getAbove(editor, { match: { type: BLOCKS.TABLE } });
 
           if (!above) return;
@@ -72,11 +72,11 @@ const createTableOnKeyDown: KeyboardHandler<RichTextEditor, HotkeyPlugin> = (edi
           const [, tablePath] = above;
 
           insertEmptyParagraph(editor, { at: tablePath, select: true });
-
-          event.preventDefault();
-          event.stopPropagation();
-          return;
         }
+
+        event.preventDefault();
+        event.stopPropagation();
+        return;
       }
     }
 


### PR DESCRIPTION
This errors happens when putting the text cursor before a table, it doesn't block anything for the user but it's annoying, it also doesn't allow me to write Cypress tests for this feature.

Cypress will complain saying the editor thrown an error.

<img width="490" alt="image" src="https://user-images.githubusercontent.com/954889/160788418-1821218d-f7bc-4386-a9e0-62a793696a14.png">

The error is also triggered for any key I press while the cursor is before table.

---

I needed to use `window.getSelection` in this case because Slate's `path` is the same when the cursor is one the first cell or before table, so I couldn't differentiate their positions based on what Slate offers.

The solution was to create a wrapper for the table, so I can identify if the selection is between the container and the table.