### PR TITLE
feat: add optional space name to entry card

### DIFF
--- a/packages/reference/src/components/SpaceName/SpaceName.tsx
+++ b/packages/reference/src/components/SpaceName/SpaceName.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react';
+
+import { Flex, Text, Tooltip } from '@contentful/f36-components';
+import { FolderOpenTrimmedIcon } from '@contentful/f36-icons';
+import tokens from '@contentful/f36-tokens';
+import { css } from 'emotion';
+
+interface SpaceNameProps {
+  spaceName: string;
+}
+
+const styles = {
+  spaceIcon: css({
+    flexShrink: 0,
+    fill: tokens.purple600,
+  }),
+  spaceName: css({
+    color: tokens.gray700,
+    fontSize: tokens.fontSizeS,
+    fontWeight: tokens.fontWeightDemiBold,
+  }),
+};
+
+export function SpaceName(props: SpaceNameProps) {
+  return (
+    <Tooltip placement="top" as="div" content="Space">
+      <Flex alignItems="center" gap="spacingXs" marginRight="spacingS">
+        <FolderOpenTrimmedIcon className={styles.spaceIcon} size="tiny" aria-label="Source space" />
+        <Text className={styles.spaceName}>{props.spaceName}</Text>
+      </Flex>
+    </Tooltip>
+  );
+}

--- a/packages/reference/src/entries/WrappedEntryCard/WrappedEntryCard.tsx
+++ b/packages/reference/src/entries/WrappedEntryCard/WrappedEntryCard.tsx
@@ -8,6 +8,7 @@ import { entityHelpers, isValidImage } from '@contentful/field-editor-shared';
 import { css } from 'emotion';
 
 import { AssetThumbnail, MissingEntityCard, ScheduledIconWithTooltip } from '../../components';
+import { SpaceName } from '../../components/SpaceName/SpaceName';
 import { ContentType, Entry, File, RenderDragFn } from '../../types';
 
 const { getEntryTitle, getEntityDescription, getEntryStatus, getEntryImage } = entityHelpers;
@@ -31,6 +32,7 @@ export interface WrappedEntryCardProps {
   localeCode: string;
   defaultLocaleCode: string;
   contentType?: ContentType;
+  spaceName?: string;
   entry: Entry;
   renderDragHandle?: RenderDragFn;
   isClickable?: boolean;
@@ -110,18 +112,23 @@ export function WrappedEntryCard(props: WrappedEntryCardProps) {
       size={props.size}
       isSelected={props.isSelected}
       status={status}
+      style={props.spaceName ? { backgroundColor: tokens.gray100 } : undefined}
       icon={
-        <ScheduledIconWithTooltip
-          getEntityScheduledActions={props.getEntityScheduledActions}
-          entityType="Entry"
-          entityId={props.entry.sys.id}>
-          <ClockIcon
-            className={styles.scheduleIcon}
-            size="small"
-            variant="muted"
-            testId="schedule-icon"
-          />
-        </ScheduledIconWithTooltip>
+        props.spaceName ? (
+          <SpaceName spaceName={props.spaceName} />
+        ) : (
+          <ScheduledIconWithTooltip
+            getEntityScheduledActions={props.getEntityScheduledActions}
+            entityType="Entry"
+            entityId={props.entry.sys.id}>
+            <ClockIcon
+              className={styles.scheduleIcon}
+              size="small"
+              variant="muted"
+              testId="schedule-icon"
+            />
+          </ScheduledIconWithTooltip>
+        )
       }
       thumbnailElement={file && isValidImage(file) ? <AssetThumbnail file={file} /> : undefined}
       dragHandleRender={props.renderDragHandle}


### PR DESCRIPTION
Add an optional space name with icon to the wrapped entry card.

![image](https://user-images.githubusercontent.com/1296628/177318665-d2000a8c-5dba-4283-a885-651131a7ef95.png)
