### PR TITLE
feat: isBeingDragged multiple reference field [TOL-361]

### DIFF
--- a/packages/reference/src/common/MultipleReferenceEditor.tsx
+++ b/packages/reference/src/common/MultipleReferenceEditor.tsx
@@ -61,12 +61,18 @@ function Editor(props: EditorProps) {
     );
   }, [props.items]);
 
-  const onSortStart: SortStartHandler = useCallback((_, event) => event.preventDefault(), []);
+  const onSortStart: SortStartHandler = useCallback((_, event) => {
+    if (event instanceof MouseEvent) {
+      document.body.classList.add('grabbing');
+    }
+    event.preventDefault();
+  }, []);
   const onSortEnd: SortEndHandler = useCallback(
     ({ oldIndex, newIndex }) => {
       const newItems = arrayMove(items, oldIndex, newIndex);
       setValue(newItems);
       setIndexToUpdate && setIndexToUpdate(undefined);
+      document.body.classList.remove('grabbing');
     },
     [items, setIndexToUpdate, setValue]
   );

--- a/packages/reference/src/common/MultipleReferenceEditor.tsx
+++ b/packages/reference/src/common/MultipleReferenceEditor.tsx
@@ -1,12 +1,14 @@
 import * as React from 'react';
-import arrayMove from 'array-move';
-import { ReferenceValue, ContentEntityType, ContentType } from '../types';
-import { ReferenceEditor, ReferenceEditorProps } from './ReferenceEditor';
-import { LinkEntityActions } from '../components';
-import { SortEndHandler, SortStartHandler } from 'react-sortable-hoc';
-import { useLinkActionsProps } from '../components/LinkActions/LinkEntityActions';
 import { useCallback } from 'react';
+import { SortEndHandler, SortStartHandler } from 'react-sortable-hoc';
+
+import arrayMove from 'array-move';
+
+import { LinkEntityActions } from '../components';
+import { useLinkActionsProps } from '../components/LinkActions/LinkEntityActions';
+import { ReferenceValue, ContentEntityType, ContentType } from '../types';
 import { CustomEntityCardProps } from './customCardTypes';
+import { ReferenceEditor, ReferenceEditorProps } from './ReferenceEditor';
 import { useEditorPermissions } from './useEditorPermissions';
 
 type ChildProps = {
@@ -23,6 +25,7 @@ type ChildProps = {
 type EditorProps = ReferenceEditorProps &
   Omit<ChildProps, 'onSortStart' | 'onSortEnd' | 'onMove'> & {
     children: (props: ReferenceEditorProps & ChildProps) => React.ReactElement;
+    setIndexToUpdate?: React.Dispatch<React.SetStateAction<number | undefined>>;
   };
 
 function onLinkOrCreate(
@@ -44,7 +47,7 @@ const emptyArray: ReferenceValue[] = [];
 const nullableValue = { sys: { id: 'null-value' } };
 
 function Editor(props: EditorProps) {
-  const { setValue, entityType } = props;
+  const { setValue, entityType, setIndexToUpdate } = props;
   const editorPermissions = useEditorPermissions(props);
 
   const items = React.useMemo(() => {
@@ -63,8 +66,9 @@ function Editor(props: EditorProps) {
     ({ oldIndex, newIndex }) => {
       const newItems = arrayMove(items, oldIndex, newIndex);
       setValue(newItems);
+      setIndexToUpdate && setIndexToUpdate(undefined);
     },
-    [items, setValue]
+    [items, setIndexToUpdate, setValue]
   );
   const onMove = useCallback(
     (oldIndex, newIndex) => {
@@ -120,6 +124,7 @@ export function MultipleReferenceEditor(
   props: ReferenceEditorProps & {
     entityType: ContentEntityType;
     children: (props: ReferenceEditorProps & ChildProps) => React.ReactElement;
+    setIndexToUpdate?: React.Dispatch<React.SetStateAction<number | undefined>>;
   }
 ) {
   const allContentTypes = props.sdk.space.getCachedContentTypes();

--- a/packages/reference/src/common/ReferenceEditor.tsx
+++ b/packages/reference/src/common/ReferenceEditor.tsx
@@ -34,6 +34,7 @@ export interface ReferenceEditorProps {
       bulkEditing?: boolean;
     };
   };
+  updateBeforeSortStart?: ({ index }: { index: number }) => void;
 }
 
 export type CustomActionProps = LinkActionsProps;
@@ -51,7 +52,8 @@ export function ReferenceEditor<T>(
         isInitiallyDisabled={props.isInitiallyDisabled}
         isEqualValues={(value1, value2) => {
           return deepEqual(value1, value2);
-        }}>
+        }}
+      >
         {props.children}
       </FieldConnector>
     </EntityProvider>

--- a/packages/reference/src/common/customCardTypes.ts
+++ b/packages/reference/src/common/customCardTypes.ts
@@ -1,5 +1,6 @@
-import { Asset, ContentType, Entry, RenderDragFn } from '../types';
 import * as React from 'react';
+
+import { Asset, ContentType, Entry, RenderDragFn } from '../types';
 import { CustomActionProps } from './ReferenceEditor';
 
 export type MissingEntityCardProps = {
@@ -37,4 +38,5 @@ export type CustomEntityCardProps = {
   onRemove?: () => void;
   onMoveTop?: () => void;
   onMoveBottom?: () => void;
+  isBeingDragged?: boolean;
 };

--- a/packages/reference/src/entries/MultipleEntryReferenceEditor.tsx
+++ b/packages/reference/src/entries/MultipleEntryReferenceEditor.tsx
@@ -7,13 +7,23 @@ import { ReferenceValue } from '../types';
 import { FetchingWrappedEntryCard } from './WrappedEntryCard/FetchingWrappedEntryCard';
 
 export function MultipleEntryReferenceEditor(props: ReferenceEditorProps) {
+  const [indexToUpdate, setIndexToUpdate] = React.useState<number | undefined>(undefined);
+
+  const updateBeforeSortStart = ({ index }: { index: number }) => {
+    setIndexToUpdate(index);
+  };
+
   return (
-    <MultipleReferenceEditor {...props} entityType="Entry">
+    <MultipleReferenceEditor {...props} entityType="Entry" setIndexToUpdate={setIndexToUpdate}>
       {(childrenProps) => (
-        <SortableLinkList<ReferenceValue> {...childrenProps} axis="y" useDragHandle={true}>
+        <SortableLinkList<ReferenceValue>
+          {...childrenProps}
+          axis="y"
+          useDragHandle={true}
+          updateBeforeSortStart={updateBeforeSortStart}
+        >
           {({ items, item, index, isDisabled, DragHandle }) => {
             const lastIndex = items.length - 1;
-
             return (
               <FetchingWrappedEntryCard
                 {...childrenProps}
@@ -30,6 +40,7 @@ export function MultipleEntryReferenceEditor(props: ReferenceEditorProps) {
                   index !== lastIndex ? () => childrenProps.onMove(index, lastIndex) : undefined
                 }
                 renderDragHandle={DragHandle}
+                isBeingDragged={index === indexToUpdate}
               />
             );
           }}

--- a/packages/reference/src/entries/WrappedEntryCard/FetchingWrappedEntryCard.tsx
+++ b/packages/reference/src/entries/WrappedEntryCard/FetchingWrappedEntryCard.tsx
@@ -28,6 +28,7 @@ export type EntryCardReferenceEditorProps = ReferenceEditorProps & {
   onMoveTop?: () => void;
   onMoveBottom?: () => void;
   renderCustomMissingEntityCard?: RenderCustomMissingEntityCard;
+  isBeingDragged?: boolean;
 };
 
 async function openEntry(
@@ -144,6 +145,7 @@ export function FetchingWrappedEntryCard(props: EntryCardReferenceEditorProps) {
       onRemove: onRemoveEntry,
       onMoveTop: props.onMoveTop,
       onMoveBottom: props.onMoveBottom,
+      isBeingDragged: props.isBeingDragged,
     };
 
     const { hasCardEditActions, hasCardMoveActions, hasCardRemoveActions } = props;


### PR DESCRIPTION
- We want to know which field is currently being dragged in a multiple reference field.
Unfortunately, `react-sortable-hoc` does not offer that out of the box.
This PR calculates and exposes this behaviour with the `isBeingDragged` boolean
- It also adds a class to the body when dragging is active, to have a drag cursor style (solution from https://github.com/clauderic/react-sortable-hoc/issues/328)