### PR TITLE
fix: increase pqueue concurrency in entitystore

### DIFF
--- a/packages/reference/src/common/EntityStore.tsx
+++ b/packages/reference/src/common/EntityStore.tsx
@@ -33,7 +33,7 @@ export type ResourceInfo<R extends Resource = Resource> = {
 };
 
 // global queue for all requests, the actual number is picked without scientific research
-const globalQueue = new PQueue({ concurrency: 20 });
+const globalQueue = new PQueue({ concurrency: 50 });
 
 type EntityStoreProps = {
   sdk: BaseExtensionSDK;


### PR DESCRIPTION
The current default concurrency limit is too low, causing increases in field editor loading times with large numbers of references.