### PR TITLE
fix: solve multi ref drag issue [TOL-823]

### DIFF
--- a/packages/reference/src/common/SortableLinkList.tsx
+++ b/packages/reference/src/common/SortableLinkList.tsx
@@ -17,7 +17,7 @@ const styles = {
   }),
   item: css({
     marginBottom: tokens.spacingM,
-    zIndex: tokens.zIndexModalContent, // setting this to an index above 99 fixes [TOL-823]
+    zIndex: tokens.zIndexModalContent, // setting this to an index above 99 fixes dragged item disappearing issue
   }),
 };
 type SortableContainerChildProps<IType> = Pick<

--- a/packages/reference/src/common/SortableLinkList.tsx
+++ b/packages/reference/src/common/SortableLinkList.tsx
@@ -17,7 +17,7 @@ const styles = {
   }),
   item: css({
     marginBottom: tokens.spacingM,
-    zIndex: tokens.zIndexModalContent,
+    zIndex: tokens.zIndexModalContent, // setting this to an index above 99 fixes [TOL-823]
   }),
 };
 type SortableContainerChildProps<IType> = Pick<

--- a/packages/reference/src/common/SortableLinkList.tsx
+++ b/packages/reference/src/common/SortableLinkList.tsx
@@ -17,6 +17,7 @@ const styles = {
   }),
   item: css({
     marginBottom: tokens.spacingM,
+    zIndex: tokens.zIndexModalContent,
   }),
 };
 type SortableContainerChildProps<IType> = Pick<
@@ -52,7 +53,8 @@ const SortableLinkListInternal = SortableContainer((props: SortableLinkListProps
         <SortableLink
           disabled={props.isDisabled}
           key={`${item.sys.urn ?? item.sys.id}-${index}`}
-          index={index}>
+          index={index}
+        >
           {props.children({
             items: props.items,
             isDisabled: props.isDisabled,


### PR DESCRIPTION
This fixes the issue with https://contentful.atlassian.net/browse/TOL-823. When reordering multi referenced items the item being dragged would disappear. Giving it a higher zIndex fixes the issue. I chose one of the constants from the f36-tokens package