### PR TITLE
fix(rte): delete event handler for tables after implementing plates methods

### DIFF
--- a/cypress/integration/rich-text/RichTextEditor.spec.ts
+++ b/cypress/integration/rich-text/RichTextEditor.spec.ts
@@ -830,6 +830,22 @@ describe('Rich Text Editor', { viewportHeight: 2000 }, () => {
       );
     });
 
+    it('delete multiple lines inside cells', () => {
+      insertTable();
+
+      richText.editor.type('hey{enter}{backspace}');
+
+      richText.expectValue(
+        doc(
+          table(
+            row(header(paragraphWithText('hey')), emptyHeader()),
+            row(emptyCell(), emptyCell())
+          ),
+          emptyParagraph()
+        )
+      );
+    });
+
     it('disables block element toolbar buttons when selected', () => {
       insertTable();
 

--- a/cypress/integration/rich-text/RichTextEditor.spec.ts
+++ b/cypress/integration/rich-text/RichTextEditor.spec.ts
@@ -799,6 +799,37 @@ describe('Rich Text Editor', { viewportHeight: 2000 }, () => {
       });
     }
 
+    it('can delete embedded inline entries inside table', () => {
+      insertTable();
+
+      richText.editor.type('hey');
+      cy.findByTestId('toolbar-toggle-embedded-entry-inline').click();
+      richText.editor.type('{backspace}{backspace}'); // one selects, the secodnd deletes it
+
+      richText.expectValue(
+        doc(
+          table(
+            row(header(paragraphWithText('hey')), emptyHeader()),
+            row(emptyCell(), emptyCell())
+          ),
+          emptyParagraph()
+        )
+      );
+    });
+
+    it('does not delete table header cells when selecting the whole table', () => {
+      insertTable();
+
+      richText.editor.type(`hey{${mod}}a{backspace}`);
+
+      richText.expectValue(
+        doc(
+          table(row(emptyHeader(), emptyHeader()), row(emptyCell(), emptyCell())),
+          emptyParagraph()
+        )
+      );
+    });
+
     it('disables block element toolbar buttons when selected', () => {
       insertTable();
 

--- a/packages/rich-text/src/helpers/editor.ts
+++ b/packages/rich-text/src/helpers/editor.ts
@@ -1,5 +1,5 @@
 import { Link } from '@contentful/field-editor-reference/dist/types';
-import { BLOCKS, INLINES, TABLE_BLOCKS } from '@contentful/rich-text-types';
+import { BLOCKS, INLINES } from '@contentful/rich-text-types';
 import {
   EditorNodesOptions,
   getText,
@@ -202,14 +202,6 @@ export function getAncestorPathFromSelection(editor: RichTextEditor) {
 export const isAtEndOfTextSelection = (editor: RichTextEditor) =>
   editor.selection?.focus.offset === getText(editor, editor.selection?.focus.path).length;
 
-export function currentSelectionStartsTableCell(editor: RichTextEditor): boolean {
-  const [tableCellNode, path] = getNodeEntryFromSelection(editor, [
-    BLOCKS.TABLE_CELL,
-    BLOCKS.TABLE_HEADER_CELL,
-  ]);
-  return !!tableCellNode && (!getText(editor, path) || editor.selection?.focus.offset === 0);
-}
-
 /**
  * This traversal strategy is unfortunately necessary because Slate doesn't
  * expose something like Node.next(editor).
@@ -231,14 +223,6 @@ export function getNextNode(editor: RichTextEditor): CustomElement | null {
     }
     return node as CustomElement;
   }
-}
-
-// TODO: move to table plugin
-export function currentSelectionPrecedesTableCell(editor: RichTextEditor): boolean {
-  const nextNode = getNextNode(editor);
-  return (
-    !!nextNode && TABLE_BLOCKS.includes(nextNode.type as BLOCKS) && isAtEndOfTextSelection(editor)
-  );
 }
 
 export const INLINE_TYPES = Object.values(INLINES) as string[];

--- a/packages/rich-text/src/plugins/Table/createTablePlugin.ts
+++ b/packages/rich-text/src/plugins/Table/createTablePlugin.ts
@@ -20,11 +20,7 @@ import {
 } from '@udecode/plate-table';
 import { NodeEntry, Path, Transforms } from 'slate';
 
-import {
-  currentSelectionPrecedesTableCell,
-  currentSelectionStartsTableCell,
-  isRootLevel,
-} from '../../helpers/editor';
+import { isRootLevel } from '../../helpers/editor';
 import { insertEmptyParagraph } from '../../helpers/editor';
 import { transformLift, transformParagraphs, transformWrapIn } from '../../helpers/transformers';
 import { RichTextPlugin, CustomElement, RichTextEditor } from '../../types';
@@ -44,18 +40,6 @@ const createTableOnKeyDown: KeyboardHandler<RichTextEditor, HotkeyPlugin> = (edi
   const defaultHandler = onKeyDownTable(editor, plugin as WithPlatePlugin);
 
   return (event) => {
-    if (
-      (event.key === 'Backspace' && currentSelectionStartsTableCell(editor)) ||
-      (event.key === 'Delete' && currentSelectionPrecedesTableCell(editor))
-    ) {
-      // The default behavior here would be to delete the preceding or forthcoming
-      // leaf node, in this case a cell or header cell. But we don't want to do that,
-      // because it would leave us with a non-standard number of table cells.
-      event.preventDefault();
-      event.stopPropagation();
-      return;
-    }
-
     // This fixes `Cannot resolve a Slate point from DOM point: [object HTMLDivElement]` when typing while the cursor is before table
     const windowSelection = window.getSelection();
     if (windowSelection) {


### PR DESCRIPTION
We no longer need to disable backspace and delete keydown event inside tables after implementing this: https://github.com/contentful/field-editors/pull/1087/files#diff-f91f4d3d54e0f418e12d1ba9ba63a4b90594f3bb7a8a11a4c2137027165287c5R70

This solves a bunch of issues we are currently having with deleting things inside and around tables.