### PR TITLE
fix(rich-text): don't disable "Edit" actions on embeds

### DIFF
--- a/packages/rich-text/src/plugins/EmbeddedEntityInline/FetchingWrappedInlineEntryCard.tsx
+++ b/packages/rich-text/src/plugins/EmbeddedEntityInline/FetchingWrappedInlineEntryCard.tsx
@@ -107,7 +107,7 @@ export function FetchingWrappedInlineEntryCard(props: FetchingWrappedInlineEntry
       title={`${contentTypeName}: ${title}`}
       status={status}
       actions={[
-        <MenuItem key="edit" onClick={props.onEdit} disabled={props.isDisabled}>
+        <MenuItem key="edit" onClick={props.onEdit}>
           Edit
         </MenuItem>,
         <MenuItem

--- a/packages/rich-text/src/plugins/shared/FetchingWrappedAssetCard.tsx
+++ b/packages/rich-text/src/plugins/shared/FetchingWrappedAssetCard.tsx
@@ -89,7 +89,7 @@ export function renderActions(props: {
   return [
     <Menu.SectionTitle key="section-title">Actions</Menu.SectionTitle>,
     onEdit ? (
-      <Menu.Item key="edit" disabled={isDisabled} onClick={onEdit} testId="card-action-edit">
+      <Menu.Item key="edit" onClick={onEdit} testId="card-action-edit">
         Edit
       </Menu.Item>
     ) : null,

--- a/packages/rich-text/src/plugins/shared/FetchingWrappedEntryCard.tsx
+++ b/packages/rich-text/src/plugins/shared/FetchingWrappedEntryCard.tsx
@@ -91,7 +91,6 @@ export function FetchingWrappedEntryCard(props: FetchingWrappedEntryCardProps) {
       props.onEdit ? (
         <MenuItem
           key="edit"
-          disabled={props.isDisabled}
           testId="card-action-edit"
           onClick={() => {
             props.onEdit && props.onEdit();

--- a/packages/rich-text/src/plugins/shared/__tests__/FetchingWrappedAssetCard.test.tsx
+++ b/packages/rich-text/src/plugins/shared/__tests__/FetchingWrappedAssetCard.test.tsx
@@ -28,7 +28,7 @@ beforeEach(() => {
   };
 });
 
-test('dropdown actions should be disabled', async () => {
+test('some dropdown actions should be disabled', async () => {
   const { getByTestId } = render(
     <EntityProvider sdk={sdk}>
       <FetchingWrappedAssetCard
@@ -51,7 +51,7 @@ test('dropdown actions should be disabled', async () => {
   fireEvent.click(getByTestId('cf-ui-card-actions'));
 
   await waitFor(() => {
-    expect(getByTestId('card-action-edit')).toBeDisabled();
+    expect(getByTestId('card-action-edit')).not.toBeDisabled();
     expect(getByTestId('card-action-remove')).toBeDisabled();
     expect(getByTestId('card-action-download')).not.toBeDisabled();
   });

--- a/packages/rich-text/src/plugins/shared/__tests__/FetchingWrappedEntryCard.test.tsx
+++ b/packages/rich-text/src/plugins/shared/__tests__/FetchingWrappedEntryCard.test.tsx
@@ -30,7 +30,7 @@ beforeEach(() => {
   };
 });
 
-test('dropdown actions should be disabled', async () => {
+test('some dropdown actions should be disabled', async () => {
   const { getByTestId } = render(
     <EntityProvider sdk={sdk}>
       <FetchingWrappedEntryCard
@@ -53,7 +53,7 @@ test('dropdown actions should be disabled', async () => {
   fireEvent.click(getByTestId('cf-ui-card-actions'));
 
   await waitFor(() => {
-    expect(getByTestId('card-action-edit')).toBeDisabled();
+    expect(getByTestId('card-action-edit')).not.toBeDisabled();
     expect(getByTestId('card-action-remove')).toBeDisabled();
   });
 });


### PR DESCRIPTION
Users should still be able to edit (or view) embedded entities when the RT editor is disabled.