### PR TITLE
fix: hide embed button when all actions are disabled

### DIFF
--- a/packages/rich-text/src/Toolbar/components/EmbedEntityWidget.tsx
+++ b/packages/rich-text/src/Toolbar/components/EmbedEntityWidget.tsx
@@ -56,7 +56,10 @@ export const EmbedEntityWidget = ({ isDisabled, canInsertBlocks }: EmbedEntityWi
     </>
   );
 
-  return (
+  const showEmbedButton =
+    blockEntryEmbedEnabled || inlineEntryEmbedEnabled || blockAssetEmbedEnabled;
+
+  return showEmbedButton ? (
     <EmbeddedEntityDropdownButton
       isDisabled={isDisabled}
       onClose={onCloseEntityDropdown}
@@ -64,5 +67,5 @@ export const EmbedEntityWidget = ({ isDisabled, canInsertBlocks }: EmbedEntityWi
       isOpen={isEmbedDropdownOpen}>
       {actions}
     </EmbeddedEntityDropdownButton>
-  );
+  ) : null;
 };


### PR DESCRIPTION
Hiding the `+Embed` dropdown button when there are no actions under it,

> This is already implemented on the master branch  

https://github.com/contentful/field-editors/blob/58dedc65a2de20973775b48cbb95b54d81894d0a/packages/rich-text/src/Toolbar/index.js#L130-L158