### PR TITLE
fix: change input type to number

### DIFF
--- a/packages/number/src/NumberEditor.spec.tsx
+++ b/packages/number/src/NumberEditor.spec.tsx
@@ -45,7 +45,7 @@ describe('NumberEditor', () => {
     render(<NumberEditor field={field} isInitiallyDisabled={false} />);
     const $input = screen.getByTestId('number-editor-input');
 
-    expect($input).toHaveValue('42');
+    expect($input).toHaveValue(42);
   });
 
   it('calls setValue when user inputs valid numbers', () => {
@@ -83,10 +83,10 @@ describe('NumberEditor', () => {
     render(<NumberEditor field={field} isInitiallyDisabled={false} />);
     const $input = screen.getByTestId('number-editor-input');
 
-    expect($input).toHaveValue('42');
+    expect($input).toHaveValue(42);
 
     userEvent.clear($input);
-    expect($input).toHaveValue('');
+    expect($input).toHaveValue(null);
     expect(field.setValue).not.toHaveBeenCalled();
     expect(field.removeValue).toHaveBeenCalledTimes(1);
     expect(field.removeValue).toHaveBeenLastCalledWith();

--- a/packages/number/src/NumberEditor.tsx
+++ b/packages/number/src/NumberEditor.tsx
@@ -75,9 +75,7 @@ function InnerNumberEditor({
         isInvalid={errors.length > 0}
         isDisabled={disabled}
         value={inputValue}
-        // React cannot call onChange for certain changes to type="number"
-        // so we use "text" instead. See https://github.com/facebook/react/issues/6556
-        type="text"
+        type="number"
         onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
           const parseResult = parseNumber(e.target.value, field.type);
           field.setInvalid(!parseResult.isValid);


### PR DESCRIPTION
it changes the input type to `number` and it is still calling the onChange event, check:

![Screenshot 2022-04-20 at 16 39 33](https://user-images.githubusercontent.com/6597467/164256521-1996193c-b119-44c3-896c-0ed1fce15459.png)
