### PR TITLE
fix: truncate long space names on entry card [DANTE-634]

### DIFF
--- a/packages/reference/src/components/SpaceName/SpaceName.tsx
+++ b/packages/reference/src/components/SpaceName/SpaceName.tsx
@@ -18,12 +18,16 @@ const styles = {
     color: tokens.gray700,
     fontSize: tokens.fontSizeS,
     fontWeight: tokens.fontWeightDemiBold,
+    maxWidth: '80px',
+    textOverflow: 'ellipsis',
+    overflow: 'hidden',
+    whiteSpace: 'nowrap',
   }),
 };
 
 export function SpaceName(props: SpaceNameProps) {
   return (
-    <Tooltip placement="top" as="div" content="Space">
+    <Tooltip placement="top" as="div" content={`Space: ${props.spaceName}`}>
       <Flex alignItems="center" gap="spacingXs" marginRight="spacingS">
         <FolderOpenTrimmedIcon className={styles.spaceIcon} size="tiny" aria-label="Source space" />
         <Text className={styles.spaceName}>{props.spaceName}</Text>


### PR DESCRIPTION
## Purpose

Truncate long space names on entry card and reveal the name on the tooltip.

Ticket: https://contentful.atlassian.net/browse/DANTE-634

![Screenshot 2022-07-22 at 13 59 39](https://user-images.githubusercontent.com/11991830/180434877-7ef92381-c185-4a6d-b77b-f6654fb2aec4.png)

![Screenshot 2022-07-22 at 13 58 15](https://user-images.githubusercontent.com/11991830/180434667-0dfc2af9-531d-4563-a201-4e11520af511.png)
