### PR TITLE
fix: pass already known entry link id to onAction

### DIFF
--- a/packages/reference/src/entries/WrappedEntryCard/FetchingWrappedEntryCard.tsx
+++ b/packages/reference/src/entries/WrappedEntryCard/FetchingWrappedEntryCard.tsx
@@ -69,7 +69,7 @@ export function FetchingWrappedEntryCard(props: EntryCardReferenceEditorProps) {
       : `:${entry.sys.id}:${entry.sys.version}`;
 
   const onEdit = async () => {
-    const slide = await openEntry(props.sdk, get(entry, 'sys.id'), {
+    const slide = await openEntry(props.sdk, props.entryId, {
       bulkEditing: props.parameters.instance.bulkEditing,
       index: props.index,
     });
@@ -77,7 +77,7 @@ export function FetchingWrappedEntryCard(props: EntryCardReferenceEditorProps) {
       props.onAction({
         entity: 'Entry',
         type: 'edit',
-        id: get(entry, 'sys.id'),
+        id: props.entryId,
         contentTypeId: get(entry, 'sys.contentType.sys.id'),
         slide,
       });
@@ -89,7 +89,7 @@ export function FetchingWrappedEntryCard(props: EntryCardReferenceEditorProps) {
       props.onAction({
         entity: 'Entry',
         type: 'delete',
-        id: get(entry, 'sys.id'),
+        id: props.entryId,
         contentTypeId: get(entry, 'sys.contentType.sys.id'),
       });
   };


### PR DESCRIPTION
Instead of passing the fetched entry's `sys.id` to `onAction` callbacks, simply pass the already known entry ID prop. We know the ID as it's part of the actual link.

This has a big advantage that even when the entry can't be loaded, or if an `onAction` is called before it loaded, we can still send teh entry ID.