### PR TITLE
fix: add not allowed cursor to the disabled rich text editor

### DIFF
--- a/packages/rich-text/src/RichTextEditor.styles.ts
+++ b/packages/rich-text/src/RichTextEditor.styles.ts
@@ -49,5 +49,6 @@ export const styles = {
   }),
   disabled: css({
     background: tokens.gray100,
+    cursor: 'not-allowed',
   }),
 };


### PR DESCRIPTION
Adding `not-allowed` cursor to the disabled rich text editor

## Related PRs

https://github.com/contentful/field-editors/pull/1125