### PR TITLE
feat: dropdown toolbar rich text [TOL-764]

### DIFF
--- a/cypress/integration/rich-text/RichTextEditor.Tracking.spec.ts
+++ b/cypress/integration/rich-text/RichTextEditor.Tracking.spec.ts
@@ -173,13 +173,19 @@ describe('Rich Text Editor - Tracking', { viewportHeight: 2000 }, () => {
       [MARKS.UNDERLINE, `{${mod}}u`],
       [MARKS.CODE, `{${mod}}/`],
     ].forEach(([mark, shortcut]) => {
-      const toggleMarkViaToolbar = () => cy.findByTestId(`${mark}-toolbar-button`).click();
-
+      const toggleMarkViaToolbar = (mark: MARKS) => {
+        if (mark === 'code' || mark === 'superscript' || mark === 'subscript') {
+          cy.findByTestId('dropdown-toolbar-button').click();
+          cy.findByTestId(`${mark}-toolbar-button`).click();
+        } else {
+          cy.findByTestId(`${mark}-toolbar-button`).click();
+        }
+      };
       it(`tracks ${mark} mark via toolbar`, () => {
         richText.editor.click();
 
-        toggleMarkViaToolbar();
-        toggleMarkViaToolbar();
+        toggleMarkViaToolbar(mark);
+        toggleMarkViaToolbar(mark);
 
         richText.expectTrackingValue([
           action('mark', 'toolbar-icon', { markType: mark }),

--- a/cypress/integration/rich-text/RichTextEditor.spec.ts
+++ b/cypress/integration/rich-text/RichTextEditor.spec.ts
@@ -208,8 +208,23 @@ describe('Rich Text Editor', { viewportHeight: 2000 }, () => {
   });
 
   describe('Marks', () => {
-    const findMarkViaToolbar = (mark: MARKS) => cy.findByTestId(`${mark}-toolbar-button`);
-    const toggleMarkViaToolbar = (mark: MARKS) => cy.findByTestId(`${mark}-toolbar-button`).click();
+    const findMarkViaToolbar = (mark: MARKS) => {
+      if (mark === 'code' || mark === 'superscript' || mark === 'subscript') {
+        cy.findByTestId('dropdown-toolbar-button').click();
+        return cy.findByTestId(`${mark}-toolbar-button`);
+      } else {
+        return cy.findByTestId(`${mark}-toolbar-button`);
+      }
+    };
+
+    const toggleMarkViaToolbar = (mark: MARKS) => {
+      if (mark === 'code' || mark === 'superscript' || mark === 'subscript') {
+        cy.findByTestId('dropdown-toolbar-button').click();
+        cy.findByTestId(`${mark}-toolbar-button`).click();
+      } else {
+        cy.findByTestId(`${mark}-toolbar-button`).click();
+      }
+    };
 
     it(`shows ${MARKS.BOLD}, ${MARKS.ITALIC}, ${MARKS.UNDERLINE}, ${MARKS.CODE} if not explicitly allowed`, () => {
       cy.setFieldValidations([]);

--- a/packages/rich-text/src/Toolbar/_tests_/toolbar.test.tsx
+++ b/packages/rich-text/src/Toolbar/_tests_/toolbar.test.tsx
@@ -26,14 +26,7 @@ const mockSdk = (marks?: MARKS[]): any => {
       locale: 'en-US',
       validations: [
         {
-          enabledMarks: marks || [
-            'bold',
-            'italic',
-            'underline',
-            'code',
-            'superscript',
-            'subscript',
-          ],
+          enabledMarks: marks || Object.values(MARKS),
         },
       ],
     },
@@ -60,9 +53,9 @@ describe('Toolbar', () => {
     await waitFor(() => {
       expect(getByTestId('toolbar-heading-toggle')).toBeDisabled();
       [
-        'bold',
-        'italic',
-        'underline',
+        MARKS.BOLD,
+        MARKS.ITALIC,
+        MARKS.UNDERLINE,
         'dropdown',
         'hyperlink',
         'quote',

--- a/packages/rich-text/src/plugins/Marks/Code.tsx
+++ b/packages/rich-text/src/plugins/Marks/Code.tsx
@@ -16,6 +16,11 @@ export const ToolbarCodeButton = createMarkToolbarButton({
   icon: <CodeIcon />,
 });
 
+export const ToolbarDropdownCodeButton = createMarkToolbarButton({
+  title: 'Code',
+  mark: MARKS.CODE,
+});
+
 const styles = {
   code: css({
     fontFamily: 'monospace',

--- a/packages/rich-text/src/plugins/Marks/Subscript.tsx
+++ b/packages/rich-text/src/plugins/Marks/Subscript.tsx
@@ -23,6 +23,11 @@ export const ToolbarSubscriptButton = createMarkToolbarButton({
   icon: <SubscriptIcon viewBox="0 0 23 18" />,
 });
 
+export const ToolbarDropdownSubscriptButton = createMarkToolbarButton({
+  title: 'Subscript',
+  mark: MARKS.SUBSCRIPT,
+});
+
 export function Subscript(props: Slate.RenderLeafProps) {
   return (
     <sub {...props.attributes} className={styles.subscript}>

--- a/packages/rich-text/src/plugins/Marks/Superscript.tsx
+++ b/packages/rich-text/src/plugins/Marks/Superscript.tsx
@@ -23,6 +23,11 @@ export const ToolbarSuperscriptButton = createMarkToolbarButton({
   icon: <SuperscriptIcon />,
 });
 
+export const ToolbarDropdownSuperscriptButton = createMarkToolbarButton({
+  title: 'Superscript',
+  mark: MARKS.SUPERSCRIPT,
+});
+
 export function Superscript(props: Slate.RenderLeafProps) {
   return (
     <sup {...props.attributes} className={styles.superscript}>

--- a/packages/rich-text/src/plugins/Marks/components/MarkToolbarButton.tsx
+++ b/packages/rich-text/src/plugins/Marks/components/MarkToolbarButton.tsx
@@ -1,7 +1,10 @@
 import * as React from 'react';
 
+import { Menu } from '@contentful/f36-components';
+import tokens from '@contentful/f36-tokens';
 import { MARKS } from '@contentful/rich-text-types';
 import { isMarkActive } from '@udecode/plate-core';
+import { css, cx } from 'emotion';
 
 import { useContentfulEditor } from '../../../ContentfulEditorProvider';
 import { focus } from '../../../helpers/editor';
@@ -11,8 +14,15 @@ import { toggleMarkAndDeactivateConflictingMarks } from '../helpers';
 export interface MarkOptions {
   mark: MARKS;
   title: string;
-  icon: React.ReactElement;
+  icon?: React.ReactElement;
 }
+
+const styles = {
+  isActive: css({
+    backgroundColor: tokens.blue100,
+    color: tokens.blue600,
+  }),
+};
 
 export const createMarkToolbarButton = ({ mark, title, icon }: MarkOptions) => {
   const Mark = ({ isDisabled }: { isDisabled?: boolean }) => {
@@ -29,6 +39,21 @@ export const createMarkToolbarButton = ({ mark, title, icon }: MarkOptions) => {
     }, [editor]);
 
     if (!editor) return null;
+
+    if (!icon) {
+      return (
+        <Menu.Item
+          onClick={handleClick}
+          disabled={isDisabled}
+          className={cx({
+            [styles.isActive]: isMarkActive(editor, mark),
+          })}
+          testId={`${mark}-toolbar-button`}
+        >
+          {title}
+        </Menu.Item>
+      );
+    }
 
     return (
       <ToolbarButton


### PR DESCRIPTION
- [x] Add a dropdown menu to the toolbar after underline
- [x] It triggers a dropdown with hidden options: Superscript, Subscript, Code
- [x] We only show the dropdown menu when: Whenever at least bold , italic and underline are available
- [x] If nothing that would go inside ... is available, we hide it
- [x] If bold, italic and underline aren’t available, we show the options from ... in the toolbar.
- [x] To indicate an item inside the ... menu is toggled, use the same behaviour as for the other marks.
- [x] The menu item should be marked as active.