### PR TITLE
fix: disable search keymap option to prevent breaking on search [ZEND-2879]

### DIFF
--- a/packages/json/src/JsonEditorField.tsx
+++ b/packages/json/src/JsonEditorField.tsx
@@ -55,7 +55,8 @@ export function JsonEditorField(props: JsonEditorFieldProps) {
   return (
     <div
       className={cx(styles.root, { disabled: props.isDisabled })}
-      data-test-id="json-editor-code-mirror">
+      data-test-id="json-editor-code-mirror"
+    >
       <CodeMirror
         value={props.value}
         onChange={props.onChange}
@@ -65,6 +66,7 @@ export function JsonEditorField(props: JsonEditorFieldProps) {
           closeBrackets: false,
           lineNumbers: false,
           highlightActiveLineGutter: false,
+          searchKeymap: false,
           highlightActiveLine: false,
           foldGutter: false,
           bracketMatching: false,


### PR DESCRIPTION
When the json field editor is focused today the user tries to do a browser search (CMD + F) the component breaks because we haven't configured codemirror's search module. 

Disable codemirror's search, so that the key binding falls back to the native browser search. 