### PR TITLE
feat: reference hide actions prop [DANTE-488]

### DIFF
--- a/packages/reference/src/common/ReferenceEditor.tsx
+++ b/packages/reference/src/common/ReferenceEditor.tsx
@@ -15,8 +15,8 @@ export interface ReferenceEditorProps {
    */
   isInitiallyDisabled: boolean;
   hasCardEditActions: boolean;
-  hasMoveActions?: boolean;
-  hasRemoveActions?: boolean;
+  hasCardMoveActions?: boolean;
+  hasCardRemoveActions?: boolean;
   sdk: FieldExtensionSDK;
   viewType: ViewType;
   renderCustomCard?: CustomCardRenderer;

--- a/packages/reference/src/common/ReferenceEditor.tsx
+++ b/packages/reference/src/common/ReferenceEditor.tsx
@@ -15,6 +15,8 @@ export interface ReferenceEditorProps {
    */
   isInitiallyDisabled: boolean;
   hasCardEditActions: boolean;
+  hasMoveActions?: boolean;
+  hasRemoveActions?: boolean;
   sdk: FieldExtensionSDK;
   viewType: ViewType;
   renderCustomCard?: CustomCardRenderer;

--- a/packages/reference/src/common/SingleReferenceEditor.tsx
+++ b/packages/reference/src/common/SingleReferenceEditor.tsx
@@ -15,6 +15,7 @@ type ChildProps = {
   allContentTypes: ContentType[];
   renderCustomCard?: ReferenceEditorProps['renderCustomCard'];
   hasCardEditActions: boolean;
+  hasRemoveActions?: boolean;
 };
 
 type EditorProps = ReferenceEditorProps &
@@ -94,4 +95,6 @@ export function SingleReferenceEditor(
 
 SingleReferenceEditor.defaultProps = {
   hasCardEditActions: true,
+  hasMoveActions: true,
+  hasRemoveActions: true,
 };

--- a/packages/reference/src/common/SingleReferenceEditor.tsx
+++ b/packages/reference/src/common/SingleReferenceEditor.tsx
@@ -15,7 +15,7 @@ type ChildProps = {
   allContentTypes: ContentType[];
   renderCustomCard?: ReferenceEditorProps['renderCustomCard'];
   hasCardEditActions: boolean;
-  hasRemoveActions?: boolean;
+  hasCardRemoveActions?: boolean;
 };
 
 type EditorProps = ReferenceEditorProps &
@@ -95,6 +95,5 @@ export function SingleReferenceEditor(
 
 SingleReferenceEditor.defaultProps = {
   hasCardEditActions: true,
-  hasMoveActions: true,
-  hasRemoveActions: true,
+  hasCardRemoveActions: true,
 };

--- a/packages/reference/src/entries/SingleEntryReferenceEditor.tsx
+++ b/packages/reference/src/entries/SingleEntryReferenceEditor.tsx
@@ -12,6 +12,7 @@ export function SingleEntryReferenceEditor(props: ReferenceEditorProps) {
         entityId,
         setValue,
         renderCustomCard,
+        hasRemoveActions,
         hasCardEditActions,
       }) => {
         return (
@@ -22,6 +23,7 @@ export function SingleEntryReferenceEditor(props: ReferenceEditorProps) {
             entryId={entityId}
             renderCustomCard={renderCustomCard}
             hasCardEditActions={hasCardEditActions}
+            hasRemoveActions={hasRemoveActions}
             onRemove={() => {
               setValue(null);
             }}

--- a/packages/reference/src/entries/SingleEntryReferenceEditor.tsx
+++ b/packages/reference/src/entries/SingleEntryReferenceEditor.tsx
@@ -12,7 +12,7 @@ export function SingleEntryReferenceEditor(props: ReferenceEditorProps) {
         entityId,
         setValue,
         renderCustomCard,
-        hasRemoveActions,
+        hasCardRemoveActions,
         hasCardEditActions,
       }) => {
         return (
@@ -23,7 +23,7 @@ export function SingleEntryReferenceEditor(props: ReferenceEditorProps) {
             entryId={entityId}
             renderCustomCard={renderCustomCard}
             hasCardEditActions={hasCardEditActions}
-            hasRemoveActions={hasRemoveActions}
+            hasCardRemoveActions={hasCardRemoveActions}
             onRemove={() => {
               setValue(null);
             }}

--- a/packages/reference/src/entries/WrappedEntryCard/FetchingWrappedEntryCard.tsx
+++ b/packages/reference/src/entries/WrappedEntryCard/FetchingWrappedEntryCard.tsx
@@ -141,13 +141,15 @@ export function FetchingWrappedEntryCard(props: EntryCardReferenceEditorProps) {
       onMoveBottom: props.onMoveBottom,
     };
 
-    const { hasCardEditActions } = props;
+    const { hasCardEditActions, hasMoveActions, hasRemoveActions } = props;
 
     function renderDefaultCard(props?: CustomEntityCardProps) {
       const builtinCardProps: WrappedEntryCardProps = {
         ...sharedCardProps,
         ...props,
-        hasCardEditActions: hasCardEditActions,
+        hasCardEditActions,
+        hasMoveActions,
+        hasRemoveActions,
         getAsset: getOrLoadAsset,
         getEntityScheduledActions: loadEntityScheduledActions,
         entry: props?.entity || sharedCardProps.entity,

--- a/packages/reference/src/entries/WrappedEntryCard/FetchingWrappedEntryCard.tsx
+++ b/packages/reference/src/entries/WrappedEntryCard/FetchingWrappedEntryCard.tsx
@@ -141,15 +141,15 @@ export function FetchingWrappedEntryCard(props: EntryCardReferenceEditorProps) {
       onMoveBottom: props.onMoveBottom,
     };
 
-    const { hasCardEditActions, hasMoveActions, hasRemoveActions } = props;
+    const { hasCardEditActions, hasCardMoveActions, hasCardRemoveActions } = props;
 
     function renderDefaultCard(props?: CustomEntityCardProps) {
       const builtinCardProps: WrappedEntryCardProps = {
         ...sharedCardProps,
         ...props,
         hasCardEditActions,
-        hasMoveActions,
-        hasRemoveActions,
+        hasCardMoveActions,
+        hasCardRemoveActions,
         getAsset: getOrLoadAsset,
         getEntityScheduledActions: loadEntityScheduledActions,
         entry: props?.entity || sharedCardProps.entity,

--- a/packages/reference/src/entries/WrappedEntryCard/WrappedEntryCard.tsx
+++ b/packages/reference/src/entries/WrappedEntryCard/WrappedEntryCard.tsx
@@ -36,15 +36,15 @@ export interface WrappedEntryCardProps {
   onMoveTop?: () => void;
   onMoveBottom?: () => void;
   hasCardEditActions: boolean;
-  hasMoveActions?: boolean;
-  hasRemoveActions?: boolean;
+  hasCardMoveActions?: boolean;
+  hasCardRemoveActions?: boolean;
 }
 
 const defaultProps = {
   isClickable: true,
   hasCardEditActions: true,
-  hasMoveActions: true,
-  hasRemoveActions: true,
+  hasCardMoveActions: true,
+  hasCardRemoveActions: true,
 };
 
 export function WrappedEntryCard(props: WrappedEntryCardProps) {
@@ -138,7 +138,7 @@ export function WrappedEntryCard(props: WrappedEntryCardProps) {
                   Edit
                 </MenuItem>
               ) : null,
-              props.hasRemoveActions && props.onRemove ? (
+              props.hasCardRemoveActions && props.onRemove ? (
                 <MenuItem
                   key="delete"
                   testId="delete"
@@ -148,15 +148,15 @@ export function WrappedEntryCard(props: WrappedEntryCardProps) {
                   Remove
                 </MenuItem>
               ) : null,
-              props.hasMoveActions && (props.onMoveTop || props.onMoveBottom) ? (
+              props.hasCardMoveActions && (props.onMoveTop || props.onMoveBottom) ? (
                 <MenuDivider />
               ) : null,
-              props.hasMoveActions && props.onMoveTop ? (
+              props.hasCardMoveActions && props.onMoveTop ? (
                 <MenuItem onClick={() => props.onMoveTop && props.onMoveTop()} testId="move-top">
                   Move to top
                 </MenuItem>
               ) : null,
-              props.hasMoveActions && props.onMoveBottom ? (
+              props.hasCardMoveActions && props.onMoveBottom ? (
                 <MenuItem
                   onClick={() => props.onMoveBottom && props.onMoveBottom()}
                   testId="move-bottom">

--- a/packages/reference/src/entries/WrappedEntryCard/WrappedEntryCard.tsx
+++ b/packages/reference/src/entries/WrappedEntryCard/WrappedEntryCard.tsx
@@ -33,16 +33,18 @@ export interface WrappedEntryCardProps {
   entry: Entry;
   renderDragHandle?: RenderDragFn;
   isClickable?: boolean;
-  hasCardEditActions: boolean;
   onMoveTop?: () => void;
   onMoveBottom?: () => void;
-  hasMoveOptions?: boolean;
+  hasCardEditActions: boolean;
+  hasMoveActions?: boolean;
+  hasRemoveActions?: boolean;
 }
 
 const defaultProps = {
   isClickable: true,
   hasCardEditActions: true,
-  hasMoveOptions: true,
+  hasMoveActions: true,
+  hasRemoveActions: true,
 };
 
 export function WrappedEntryCard(props: WrappedEntryCardProps) {
@@ -136,7 +138,7 @@ export function WrappedEntryCard(props: WrappedEntryCardProps) {
                   Edit
                 </MenuItem>
               ) : null,
-              props.onRemove ? (
+              props.hasRemoveActions && props.onRemove ? (
                 <MenuItem
                   key="delete"
                   testId="delete"
@@ -146,15 +148,15 @@ export function WrappedEntryCard(props: WrappedEntryCardProps) {
                   Remove
                 </MenuItem>
               ) : null,
-              props.hasMoveOptions && (props.onMoveTop || props.onMoveBottom) ? (
+              props.hasMoveActions && (props.onMoveTop || props.onMoveBottom) ? (
                 <MenuDivider />
               ) : null,
-              props.hasMoveOptions && props.onMoveTop ? (
+              props.hasMoveActions && props.onMoveTop ? (
                 <MenuItem onClick={() => props.onMoveTop && props.onMoveTop()} testId="move-top">
                   Move to top
                 </MenuItem>
               ) : null,
-              props.hasMoveOptions && props.onMoveBottom ? (
+              props.hasMoveActions && props.onMoveBottom ? (
                 <MenuItem
                   onClick={() => props.onMoveBottom && props.onMoveBottom()}
                   testId="move-bottom">


### PR DESCRIPTION
Expose two props `hasRemoveActions` and `hasMoveActions ` in `MultipleEntryReferenceEditor` and one prop `hasRemoveActions` in `SingleEntryReferenceEditor` to be able to hide the actions menu completely.
This is to fix a bug when a user without editing permissions could still open the actions menu in the web app.