### PR TITLE
fix: only show readable / creatable CTs in reference field editor [ZEND-2154]

### DIFF
--- a/packages/reference/src/components/LinkActions/LinkEntityActions.tsx
+++ b/packages/reference/src/components/LinkActions/LinkEntityActions.tsx
@@ -88,6 +88,7 @@ export function useLinkActionsProps(props: LinkEntityActionsProps): LinkActionsP
     [sdk, entityType, onCreated]
   );
 
+  // Wrapping these two with useCallback caused a bug [ZEND-2154] where CTs were not propagated to the UI at all
   const onLinkExisting = async (index?: number) => {
     const entity = await selectSingleEntity({
       sdk,
@@ -113,7 +114,8 @@ export function useLinkActionsProps(props: LinkEntityActionsProps): LinkActionsP
     }
     onLinkedExisting(entities, index);
   };
-
+  
+  // FIXME: The memoization might rerun every time due to the always changing callback identities above 
   return useMemo(
     () => ({
       entityType,

--- a/packages/reference/src/components/LinkActions/LinkEntityActions.tsx
+++ b/packages/reference/src/components/LinkActions/LinkEntityActions.tsx
@@ -88,37 +88,31 @@ export function useLinkActionsProps(props: LinkEntityActionsProps): LinkActionsP
     [sdk, entityType, onCreated]
   );
 
-  const onLinkExisting = React.useCallback(
-    async (index?: number) => {
-      const entity = await selectSingleEntity({
-        sdk,
-        entityType,
-        editorPermissions,
-      });
-      if (!entity) {
-        return;
-      }
+  const onLinkExisting = async (index?: number) => {
+    const entity = await selectSingleEntity({
+      sdk,
+      entityType,
+      editorPermissions,
+    });
+    if (!entity) {
+      return;
+    }
 
-      onLinkedExisting([entity], index);
-    },
-    [sdk, entityType, onLinkedExisting]
-  );
+    onLinkedExisting([entity], index);
+  };
 
-  const onLinkSeveralExisting = React.useCallback(
-    async (index?: number) => {
-      const entities = await selectMultipleEntities({
-        sdk,
-        entityType,
-        editorPermissions,
-      });
+  const onLinkSeveralExisting = async (index?: number) => {
+    const entities = await selectMultipleEntities({
+      sdk,
+      entityType,
+      editorPermissions,
+    });
 
-      if (!entities || entities.length === 0) {
-        return;
-      }
-      onLinkedExisting(entities, index);
-    },
-    [sdk, entityType, onLinkedExisting]
-  );
+    if (!entities || entities.length === 0) {
+      return;
+    }
+    onLinkedExisting(entities, index);
+  };
 
   return useMemo(
     () => ({


### PR DESCRIPTION
## Purpose

The `useCallback` prevented updating the creatable / readable CTs since we resolve them asynchronously. Actual readable / creatable CTs were never propagated to the UI.