### PR TITLE
feat: use urn from entries that are fetched from api

### DIFF
--- a/packages/reference/package.json
+++ b/packages/reference/package.json
@@ -30,7 +30,7 @@
     "@types/deep-equal": "^1.0.1",
     "array-move": "^3.0.0",
     "constate": "3.2.0",
-    "contentful-management": "^10.0.0",
+    "contentful-management": "^10.14.0",
     "deep-equal": "2.0.5",
     "emotion": "^10.0.17",
     "lodash": "^4.17.15",

--- a/packages/reference/src/resources/useResourceLinkActions.ts
+++ b/packages/reference/src/resources/useResourceLinkActions.ts
@@ -1,11 +1,11 @@
 import { useCallback, useMemo } from 'react';
 
 import { FieldExtensionSDK } from '@contentful/app-sdk';
-import { EntryProps, KeyValueMap, WithResourceName } from 'contentful-management';
+import { EntryProps, WithResourceName } from 'contentful-management';
 
 import { LinkActionsProps } from '../components';
 
-const toLinkItem = (entry: WithResourceName<EntryProps<KeyValueMap>>) => ({
+const toLinkItem = (entry: WithResourceName<EntryProps>) => ({
   sys: {
     type: 'ResourceLink',
     linkType: 'Contentful:Entry',
@@ -19,10 +19,10 @@ export function useResourceLinkActions({
   onAfterLink,
 }: Pick<FieldExtensionSDK, 'field' | 'dialogs'> & {
   apiUrl: string;
-  onAfterLink?: (e: EntryProps<KeyValueMap>) => void;
+  onAfterLink?: (e: EntryProps) => void;
 }): LinkActionsProps {
   const handleAfterLink = useCallback(
-    (entries: EntryProps<KeyValueMap>[]) => {
+    (entries: EntryProps[]) => {
       if (!onAfterLink) {
         return;
       }
@@ -33,8 +33,8 @@ export function useResourceLinkActions({
   const multiple = field.type === 'Array';
 
   const onLinkedExisting = useMemo(() => {
-    return (entries: EntryProps<KeyValueMap>[]) => {
-      const entriesWithResourceName = entries as WithResourceName<EntryProps<KeyValueMap>>[];
+    return (entries: EntryProps[]) => {
+      const entriesWithResourceName = entries as WithResourceName<EntryProps>[];
       let updatedValue;
       if (multiple) {
         const linkItems = entriesWithResourceName.map(toLinkItem);

--- a/yarn.lock
+++ b/yarn.lock
@@ -9680,18 +9680,7 @@ contentful-import@^7.9.23:
     moment "^2.22.2"
     yargs "^16.0.3"
 
-contentful-management@^10.0.0:
-  version "10.9.1"
-  resolved "https://registry.yarnpkg.com/contentful-management/-/contentful-management-10.9.1.tgz#82588ee7f9c38cfae1bbb5d01e251a68ab8533c4"
-  integrity sha512-IwKwMhxvu3fO9Ei1FtaQtvMqjVZc/xb9gFl6Pi155rUQBGUWNn6HL93b2apKCxmO9q1neQ6qgZccFrMtviKnXA==
-  dependencies:
-    "@types/json-patch" "0.0.30"
-    axios "^0.27.1"
-    contentful-sdk-core "^7.0.1"
-    fast-copy "^2.1.1"
-    lodash.isplainobject "^4.0.6"
-
-contentful-management@^10.14.0:
+contentful-management@^10.0.0, contentful-management@^10.14.0:
   version "10.14.0"
   resolved "https://registry.yarnpkg.com/contentful-management/-/contentful-management-10.14.0.tgz#c382121d2ce9d52f0f922738067795eb09ca991c"
   integrity sha512-F4CnduBr4EF/toRpNit0bB/xWcVKlUdnTqXT/DaZYURFIyh6ltGHqzHkskia2grG++/KZVPAcqNEM3Y5GV0pFg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -9691,6 +9691,17 @@ contentful-management@^10.0.0:
     fast-copy "^2.1.1"
     lodash.isplainobject "^4.0.6"
 
+contentful-management@^10.14.0:
+  version "10.14.0"
+  resolved "https://registry.yarnpkg.com/contentful-management/-/contentful-management-10.14.0.tgz#c382121d2ce9d52f0f922738067795eb09ca991c"
+  integrity sha512-F4CnduBr4EF/toRpNit0bB/xWcVKlUdnTqXT/DaZYURFIyh6ltGHqzHkskia2grG++/KZVPAcqNEM3Y5GV0pFg==
+  dependencies:
+    "@types/json-patch" "0.0.30"
+    axios "^0.27.1"
+    contentful-sdk-core "^7.0.1"
+    fast-copy "^2.1.1"
+    lodash.isplainobject "^4.0.6"
+
 contentful-management@^7.14.0, contentful-management@^7.3.1:
   version "7.45.2"
   resolved "https://registry.yarnpkg.com/contentful-management/-/contentful-management-7.45.2.tgz#60e6bca8226dcf74090b58c45dc7b2ffb574a3b2"


### PR DESCRIPTION
## Purpose

Use urn from entries that are fetched from the api. EntityMetaSysProps type in [contentful-management.js](https://github.com/contentful/contentful-management.js) repository is missing urn. It's added in this [PR](https://github.com/contentful/contentful-management.js/pull/1479)

