### PR TITLE
fix: rollback change of deps in useFetchedEntity

### DIFF
--- a/packages/rich-text/src/plugins/shared/useFetchedEntity.ts
+++ b/packages/rich-text/src/plugins/shared/useFetchedEntity.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { Entry, Asset } from '@contentful/app-sdk';
 import { useEntities } from '@contentful/field-editor-reference';
@@ -13,7 +13,7 @@ interface FetchedEntityProps {
 export function useFetchedEntity({ type, id, onEntityFetchComplete }: FetchedEntityProps) {
   const { entries, assets, getEntry, getAsset } = useEntities();
 
-  const store = useMemo(() => (type === 'Entry' ? entries : assets), [assets, entries, type]);
+  const store = type === 'Entry' ? entries : assets;
   const [entity, setEntity] = useState<Entry | Asset | 'failed' | undefined>(store?.[id]);
 
   // Deep compare the entity value to keep re-rendering to minimal
@@ -40,7 +40,7 @@ export function useFetchedEntity({ type, id, onEntityFetchComplete }: FetchedEnt
     // TODO: consider rewriting useEntities() hook to avoid that happening in
     // first place.
     // eslint-disable-next-line react-hooks/exhaustive-deps -- TODO: explain this disable
-  }, [type, id, store]);
+  }, [type, id]);
 
   useEffect(() => {
     if (entity) {


### PR DESCRIPTION
Rollback change of deps in useFetchedEntity since it was not necessary to fix the bug of the version compare in the web app