### PR TITLE
fix(rich-text): allow hyperlink viewing in readonly mode

### DIFF
--- a/packages/rich-text/src/plugins/Hyperlink/components/EntityHyperlink.tsx
+++ b/packages/rich-text/src/plugins/Hyperlink/components/EntityHyperlink.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import { FieldExtensionSDK, Link } from '@contentful/app-sdk';
 import { Tooltip, TextLink } from '@contentful/f36-components';
-import { ReactEditor, useReadOnly } from 'slate-react';
+import { ReactEditor } from 'slate-react';
 
 import { useContentfulEditor } from '../../../ContentfulEditorProvider';
 import { useSdkContext } from '../../../SdkProvider';
@@ -19,7 +19,6 @@ type HyperlinkElementProps = CustomRenderElementProps<{
 
 export function EntityHyperlink(props: HyperlinkElementProps) {
   const editor = useContentfulEditor();
-  const isReadOnly = useReadOnly();
   const sdk: FieldExtensionSDK = useSdkContext();
   const { target } = props.element.data;
   const { onEntityFetchComplete } = props;
@@ -52,7 +51,6 @@ export function EntityHyperlink(props: HyperlinkElementProps) {
       <TextLink
         as="a"
         onClick={handleClick}
-        isDisabled={isReadOnly}
         className={styles.hyperlink}
         data-link-type={target.sys.linkType}
         data-link-id={target.sys.id}>

--- a/packages/rich-text/src/plugins/Hyperlink/components/UrlHyperlink.tsx
+++ b/packages/rich-text/src/plugins/Hyperlink/components/UrlHyperlink.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import { FieldExtensionSDK, Link } from '@contentful/app-sdk';
 import { Tooltip, TextLink } from '@contentful/f36-components';
-import { ReactEditor, useReadOnly } from 'slate-react';
+import { ReactEditor } from 'slate-react';
 
 import { useContentfulEditor } from '../../../ContentfulEditorProvider';
 import { useSdkContext } from '../../../SdkProvider';
@@ -18,7 +18,6 @@ type HyperlinkElementProps = CustomRenderElementProps<{
 
 export function UrlHyperlink(props: HyperlinkElementProps) {
   const editor = useContentfulEditor();
-  const isReadOnly = useReadOnly();
   const sdk: FieldExtensionSDK = useSdkContext();
   const { uri } = props.element.data;
 
@@ -44,7 +43,6 @@ export function UrlHyperlink(props: HyperlinkElementProps) {
         href={uri}
         rel="noopener noreferrer"
         onClick={handleClick}
-        isDisabled={isReadOnly}
         className={styles.hyperlink}>
         {props.children}
       </TextLink>


### PR DESCRIPTION
Instead of completely disabling hyperlinks in the read-only mode allow users to open the modal in a non-editable state instead.