### PR TITLE
fix: remove background override from xspace refs

### DIFF
--- a/packages/reference/src/entries/WrappedEntryCard/WrappedEntryCard.tsx
+++ b/packages/reference/src/entries/WrappedEntryCard/WrappedEntryCard.tsx
@@ -112,7 +112,6 @@ export function WrappedEntryCard(props: WrappedEntryCardProps) {
       size={props.size}
       isSelected={props.isSelected}
       status={status}
-      style={props.spaceName ? { backgroundColor: tokens.gray100 } : undefined}
       icon={
         props.spaceName ? (
           <SpaceName spaceName={props.spaceName} />


### PR DESCRIPTION
Removing the grayed out background because it makes the field look disabled in Compose