### PR TITLE
fix(EmbedAsset): always assume that assets are available for linking [HOMER-829]

### DIFF
--- a/packages/rich-text/src/Toolbar/components/EmbedEntityWidget.tsx
+++ b/packages/rich-text/src/Toolbar/components/EmbedEntityWidget.tsx
@@ -23,19 +23,22 @@ export const EmbedEntityWidget = ({ isDisabled, canInsertBlocks }: EmbedEntityWi
   const onCloseEntityDropdown = () => setEmbedDropdownOpen(false);
   const onToggleEntityDropdown = () => setEmbedDropdownOpen(!isEmbedDropdownOpen);
 
-  const [canAccessAssets, setCanAccessAssets] = useState(false);
-  React.useEffect(() => {
-    let subscribed = true;
-    sdk.access.can('read', 'Asset').then((can) => {
-      if (!subscribed) {
-        return;
-      }
-      setCanAccessAssets(can);
-    });
-    return () => {
-      subscribed = false;
-    };
-  }, [sdk]);
+  // Hardcoded `true` value following https://contentful.atlassian.net/browse/DANTE-486
+  // TODO: refine permissions check in order to account for tags in rules
+  const [canAccessAssets, setCanAccessAssets] = useState(true);
+  // React.useEffect(() => {
+  //   let subscribed = true;
+  //   // TODO: See comment above about hardcoded `true` value
+  //   sdk.access.can('read', 'Asset').then((can) => {
+  //     if (!subscribed) {
+  //       return;
+  //     }
+  //     setCanAccessAssets(can);
+  //   });
+  //   return () => {
+  //     subscribed = false;
+  //   };
+  // }, [sdk]);
 
   const inlineEntryEmbedEnabled = isNodeTypeEnabled(sdk.field, INLINES.EMBEDDED_ENTRY);
   const blockEntryEmbedEnabled =

--- a/packages/rich-text/src/Toolbar/components/EmbedEntityWidget.tsx
+++ b/packages/rich-text/src/Toolbar/components/EmbedEntityWidget.tsx
@@ -25,20 +25,20 @@ export const EmbedEntityWidget = ({ isDisabled, canInsertBlocks }: EmbedEntityWi
 
   // Hardcoded `true` value following https://contentful.atlassian.net/browse/DANTE-486
   // TODO: refine permissions check in order to account for tags in rules
-  const [canAccessAssets, setCanAccessAssets] = useState(true);
-  // React.useEffect(() => {
-  //   let subscribed = true;
-  //   // TODO: See comment above about hardcoded `true` value
-  //   sdk.access.can('read', 'Asset').then((can) => {
-  //     if (!subscribed) {
-  //       return;
-  //     }
-  //     setCanAccessAssets(can);
-  //   });
-  //   return () => {
-  //     subscribed = false;
-  //   };
-  // }, [sdk]);
+  const [canAccessAssets] = useState(true);
+  React.useEffect(() => {
+    let subscribed = true;
+    // TODO: See comment above about hardcoded `true` value, still we call `access.can` for monitoring reasons
+    sdk.access.can('read', 'Asset').then(() => {
+      if (!subscribed) {
+        return;
+      }
+      // setCanAccessAssets(can);
+    });
+    return () => {
+      subscribed = false;
+    };
+  }, [sdk]);
 
   const inlineEntryEmbedEnabled = isNodeTypeEnabled(sdk.field, INLINES.EMBEDDED_ENTRY);
   const blockEntryEmbedEnabled =

--- a/packages/rich-text/src/Toolbar/components/EmbedEntityWidget.tsx
+++ b/packages/rich-text/src/Toolbar/components/EmbedEntityWidget.tsx
@@ -23,28 +23,13 @@ export const EmbedEntityWidget = ({ isDisabled, canInsertBlocks }: EmbedEntityWi
   const onCloseEntityDropdown = () => setEmbedDropdownOpen(false);
   const onToggleEntityDropdown = () => setEmbedDropdownOpen(!isEmbedDropdownOpen);
 
-  // Hardcoded `true` value following https://contentful.atlassian.net/browse/DANTE-486
-  // TODO: refine permissions check in order to account for tags in rules
-  const [canAccessAssets] = useState(true);
-  React.useEffect(() => {
-    let subscribed = true;
-    // TODO: See comment above about hardcoded `true` value, still we call `access.can` for monitoring reasons
-    sdk.access.can('read', 'Asset').then(() => {
-      if (!subscribed) {
-        return;
-      }
-      // setCanAccessAssets(can);
-    });
-    return () => {
-      subscribed = false;
-    };
-  }, [sdk]);
-
   const inlineEntryEmbedEnabled = isNodeTypeEnabled(sdk.field, INLINES.EMBEDDED_ENTRY);
   const blockEntryEmbedEnabled =
     isNodeTypeEnabled(sdk.field, BLOCKS.EMBEDDED_ENTRY) && canInsertBlocks;
+  // Removed access check following https://contentful.atlassian.net/browse/DANTE-486
+  // TODO: refine permissions check in order to account for tags in rules and then readd access.can('read', 'Asset')
   const blockAssetEmbedEnabled =
-    canAccessAssets && isNodeTypeEnabled(sdk.field, BLOCKS.EMBEDDED_ASSET) && canInsertBlocks;
+    isNodeTypeEnabled(sdk.field, BLOCKS.EMBEDDED_ASSET) && canInsertBlocks;
 
   const numEnabledEmbeds = [
     inlineEntryEmbedEnabled,


### PR DESCRIPTION
Same issue as [here](https://github.com/contentful/field-editors/blob/master/packages/reference/src/common/useEditorPermissions.ts#L49-L62): Tag-based permissions break the access evaluation. We assume that one can always link assets as fallback solution.