### PR TITLE
chore: update stale actions to be the same as on Forma 36

### DIFF
--- a/.github/workflows/remove-stale.yml
+++ b/.github/workflows/remove-stale.yml
@@ -1,0 +1,23 @@
+# This workflow removes the stale label from PRs and issues when a new comment is created
+#
+name: Remove stale label
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  remove_stale:
+    if: contains(github.event.issue.labels.*.name, 'stale')
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+      - name: Remove stale label
+        run: gh issue edit $ISSUE --remove-label $LABEL
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE: ${{ github.event.issue.number }}
+          LABEL: 'stale'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -23,7 +23,8 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         days-before-stale: 30
         days-before-close: -1
-        stale-issue-message: 'Marking issue as stale since there was no acitivty for 30 days'
-        stale-pr-message: 'Marking pull request as stale since there was no acitivty for 30 days'
+        operations-per-run: 300
+        stale-issue-message: 'Marking issue as stale since there was no activity for 30 days'
+        stale-pr-message: 'Marking pull request as stale since there was no activity for 30 days'
         stale-issue-label: 'stale'
         stale-pr-label: 'stale'


### PR DESCRIPTION
Update stale action to be the same as in [Forma 36](https://github.com/contentful/forma-36)

* Update the amount of operations per run
* Add action to remove stale on issues and PRs that have new comments