### PR TITLE
fix: remove space between tags [TOL-104]

### DIFF
--- a/cypress/integration/rich-text/RichTextEditor.Tracking.spec.ts
+++ b/cypress/integration/rich-text/RichTextEditor.Tracking.spec.ts
@@ -123,7 +123,7 @@ describe('Rich Text Editor - Tracking', { viewportHeight: 2000 }, () => {
 
       richText.expectTrackingValue([
         action('paste', 'shortcut', {
-          characterCountAfter: 14,
+          characterCountAfter: 11,
           characterCountBefore: 0,
           characterCountSelection: 0,
           source: 'Apple Notes',

--- a/cypress/integration/rich-text/__snapshots__/RichTextEditor.Pasting.spec.ts.snap
+++ b/cypress/integration/rich-text/__snapshots__/RichTextEditor.Pasting.spec.ts.snap
@@ -2172,7 +2172,7 @@ exports[`Rich Text Editor > Microsoft Word (.docx) deserialization > unordered l
                   "data": {},
                   "marks": [],
                   "nodeType": "text",
-                  "value": "This"
+                  "value": "This "
                 }
               ],
               "data": {},
@@ -2190,7 +2190,7 @@ exports[`Rich Text Editor > Microsoft Word (.docx) deserialization > unordered l
                   "data": {},
                   "marks": [],
                   "nodeType": "text",
-                  "value": "Is"
+                  "value": "Is "
                 }
               ],
               "data": {},
@@ -2208,7 +2208,7 @@ exports[`Rich Text Editor > Microsoft Word (.docx) deserialization > unordered l
                   "data": {},
                   "marks": [],
                   "nodeType": "text",
-                  "value": "A list"
+                  "value": "A list "
                 }
               ],
               "data": {},
@@ -2252,7 +2252,7 @@ exports[`Rich Text Editor > Microsoft Word (.docx) deserialization > ordered lis
                   "data": {},
                   "marks": [],
                   "nodeType": "text",
-                  "value": "This is"
+                  "value": "This is "
                 }
               ],
               "data": {},
@@ -2270,7 +2270,7 @@ exports[`Rich Text Editor > Microsoft Word (.docx) deserialization > ordered lis
                   "data": {},
                   "marks": [],
                   "nodeType": "text",
-                  "value": "An ordered list"
+                  "value": "An ordered list "
                 }
               ],
               "data": {},
@@ -2321,7 +2321,13 @@ exports[`Rich Text Editor > Microsoft Word (.docx) deserialization > tables #0`]
                       ],
                       "nodeType": "text",
                       "value": "This is some"
-                    }
+                    },
+                    {
+                      "data": {},
+                      "marks": [],
+                      "nodeType": "text",
+                      "value": " "
+                    },
                   ],
                   "data": {},
                   "nodeType": "paragraph"
@@ -2346,7 +2352,13 @@ exports[`Rich Text Editor > Microsoft Word (.docx) deserialization > tables #0`]
                       ],
                       "nodeType": "text",
                       "value": "Content on tables"
-                    }
+                    },
+                    {
+                      "data": {},
+                      "marks": [],
+                      "nodeType": "text",
+                      "value": " "
+                    },
                   ],
                   "data": {},
                   "nodeType": "paragraph"

--- a/packages/rich-text/src/plugins/PasteHTML/utils/sanitizeHTML.ts
+++ b/packages/rich-text/src/plugins/PasteHTML/utils/sanitizeHTML.ts
@@ -20,7 +20,10 @@ export const sanitizeHTML = (html: string): string => {
     new DOMParser().parseFromString(html, 'text/html')
   );
 
-  return doc.body.innerHTML
-    .replace(/>\s+</g, '><') // Remove whitespace between tags
-    .replace(/(.*)<div.*>(<table.*<\/table>)<\/div>(.*)/g, '$1$2$3'); // remove div containers from tables
+  return (
+    doc.body.innerHTML
+      // .replace(/>\s+</g, '><') // Remove whitespace between tags
+      .replace(/(<(a|p)[^]+?<\/\2)|(^|>)\s+|\s+(?=<|$)/g, '$1$3') // Remove whitespace between tags, except for <a> and <p> https://stackoverflow.com/a/40026669/18118136
+      .replace(/(.*)<div.*>(<table.*<\/table>)<\/div>(.*)/g, '$1$2$3')
+  ); // remove div containers from tables
 };


### PR DESCRIPTION
Remove spaces between tags with an exemption for `<a>` and `<p>` tags