### PR TITLE
fix(EntityStore): use fixed cache key for scheduled actions [SPA-871]

### DIFF
--- a/packages/reference/src/common/EntityStore.tsx
+++ b/packages/reference/src/common/EntityStore.tsx
@@ -239,12 +239,10 @@ const [InternalServiceProvider, useFetch, useEntityLoader, useCurrentIds] = cons
 
     /**
      * Fetch all scheduled actions for a given entity.
-     * This function actually fetches records for all entries and then returns
-     * a filtered result with only the entityId that is provided.
-     * The full result is cached with a fixed "ID" to prevent calling this function again.
+     * This function fetches all schedules for all entries and then returns
+     * a filtered result based on the entityID provided.
      *
-     * This is to avoid N+1 queries on entries that have multiple references,
-     * which would trigger 1 request per entity to scheduled actions instead of a single one.
+     * The result is then reused/cached for subsequent calls to this function.
      */
     const getEntityScheduledActions = useCallback(
       function getEntityScheduledActions(

--- a/packages/reference/src/common/EntityStore.tsx
+++ b/packages/reference/src/common/EntityStore.tsx
@@ -251,7 +251,12 @@ const [InternalServiceProvider, useFetch, useEntityLoader, useCurrentIds] = cons
         options?: GetEntityOptions
       ): QueryEntityResult<ScheduledAction[]> {
         // This is fixed to force the cache to reuse previous results
-        const fixedEntityCacheId = 'scheduledActionEntity';
+        const fixedEntityCacheId = 'scheduledActionEntityId';
+
+        // A space+environment combo can only have up to 500 scheduled actions
+        // With this request we fetch all schedules and can reuse the results.
+        // See https://www.contentful.com/developers/docs/references/content-management-api/#/reference/scheduled-actions/limitations
+        const maxScheduledActions = 500;
         const spaceId = options?.spaceId ?? currentSpaceId;
         const environmentId = options?.environmentId ?? currentEnvironmentId;
         const queryKey: ScheduledActionsQueryKey = [
@@ -272,7 +277,7 @@ const [InternalServiceProvider, useFetch, useEntityLoader, useCurrentIds] = cons
                 'environment.sys.id': environmentId,
                 'sys.status[in]': 'scheduled',
                 order: 'scheduledFor.datetime',
-                limit: 500,
+                limit: maxScheduledActions,
               },
             });
 

--- a/packages/reference/src/components/ScheduledIconWithTooltip/ScheduleTooltip.tsx
+++ b/packages/reference/src/components/ScheduledIconWithTooltip/ScheduleTooltip.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
+
 import { ScheduledAction } from '@contentful/app-sdk';
 import { Tooltip } from '@contentful/f36-components';
+
 import { formatDateAndTime } from './formatDateAndTime';
 
 export const getScheduleTooltipContent = ({
@@ -13,7 +15,7 @@ export const getScheduleTooltipContent = ({
   return `Will ${job.action.toLowerCase()} ${formatDateAndTime(
     job.scheduledFor.datetime
   ).toLowerCase()}
-  ${jobsCount > 1 && `+ ${jobsCount - 1} more`}`;
+  ${jobsCount > 1 ? `+ ${jobsCount - 1} more` : ''}`;
 };
 
 export const ScheduleTooltip = ({


### PR DESCRIPTION
## Description

- When using `app.contentful.com` you might notice that we will call `GET /scheduled_actions` 1 time per references when opening an entry. This might result in 429s for entries that have multiple references (e.g. 500).
- With this change, we fetch all scheduled actions at first since the max limit is 500 per space&environment and then return after the fetching (using the cache key) only the ones that match the current entity ID that is passed to the function. That way we reuse the request call, and only filter the data afterwards.

### Before
<img width="1168" alt="Screenshot 2022-08-29 at 18 20 13" src="https://user-images.githubusercontent.com/249782/187247757-aae60e5a-1ba9-4c75-b3d6-344897a60b41.png">


### After
<img width="1319" alt="Screenshot 2022-08-29 at 18 20 55" src="https://user-images.githubusercontent.com/249782/187247817-8fa0e124-a666-4e98-ab67-a2dc47c6d83d.png">




## Add-ons
This PR also fixes the `false` that is being displayed in the scheduled action tooltip
<img width="284" alt="Screenshot 2022-08-29 at 18 17 34" src="https://user-images.githubusercontent.com/249782/187247208-057d88de-a286-4818-a5b0-2f0b202b7c4a.png">

