### PR TITLE
style: fix json editor styling

### DIFF
--- a/packages/json/src/JsonEditorField.tsx
+++ b/packages/json/src/JsonEditorField.tsx
@@ -23,12 +23,12 @@ const styles = {
     fontSize: tokens.fontSizeM,
     '.cm-editor': {
       color: tokens.gray900,
-      fontFamily: tokens.fontStackMonospace,
       '&.cm-focused': {
         outline: 'none',
       },
     },
     '.cm-scroller': {
+      fontFamily: tokens.fontStackMonospace,
       minHeight: '6rem',
     },
     '&.disabled': {
@@ -68,6 +68,7 @@ export function JsonEditorField(props: JsonEditorFieldProps) {
           highlightActiveLine: false,
           foldGutter: false,
           bracketMatching: false,
+          syntaxHighlighting: false,
         }}
         width="100%"
         editable={!props.isDisabled}


### PR DESCRIPTION
Makes styling match the earlier codemirror version's, specifically by removing the red syntax highlighting and correctly applying the font override

Before:
<img width="429" alt="image" src="https://user-images.githubusercontent.com/101652314/193272110-b67f9c24-f365-417a-bd17-78b45f224022.png">

After:
<img width="427" alt="image" src="https://user-images.githubusercontent.com/101652314/193272163-610df1f9-a3bc-408e-a489-863ddd07fe5a.png">
