### PR TITLE
fix(field-editor-date): fix date formatting []

### DIFF
--- a/packages/date/src/DatepickerInput.tsx
+++ b/packages/date/src/DatepickerInput.tsx
@@ -30,11 +30,13 @@ export const DatepickerInput = (props: DatePickerProps) => {
   }, []);
 
   // The DatepickerInput should be time and timezone agnostic,
-  // thats why we use moment().format() instead of moment().toDate().
+  // thats why we don't use moment().toDate() to get Date object.
   // moment().toDate() takes into account time and timezone and converts it
   // based on your system timezone which can result in the date change.
-  // e.g. for user who has a timezone +02:00, moment('2022-09-16T00:00+4:00').toDate() will return '2022-09-15'
-  const selectedDate = props.value && new Date(props.value?.format('YYYY-MM-DD'));
+  // e.g. if user has a timezone +02:00, moment('2022-09-16T00:00+04:00').toDate()
+  // will return September 15 instead of September 16
+  const dateObj = props.value?.toObject();
+  const selectedDate = dateObj ? new Date(dateObj.years, dateObj.months, dateObj.date) : undefined;
 
   return (
     <Datepicker


### PR DESCRIPTION
When we pass the date-only strings 'YYYY-MM-DD' to the `new Date()` it is treated as UTC, but we need it to be treated with the system's local timezone.
So for example, if you have UTC offset `-0700`  and do `new Date('1970-01-01')` it will return `Wed Dec 31 1969 17:00:00 GMT-0700`. 
But if you do `new Date(1970, 0, 1)` it will return `Thu Jan 01 1970 00:00:00 GMT-0700`.

❗️ I will add test coverage in the separate PR, so we can merge this PR asap and fix the latest `field-editor-date` pkg.