### PR TITLE
fix: on sort end multiple reference field

### DIFF
--- a/packages/reference/src/common/MultipleReferenceEditor.tsx
+++ b/packages/reference/src/common/MultipleReferenceEditor.tsx
@@ -68,13 +68,14 @@ function Editor(props: EditorProps) {
     event.preventDefault();
   }, []);
   const onSortEnd: SortEndHandler = useCallback(
-    ({ oldIndex, newIndex }) => {
+    ({ oldIndex, newIndex, collection }) => {
       const newItems = arrayMove(items, oldIndex, newIndex);
       setValue(newItems);
       setIndexToUpdate && setIndexToUpdate(undefined);
       document.body.classList.remove('grabbing');
+      props.onSortingEnd && props.onSortingEnd({ oldIndex, newIndex, collection });
     },
-    [items, setIndexToUpdate, setValue]
+    [items, props, setIndexToUpdate, setValue]
   );
   const onMove = useCallback(
     (oldIndex, newIndex) => {

--- a/packages/reference/src/common/ReferenceEditor.tsx
+++ b/packages/reference/src/common/ReferenceEditor.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { SortEndHandler } from 'react-sortable-hoc';
+import { Offset, SortEndHandler } from 'react-sortable-hoc';
 
 import { FieldConnector } from '@contentful/field-editor-shared';
 import deepEqual from 'deep-equal';
@@ -36,7 +36,15 @@ export interface ReferenceEditorProps {
     };
   };
   updateBeforeSortStart?: ({ index }: { index: number }) => void;
-  onSortingEnd?: (({ index }: { index: number }) => void) & SortEndHandler;
+  onSortingEnd?: (({
+    oldIndex,
+    newIndex,
+  }: {
+    oldIndex: number;
+    newIndex: number;
+    collection: Offset;
+  }) => void) &
+    SortEndHandler;
 }
 
 export type CustomActionProps = LinkActionsProps;

--- a/packages/reference/src/entries/MultipleEntryReferenceEditor.tsx
+++ b/packages/reference/src/entries/MultipleEntryReferenceEditor.tsx
@@ -21,7 +21,6 @@ export function MultipleEntryReferenceEditor(props: ReferenceEditorProps) {
           axis="y"
           useDragHandle={true}
           updateBeforeSortStart={updateBeforeSortStart}
-          onSortEnd={props.onSortingEnd}
         >
           {({ items, item, index, isDisabled, DragHandle }) => {
             const lastIndex = items.length - 1;


### PR DESCRIPTION
Last PR (https://github.com/contentful/field-editors/pull/1272) was overriding the default sort end behaviour, which broke the drag and drop.

This fixes the issue