### PR TITLE
feat: custom actions in resource reference editors [DANTE-793]

### DIFF
--- a/packages/reference/src/components/LinkActions/LinkEntityActions.tsx
+++ b/packages/reference/src/components/LinkActions/LinkEntityActions.tsx
@@ -11,6 +11,7 @@ import {
   Asset,
   NavigatorSlideInfo,
 } from '../../types';
+import { CombinedLinkActions } from './CombinedLinkActions';
 import { createEntity, selectMultipleEntities, selectSingleEntity } from './helpers';
 import { LinkActions, LinkActionsProps } from './LinkActions';
 
@@ -174,6 +175,19 @@ export function LinkEntityActions({
   const renderLinkActions = renderCustomActions
     ? renderCustomActions
     : (props: LinkActionsProps) => <LinkActions {...props} />;
+
+  return renderLinkActions(props);
+}
+
+export function CombinedLinkEntityActions({
+  renderCustomActions,
+  ...props
+}: LinkActionsProps & {
+  renderCustomActions?: (props: LinkActionsProps) => React.ReactElement;
+}) {
+  const renderLinkActions = renderCustomActions
+    ? renderCustomActions
+    : (props: LinkActionsProps) => <CombinedLinkActions {...props} />;
 
   return renderLinkActions(props);
 }

--- a/packages/reference/src/components/LinkActions/LinkEntityActions.tsx
+++ b/packages/reference/src/components/LinkActions/LinkEntityActions.tsx
@@ -172,11 +172,7 @@ export function LinkEntityActions({
 }: LinkActionsProps & {
   renderCustomActions?: (props: LinkActionsProps) => React.ReactElement;
 }) {
-  const renderLinkActions = renderCustomActions
-    ? renderCustomActions
-    : (props: LinkActionsProps) => <LinkActions {...props} />;
-
-  return renderLinkActions(props);
+  return renderCustomActions ? renderCustomActions(props) : <LinkActions {...props} />;
 }
 
 export function CombinedLinkEntityActions({
@@ -185,9 +181,5 @@ export function CombinedLinkEntityActions({
 }: LinkActionsProps & {
   renderCustomActions?: (props: LinkActionsProps) => React.ReactElement;
 }) {
-  const renderLinkActions = renderCustomActions
-    ? renderCustomActions
-    : (props: LinkActionsProps) => <CombinedLinkActions {...props} />;
-
-  return renderLinkActions(props);
+  return renderCustomActions ? renderCustomActions(props) : <CombinedLinkActions {...props} />;
 }

--- a/packages/reference/src/resources/MultipleResourceReferenceEditor.spec.tsx
+++ b/packages/reference/src/resources/MultipleResourceReferenceEditor.spec.tsx
@@ -76,6 +76,24 @@ describe('Multiple resource editor', () => {
     });
   });
 
+  it('renders custom actions when passed', async () => {
+    const sdk: FieldExtensionSDK = mockSdkForField(fieldDefinition);
+    render(
+      <MultipleResourceReferenceEditor
+        isInitiallyDisabled={false}
+        sdk={sdk}
+        hasCardEditActions={true}
+        viewType="card"
+        // @ts-expect-error unused...
+        parameters={{}}
+        renderCustomActions={() => <div data-testid="custom-actions" />}
+      />
+    );
+
+    const customActions = await screen.findByTestId('custom-actions');
+    expect(customActions).toBeDefined();
+  });
+
   describe('with value', () => {
     it('renders the cards', async () => {
       const { entryLinks, entryInfos } = generateMultipleTestResources();

--- a/packages/reference/src/resources/MultipleResourceReferenceEditor.tsx
+++ b/packages/reference/src/resources/MultipleResourceReferenceEditor.tsx
@@ -9,7 +9,7 @@ import deepEqual from 'deep-equal';
 import { EntityProvider } from '../common/EntityStore';
 import { ReferenceEditorProps } from '../common/ReferenceEditor';
 import { SortableLinkList } from '../common/SortableLinkList';
-import { CombinedLinkActions } from '../components';
+import { CombinedLinkEntityActions } from '../components/LinkActions/LinkEntityActions';
 import { ResourceLink } from '../types';
 import { EntryRoute } from './Cards/ContentfulEntryCard';
 import { ResourceCard } from './Cards/ResourceCard';
@@ -73,7 +73,10 @@ function ResourceEditor(props: EditorProps) {
         onMove,
         onRemoteItemAtIndex,
       })}
-      <CombinedLinkActions {...linkActionsProps} />
+      <CombinedLinkEntityActions
+        {...linkActionsProps}
+        renderCustomActions={props.renderCustomActions}
+      />
     </>
   );
 }
@@ -131,7 +134,8 @@ export function MultipleResourceReferenceEditor(
         throttle={0}
         field={props.sdk.field}
         isInitiallyDisabled={props.isInitiallyDisabled}
-        isEqualValues={deepEqual}>
+        isEqualValues={deepEqual}
+      >
         {({ value, disabled, setValue, externalReset }) => {
           return (
             <ResourceEditor
@@ -139,7 +143,9 @@ export function MultipleResourceReferenceEditor(
               items={value || EMPTY_ARRAY}
               isDisabled={disabled}
               setValue={setValue}
-              key={`${externalReset}-list`}>
+              renderCustomActions={props.renderCustomActions}
+              key={`${externalReset}-list`}
+            >
               {(editorProps) => (
                 <SortableLinkList<ResourceLink> {...editorProps}>
                   {({ item, isDisabled, DragHandle, index }) => (
@@ -147,7 +153,8 @@ export function MultipleResourceReferenceEditor(
                       index={index}
                       onMove={editorProps.onMove}
                       onRemoteItemAtIndex={editorProps.onRemoteItemAtIndex}
-                      listLength={value?.length || 0}>
+                      listLength={value?.length || 0}
+                    >
                       {({ onMoveBottom, onMoveTop, onRemove }) => (
                         <ResourceCard
                           index={index}

--- a/packages/reference/src/resources/SingleResourceReferenceEditor.spec.tsx
+++ b/packages/reference/src/resources/SingleResourceReferenceEditor.spec.tsx
@@ -71,6 +71,24 @@ describe('Single resource editor', () => {
     });
   });
 
+  it('renders custom actions when passed', async () => {
+    const sdk: FieldExtensionSDK = mockSdkForField(fieldDefinition);
+    render(
+      <SingleResourceReferenceEditor
+        isInitiallyDisabled={false}
+        sdk={sdk}
+        hasCardEditActions={true}
+        viewType="card"
+        // @ts-expect-error unused...
+        parameters={{}}
+        renderCustomActions={() => <div data-testid="custom-actions" />}
+      />
+    );
+
+    const customActions = await screen.findByTestId('custom-actions');
+    expect(customActions).toBeDefined();
+  });
+
   it('renders the card button when the value is set', async () => {
     const sdk: FieldExtensionSDK = mockSdkForField(fieldDefinition, {
       sys: {

--- a/packages/reference/src/resources/SingleResourceReferenceEditor.tsx
+++ b/packages/reference/src/resources/SingleResourceReferenceEditor.tsx
@@ -41,7 +41,6 @@ export function SingleResourceReferenceEditor(
               getEntryRouteHref={props.getEntryRouteHref}
             />
           ) : (
-            // TODO: support custom actions once publicly available
             <CombinedLinkEntityActions
               {...linkActionsProps}
               renderCustomActions={props.renderCustomActions}

--- a/packages/reference/src/resources/SingleResourceReferenceEditor.tsx
+++ b/packages/reference/src/resources/SingleResourceReferenceEditor.tsx
@@ -5,7 +5,7 @@ import deepEqual from 'deep-equal';
 
 import { EntityProvider } from '../common/EntityStore';
 import { ReferenceEditorProps } from '../common/ReferenceEditor';
-import { CombinedLinkActions } from '../components';
+import { CombinedLinkEntityActions } from '../components/LinkActions/LinkEntityActions';
 import { ResourceLink } from '../types';
 import { EntryRoute } from './Cards/ContentfulEntryCard';
 import { ResourceCard } from './Cards/ResourceCard';
@@ -30,7 +30,8 @@ export function SingleResourceReferenceEditor(
         throttle={0}
         field={props.sdk.field}
         isInitiallyDisabled={props.isInitiallyDisabled}
-        isEqualValues={deepEqual}>
+        isEqualValues={deepEqual}
+      >
         {({ value, disabled }) => {
           return value ? (
             <ResourceCard
@@ -41,7 +42,10 @@ export function SingleResourceReferenceEditor(
             />
           ) : (
             // TODO: support custom actions once publicly available
-            <CombinedLinkActions {...linkActionsProps} />
+            <CombinedLinkEntityActions
+              {...linkActionsProps}
+              renderCustomActions={props.renderCustomActions}
+            />
           );
         }}
       </FieldConnector>


### PR DESCRIPTION
Allow custom actions to be passed to resource reference editors via the existing `renderCustomActions` parameter.