### PR TITLE
fix: increased time input width in date picker to fix visual bug [TOL-122]

### DIFF
--- a/packages/date/src/TimepickerInput.tsx
+++ b/packages/date/src/TimepickerInput.tsx
@@ -83,7 +83,7 @@ export const TimepickerInput = ({
   };
 
   return (
-    <Flex className={css({ width: '140px' })}>
+    <Flex className={css({ width: '145px' })}>
       <TextInput
         aria-label="Select time"
         placeholder={uses12hClock ? '12:00 AM' : '00:00'}


### PR DESCRIPTION
Before:
<img width="790" alt="image" src="https://user-images.githubusercontent.com/101652314/169774199-0d31fd8c-245f-42e0-91f5-6988cabdc0d0.png">


After: 
<img width="780" alt="image" src="https://user-images.githubusercontent.com/101652314/169774141-04c04d89-0a31-48d3-8c5e-7e22a831635a.png">
