### PR TITLE
fix(rich-text): sanitize slate content

### DIFF
--- a/cypress/integration/rich-text/RichTextEditor.spec.ts
+++ b/cypress/integration/rich-text/RichTextEditor.spec.ts
@@ -1687,6 +1687,73 @@ describe('Rich Text Editor', { viewportHeight: 2000 }, () => {
       richText.expectValue(doc(paragraphWithText('it works')));
     });
 
+    it('does not crash when an empty link is followed by a list', () => {
+      const exampleDoc = {
+        data: {},
+        content: [
+          {
+            data: {},
+            content: [
+              {
+                data: {
+                  uri: 'https://example.com',
+                },
+                content: [],
+                nodeType: 'hyperlink',
+              },
+            ],
+            nodeType: 'paragraph',
+          },
+          {
+            data: {},
+            content: [
+              {
+                data: {},
+                content: [
+                  {
+                    data: {},
+                    content: [
+                      {
+                        data: {},
+                        marks: [],
+                        value: 'some text',
+                        nodeType: 'text',
+                      },
+                      {
+                        data: {},
+                        marks: [],
+                        value: ' more text',
+                        nodeType: 'text',
+                      },
+                    ],
+                    nodeType: 'paragraph',
+                  },
+                ],
+                nodeType: 'list-item',
+              },
+            ],
+            nodeType: 'unordered-list',
+          },
+        ],
+        nodeType: 'document',
+      };
+
+      cy.setInitialValue(exampleDoc);
+
+      cy.reload();
+
+      // The field value in this case will still be untouched (i.e. un-normalized)
+      // since we won't trigger onChange.
+      richText.expectValue(exampleDoc);
+
+      // Initial normalization should not invoke onChange
+      cy.editorEvents()
+        .then((events) => events.filter((e) => e.type === 'onValueChanged'))
+        .should('deep.equal', []);
+
+      cy.findByText('some text more text');
+    });
+
     it('runs initial normalization without triggering a value change', () => {
       cy.setInitialValue(invalidDocumentNormalizable);
 

--- a/packages/rich-text/src/helpers/sanitizeIncomingSlateDoc.ts
+++ b/packages/rich-text/src/helpers/sanitizeIncomingSlateDoc.ts
@@ -1,0 +1,25 @@
+import { CustomText, TextOrCustomElement } from '../types';
+
+const isTextElement = (node: TextOrCustomElement): node is CustomText => 'text' in node;
+
+/**
+ * Ensures all nodes have a child leaf text element. This should be handled by
+ * Slate but its behavior has proven to be buggy and unpredictable.
+ */
+export function sanitizeIncomingSlateDoc(nodes: TextOrCustomElement[] = []): TextOrCustomElement[] {
+  return nodes.map((node: TextOrCustomElement): TextOrCustomElement => {
+    if (isTextElement(node)) {
+      return node;
+    }
+    if (node.children?.length === 0) {
+      return {
+        ...node,
+        children: [{ text: '', data: {} }],
+      };
+    }
+    return {
+      ...node,
+      children: sanitizeIncomingSlateDoc(node.children),
+    };
+  });
+}

--- a/packages/rich-text/src/prepareDocument.ts
+++ b/packages/rich-text/src/prepareDocument.ts
@@ -5,6 +5,7 @@ import { Descendant, Editor, Node, Transforms } from 'slate';
 import { RichTextEditor } from 'types';
 
 import schema from './constants/Schema';
+import { sanitizeIncomingSlateDoc } from './helpers/sanitizeIncomingSlateDoc';
 
 /**
  * For legacy reasons, a document may not have any content at all
@@ -47,15 +48,17 @@ export const setEditorContent = (editor: Editor, nodes?: Node[]): void => {
 };
 
 /**
- * Converts a contenful rich text document to the corresponding slate editor
+ * Converts a Contentful rich text document to the corresponding slate editor
  * value
  */
 export const documentToEditorValue = (doc: any) => {
-  return toSlatejsDocument({
+  const slateDoc = toSlatejsDocument({
     document: hasContent(doc) ? doc : EMPTY_DOCUMENT,
     // TODO: get rid of schema, https://github.com/contentful/field-editors/pull/1065#discussion_r826723248
     schema,
   });
+
+  return sanitizeIncomingSlateDoc(slateDoc);
 };
 
 export const normalizeEditorValue = (


### PR DESCRIPTION
We rely on initial normalization to prevent crashes when we find e.g. hyperlink without children, however, Slate still crashes in some cases (when attempting to do the normalization) and complains about empty nodes (nodes without text).

In this particular case, having an empty hyperlink is fine (i.e. handled by the normalization) but the editor crashes as soon as that link is followed by a list with exactly two text nodes 🤷🏻‍♂️ 

This PR brings back the old `santizeIncomingSlateDoc` helper 😞 as it seems the most reliable way we got to prevent such errors.