### PR TITLE
chore(deps): fix codeowners shadowing dependabot config

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,7 @@
-*        @contentful/team-tolkien
+# Disabling this rule as it shadows Dependabot "reviewers" config
+# *        @contentful/team-tolkien
+
+cypress/        @contentful/team-tolkien
+packages/        @contentful/team-tolkien
 
 apps/    @contentful/team-extensibility


### PR DESCRIPTION
I think the `*` syntax is taking over `dependabot.reviewers` config. This works because dependabot PRs typically modify only `package{-lock}.json` and/or `yarn.lock` files