### PR TITLE
fix: add p-queue as dependency

### DIFF
--- a/packages/reference/package.json
+++ b/packages/reference/package.json
@@ -36,6 +36,7 @@
     "lodash": "^4.17.15",
     "lodash-es": "^4.17.15",
     "moment": "^2.20.0",
+    "p-queue": "^4.0.0",
     "react-intersection-observer": "9.4.0",
     "react-sortable-hoc": "^2.0.0",
     "type-fest": "2.17.0"


### PR DESCRIPTION
We are using `p-queue` in `@contentful/field-editor-reference`, but it is currently not a dependency. Users, therefore, receive an error when using the package.

https://github.com/contentful/field-editors/blob/8567b37782848c996509a04e3a7e01a02be839f7/packages/reference/src/common/EntityStore.tsx#L16

The issue was probably introduced in https://github.com/contentful/field-editors/pull/1214