### PR TITLE
fix: reflect disabled state on fields

### DIFF
--- a/packages/json/src/JsonEditoField.tsx
+++ b/packages/json/src/JsonEditoField.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import tokens from '@contentful/f36-tokens';
-import { css } from 'emotion';
+import { css, cx } from 'emotion';
 import { Controlled as CodeMirror } from 'react-codemirror2';
 
 const CODE_MIRROR_CONFIG = {
@@ -61,7 +61,7 @@ const styles = {
 export function JsonEditorField(props: JsonEditorFieldProps) {
   return (
     <div
-      className={`${styles.root} ${props.isDisabled ? 'disabled' : ''}`}
+      className={cx(styles.root, { disabled: props.isDisabled })}
       data-test-id="json-editor-code-mirror">
       <CodeMirror
         value={props.value}

--- a/packages/json/src/JsonEditoField.tsx
+++ b/packages/json/src/JsonEditoField.tsx
@@ -38,12 +38,31 @@ const styles = {
     '.CodeMirror-scroll': {
       minHeight: '6rem',
     },
+    '&.disabled': {
+      cursor: 'auto',
+      '.CodeMirror-scroll ': {
+        minHeight: '6rem',
+        backgroundColor: tokens.gray100,
+        cursor: 'not-allowed',
+      },
+      '.react-codemirror2': {
+        border: `1px solid ${tokens.gray200}`,
+      },
+      '.CodeMirror-line': {
+        cursor: 'not-allowed',
+      },
+      '.CodeMirror-lines': {
+        cursor: 'not-allowed',
+      },
+    },
   }),
 };
 
 export function JsonEditorField(props: JsonEditorFieldProps) {
   return (
-    <div className={styles.root} data-test-id="json-editor-code-mirror">
+    <div
+      className={`${styles.root} ${props.isDisabled ? 'disabled' : ''}`}
+      data-test-id="json-editor-code-mirror">
       <CodeMirror
         value={props.value}
         onBeforeChange={(_editor, _data, value) => {
@@ -51,7 +70,7 @@ export function JsonEditorField(props: JsonEditorFieldProps) {
         }}
         options={{
           ...CODE_MIRROR_CONFIG,
-          readOnly: props.isDisabled,
+          readOnly: props.isDisabled ? 'nocursor' : false,
         }}
       />
     </div>

--- a/packages/location/src/GoogleMapView.tsx
+++ b/packages/location/src/GoogleMapView.tsx
@@ -48,6 +48,8 @@ export class GoogleMapView extends React.Component<GoogleMapViewProps, GoogleMap
       } else {
         this.state.marker.setVisible(false);
       }
+      this.state.marker.setDraggable(!this.props.disabled);
+      this.state.marker.setCursor(this.props.disabled ? 'not-allowed' : 'auto');
     }
   }
 
@@ -56,7 +58,8 @@ export class GoogleMapView extends React.Component<GoogleMapViewProps, GoogleMap
     const marker = new maps.Marker({
       map,
       position: map.getCenter(),
-      draggable: true,
+      cursor: this.props.disabled ? 'not-allowed' : 'auto',
+      draggable: !this.props.disabled,
       visible: Boolean(this.props.location),
     });
 

--- a/packages/markdown/src/components/MarkdownTextarea/MarkdownTextarea.tsx
+++ b/packages/markdown/src/components/MarkdownTextarea/MarkdownTextarea.tsx
@@ -102,9 +102,15 @@ const styles = {
   disabled: css`
     .CodeMirror {
       background: ${tokens.gray100};
+      cursor: 'not-allowed';
     }
     .CodeMirror-cursors {
       visibility: hidden !important;
+    }
+    .CodeMirror-scroll,
+    .CodeMirror-sizer,
+    .CodeMirror-lines {
+      cursor: not-allowed;
     }
   `,
 };

--- a/packages/radio/src/RadioEditor.tsx
+++ b/packages/radio/src/RadioEditor.tsx
@@ -75,7 +75,11 @@ export function RadioEditor(props: RadioEditorProps) {
                     {item.label}
                   </Radio>
                   {checked && (
-                    <TextLink as="button" className={styles.clearBtn} onClick={clearOption}>
+                    <TextLink
+                      as="button"
+                      className={styles.clearBtn}
+                      onClick={clearOption}
+                      isDisabled={disabled}>
                       Clear
                     </TextLink>
                   )}

--- a/packages/radio/src/RadioEditor.tsx
+++ b/packages/radio/src/RadioEditor.tsx
@@ -74,12 +74,8 @@ export function RadioEditor(props: RadioEditorProps) {
                     }}>
                     {item.label}
                   </Radio>
-                  {checked && (
-                    <TextLink
-                      as="button"
-                      className={styles.clearBtn}
-                      onClick={clearOption}
-                      isDisabled={disabled}>
+                  {checked && !disabled && (
+                    <TextLink as="button" className={styles.clearBtn} onClick={clearOption}>
                       Clear
                     </TextLink>
                   )}

--- a/packages/rich-text/src/RichTextEditor.jsx
+++ b/packages/rich-text/src/RichTextEditor.jsx
@@ -64,6 +64,7 @@ const styles = {
   }),
   disabled: css({
     background: tokens.gray100,
+    cursor: 'not-allowed',
   }),
 };
 

--- a/packages/tags/src/TagsEditor.tsx
+++ b/packages/tags/src/TagsEditor.tsx
@@ -145,9 +145,12 @@ export function TagsEditor(props: TagsEditorProps) {
               label={item}
               index={index}
               key={item + index}
-              // disabled goes for SortableElement
               disabled={isDisabled}
-              // isDisabled goes for SortablePill
+              /**
+               * `isSortablePillDisabled` is needed as SortableElement
+               * from react-sortable-hoc doesn't pass down the disabled prop.
+               * See: https://github.com/clauderic/react-sortable-hoc/issues/612
+               */
               isSortablePillDisabled={isDisabled}
               onRemove={() => {
                 removeItem(index);

--- a/packages/tags/src/TagsEditor.tsx
+++ b/packages/tags/src/TagsEditor.tsx
@@ -1,6 +1,6 @@
 import noop from 'lodash/noop';
 import React, { useState, useCallback } from 'react';
-import { css } from 'emotion';
+import { css, cx } from 'emotion';
 import tokens from '@contentful/f36-tokens';
 import { TagsEditorConstraints } from './TagsEditorConstraints';
 import { ConstraintsType, Constraint } from './types';
@@ -56,7 +56,7 @@ const styles = {
 };
 
 const SortablePillHandle = SortableHandle((props: { isDisabled: boolean }) => (
-  <div className={`${styles.handle} ${props.isDisabled ? styles.pillDisabled : ''}`}>
+  <div className={cx(styles.handle, { [styles.pillDisabled]: props.isDisabled })}>
     <DragIcon variant="muted" />
   </div>
 ));
@@ -71,7 +71,7 @@ interface SortablePillProps {
 const SortablePill = SortableElement((props: SortablePillProps) => (
   <Pill
     testId="tag-editor-pill"
-    className={`${styles.pill} ${props.isSortablePillDisabled ? styles.pillDisabled : ''}`}
+    className={cx(styles.pill, { [styles.pillDisabled]: props.isSortablePillDisabled })}
     label={props.label}
     onClose={() => {
       if (!props.isSortablePillDisabled) {

--- a/packages/tags/src/TagsEditor.tsx
+++ b/packages/tags/src/TagsEditor.tsx
@@ -34,6 +34,14 @@ const styles = {
     marginRight: tokens.spacingS,
     marginBottom: tokens.spacingS,
   }),
+  pillDisabled: css({
+    cursor: 'not-allowed !important',
+    button: {
+      cursor: 'not-allowed !important',
+      // instead of changing the @contentful/f36-components package
+      pointerEvents: 'none',
+    },
+  }),
   handle: css({
     lineHeight: '1.5rem',
     padding: '0.375rem 0.625rem',
@@ -47,8 +55,8 @@ const styles = {
   }),
 };
 
-const SortablePillHandle = SortableHandle(() => (
-  <div className={styles.handle}>
+const SortablePillHandle = SortableHandle((props: { isDisabled: boolean }) => (
+  <div className={`${styles.handle} ${props.isDisabled ? styles.pillDisabled : ''}`}>
     <DragIcon variant="muted" />
   </div>
 ));
@@ -56,22 +64,22 @@ const SortablePillHandle = SortableHandle(() => (
 interface SortablePillProps {
   label: string;
   onRemove: Function;
-  disabled: boolean;
+  isSortablePillDisabled: boolean;
   index: number;
 }
 
 const SortablePill = SortableElement((props: SortablePillProps) => (
   <Pill
     testId="tag-editor-pill"
-    className={styles.pill}
+    className={`${styles.pill} ${props.isSortablePillDisabled ? styles.pillDisabled : ''}`}
     label={props.label}
     onClose={() => {
-      if (!props.disabled) {
+      if (!props.isSortablePillDisabled) {
         props.onRemove(props.index);
       }
     }}
     onDrag={noop}
-    dragHandleComponent={<SortablePillHandle />}
+    dragHandleComponent={<SortablePillHandle isDisabled={props.isSortablePillDisabled} />}
   />
 ));
 
@@ -137,7 +145,10 @@ export function TagsEditor(props: TagsEditorProps) {
               label={item}
               index={index}
               key={item + index}
+              // disabled goes for SortableElement
               disabled={isDisabled}
+              // isDisabled goes for SortablePill
+              isSortablePillDisabled={isDisabled}
               onRemove={() => {
                 removeItem(index);
               }}


### PR DESCRIPTION
Some field editors do not look disabled when you disable them (by setting `isInitiallyDisabled` to true)

- JSON ( looks the same but you can’t edit )
- Rich text ( the courser is not `not-allowed` )
- Mark down ( the courser is not `not-allowed` )

Even after passing `isInitiallyDisabled` as `true`  you can still edit/delete or add values to these fields 

- Map editor (you can still change the marker location (edit))
- Radio (you can click the clear button )
- Tags (you can still delete tags and the courser is not `not-allowed` )

## Related PRs

https://github.com/contentful/field-editors/pull/1128