### PR TITLE
chore: update `contentful-management` to the latest version

### DIFF
--- a/packages/_test/package.json
+++ b/packages/_test/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "@contentful/app-sdk": "^4.2.0",
-    "contentful-management": "^10.8.0",
+    "contentful-management": "^10.0.0",
     "type-fest": "^2.16.0"
   },
   "dependencies": {

--- a/packages/default-field-editors/package.json
+++ b/packages/default-field-editors/package.json
@@ -42,7 +42,7 @@
     "@contentful/field-editor-tags": "^1.1.5",
     "@contentful/field-editor-url": "^1.1.4",
     "@contentful/field-editor-validation-errors": "^1.1.4",
-    "contentful-management": "^7.22.0",
+    "contentful-management": "^10.0.0",
     "emotion": "^10.0.27"
   },
   "devDependencies": {

--- a/packages/dropdown/package.json
+++ b/packages/dropdown/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@contentful/field-editor-test-utils": "^1.2.0",
-    "contentful-management": "^7.42.1"
+    "contentful-management": "^10.0.0"
   },
   "peerDependencies": {
     "react": ">=16.8.0"

--- a/packages/radio/package.json
+++ b/packages/radio/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@contentful/field-editor-test-utils": "^1.2.0",
-    "contentful-management": "^7.42.1"
+    "contentful-management": "^10.0.0"
   },
   "peerDependencies": {
     "react": ">=16.8.0"

--- a/packages/reference/package.json
+++ b/packages/reference/package.json
@@ -29,7 +29,7 @@
     "@types/deep-equal": "^1.0.1",
     "array-move": "^3.0.0",
     "constate": "3.2.0",
-    "contentful-management": "^10.8.0",
+    "contentful-management": "^10.0.0",
     "deep-equal": "2.0.5",
     "emotion": "^10.0.17",
     "lodash": "^4.17.15",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9606,10 +9606,10 @@ contentful-import@^7.9.23:
     moment "^2.22.2"
     yargs "^16.0.3"
 
-contentful-management@^10.8.0:
-  version "10.8.0"
-  resolved "https://registry.yarnpkg.com/contentful-management/-/contentful-management-10.8.0.tgz#6f60264e180a1e97b1dd9dab849a553d069f731a"
-  integrity sha512-K+q9tbw8SULf5fg+tfLxE4WhHO+1iXyxjdGfy+hv9m1pwJFLhvBmudHOAA1jX1RnqayDUuRqjs/4otVb9cs/KA==
+contentful-management@^10.0.0:
+  version "10.9.1"
+  resolved "https://registry.yarnpkg.com/contentful-management/-/contentful-management-10.9.1.tgz#82588ee7f9c38cfae1bbb5d01e251a68ab8533c4"
+  integrity sha512-IwKwMhxvu3fO9Ei1FtaQtvMqjVZc/xb9gFl6Pi155rUQBGUWNn6HL93b2apKCxmO9q1neQ6qgZccFrMtviKnXA==
   dependencies:
     "@types/json-patch" "0.0.30"
     axios "^0.27.1"
@@ -9617,7 +9617,7 @@ contentful-management@^10.8.0:
     fast-copy "^2.1.1"
     lodash.isplainobject "^4.0.6"
 
-contentful-management@^7.14.0, contentful-management@^7.22.0, contentful-management@^7.3.1, contentful-management@^7.42.1:
+contentful-management@^7.14.0, contentful-management@^7.3.1:
   version "7.45.2"
   resolved "https://registry.yarnpkg.com/contentful-management/-/contentful-management-7.45.2.tgz#60e6bca8226dcf74090b58c45dc7b2ffb574a3b2"
   integrity sha512-NFAkV6mxqOW4SIx8pAhraQq234Gl8+Np8cxaw7+bB9DCelpxmWvySyaoDczAaYmXLZcejeOFt/NS+Rhp7hPvJA==


### PR DESCRIPTION
Version is set to `^10.0.0` instead of a later one to provide maximum compatibility when `field-editors` is used with other libraries using `contentful-management`.