### PR TITLE
fix: avoid disabling button if no creatable content type []

### DIFF
--- a/packages/reference/src/components/CreateEntryLinkButton/CreateEntryLinkButton.tsx
+++ b/packages/reference/src/components/CreateEntryLinkButton/CreateEntryLinkButton.tsx
@@ -82,7 +82,7 @@ export const CreateEntryLinkButton = ({
           endIcon={hasDropdown ? <ChevronDownIcon /> : undefined}
           variant="secondary"
           className={styles.action}
-          isDisabled={disabled || isSelecting || (contentTypes && contentTypes.length === 0)}
+          isDisabled={disabled || isSelecting} // (contentTypes && contentTypes.length === 0)}
           startIcon={isSelecting ? undefined : plusIcon}
           size="small"
           testId="create-entry-link-button"


### PR DESCRIPTION
The add content button is disable if it receives no creatable content types, but there might still be readable one for the "link existing" option