### PR TITLE
fix: a11y issues focus rich text

### DIFF
--- a/packages/rich-text/src/plugins/Table/onKeyDownTable.ts
+++ b/packages/rich-text/src/plugins/Table/onKeyDownTable.ts
@@ -9,6 +9,7 @@ import {
   isLastChild,
 } from '@udecode/plate-core';
 import { getTableCellEntry, onKeyDownTable as defaultKeyDownTable } from '@udecode/plate-table';
+import { ReactEditor } from 'slate-react';
 
 import { insertEmptyParagraph } from '../../helpers/editor';
 import { RichTextEditor } from '../../types';
@@ -45,10 +46,10 @@ export const onKeyDownTable: KeyboardHandler<RichTextEditor, HotkeyPlugin> = (ed
     // Pressing Tab on the last cell creates a new row
     // Otherwise, jumping between cells is handled in the defaultKeyDownTable
     if (event.key === 'Tab' && !event.shiftKey) {
-      event.preventDefault();
       const res = getTableCellEntry(editor, {});
 
       if (res) {
+        event.preventDefault();
         const { tableElement, tableRow, tableCell } = res;
 
         const isLastCell = isLastChild(tableRow, tableCell[1]);
@@ -59,10 +60,14 @@ export const onKeyDownTable: KeyboardHandler<RichTextEditor, HotkeyPlugin> = (ed
 
           // skip default handler
           return;
+        } else {
+          defaultHandler(event);
         }
       }
     }
 
-    defaultHandler(event);
+    if (event.key === 'Escape') {
+      ReactEditor.blur(editor);
+    }
   };
 };


### PR DESCRIPTION
Fixes some A11Y issues with tabbing in rich text.
Rich Text Tables plugin introduced a bug where you could not tab _out_ of the rich text field anymore. This PR should fix that.
Also when you are in a table and you want to exit the rich text editor with a keyboard, you can now use the ESC key. Previously this was impossible with a keyboard.