### PR TITLE
fix: no embedded entries check rich text commands [TOL-273]

### DIFF
--- a/packages/rich-text/src/plugins/CommandPalette/hooks/useCommandList.tsx
+++ b/packages/rich-text/src/plugins/CommandPalette/hooks/useCommandList.tsx
@@ -5,6 +5,9 @@ import isHotkey from 'is-hotkey';
 export const useCommandList = (commandItems, container) => {
   const [selectedItem, setSelectedItem] = React.useState<string>(() => {
     // select the first item on initial render
+    if (!commandItems.length) {
+      return '';
+    }
     if ('group' in commandItems[0]) {
       return commandItems[0].commands[0].id;
     }


### PR DESCRIPTION
Rich Text Editor crashes anytime a customer types "/", when the rich text field does not allow embedded entries in validation