### PR TITLE
fix: enter key open asset modal [TOL-889]

### DIFF
--- a/cypress/component/reference/WrappedAssetCard.spec.tsx
+++ b/cypress/component/reference/WrappedAssetCard.spec.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+import { WrappedAssetCard } from '../../../packages/reference/src';
+import { WrappedAssetCardProps } from '../../../packages/reference/src/assets/WrappedAssetCard/WrappedAssetCard';
+import { fixtures } from '../../fixtures';
+import { mount } from '../mount';
+
+const props: WrappedAssetCardProps = {
+  size: 'default',
+  renderDragHandle: undefined,
+  onRemove: () => null,
+  localeCode: 'en-US',
+  isDisabled: false,
+  defaultLocaleCode: 'en-US',
+  entityUrl: undefined,
+  getAssetUrl: undefined,
+  getEntityScheduledActions: () => Promise.resolve([]),
+  // @ts-expect-error -- fix types from asset
+  asset: fixtures.assets.published,
+};
+
+describe('Wrapped Asset Card', () => {
+  it('also fires onEdit event when pressing enter on the keyboard', () => {
+    const onEdit = cy.stub().as('on-edit');
+    mount(<WrappedAssetCard {...props} isClickable={true} onEdit={onEdit} />);
+    cy.findByTestId('cf-ui-asset-card').focus().type('{enter}');
+    cy.get('@on-edit').should('have.been.called');
+  });
+});

--- a/packages/reference/src/assets/WrappedAssetCard/WrappedAssetCard.tsx
+++ b/packages/reference/src/assets/WrappedAssetCard/WrappedAssetCard.tsx
@@ -110,7 +110,8 @@ export const WrappedAssetCard = (props: WrappedAssetCardProps) => {
         <ScheduledIconWithTooltip
           getEntityScheduledActions={props.getEntityScheduledActions}
           entityType="Asset"
-          entityId={props.asset.sys.id}>
+          entityId={props.asset.sys.id}
+        >
           <ClockIcon
             className={styles.scheduleIcon}
             size="small"
@@ -135,6 +136,18 @@ export const WrappedAssetCard = (props: WrappedAssetCardProps) => {
           ? (e: React.MouseEvent<HTMLElement>) => {
               e.preventDefault();
               onEdit && onEdit();
+            }
+          : undefined
+      }
+      /* todo - remove this when onKeyDown is allowed as a prop for BaseCard in forma 36
+      // @ts-expect-error */
+      onKeyDown={
+        isClickable
+          ? (e: React.KeyboardEvent<HTMLElement>) => {
+              if (e.key === 'Enter' && onEdit) {
+                e.preventDefault();
+                onEdit();
+              }
             }
           : undefined
       }

--- a/packages/reference/src/assets/WrappedAssetCard/WrappedAssetLink.tsx
+++ b/packages/reference/src/assets/WrappedAssetCard/WrappedAssetLink.tsx
@@ -1,13 +1,14 @@
 import React from 'react';
-import { css } from 'emotion';
-import tokens from '@contentful/f36-tokens';
-import { EntryCard } from '@contentful/f36-components';
-import { renderActions, renderAssetInfo } from './AssetCardActions';
-import { Asset, RenderDragFn } from '../../types';
-import { entityHelpers, isValidImage, SpaceAPI } from '@contentful/field-editor-shared';
-import { MissingEntityCard, ScheduledIconWithTooltip, AssetThumbnail } from '../../components';
 
+import { EntryCard } from '@contentful/f36-components';
 import { ClockIcon } from '@contentful/f36-icons';
+import tokens from '@contentful/f36-tokens';
+import { entityHelpers, isValidImage, SpaceAPI } from '@contentful/field-editor-shared';
+import { css } from 'emotion';
+
+import { MissingEntityCard, ScheduledIconWithTooltip, AssetThumbnail } from '../../components';
+import { Asset, RenderDragFn } from '../../types';
+import { renderActions, renderAssetInfo } from './AssetCardActions';
 
 const styles = {
   scheduleIcon: css({
@@ -70,7 +71,8 @@ export const WrappedAssetLink = (props: WrappedAssetLinkProps) => {
         <ScheduledIconWithTooltip
           getEntityScheduledActions={props.getEntityScheduledActions}
           entityType="Asset"
-          entityId={props.asset.sys.id}>
+          entityId={props.asset.sys.id}
+        >
           <ClockIcon
             className={styles.scheduleIcon}
             size="small"
@@ -82,6 +84,12 @@ export const WrappedAssetLink = (props: WrappedAssetLinkProps) => {
       onClick={(e: React.MouseEvent<HTMLElement>) => {
         e.preventDefault();
         onEdit();
+      }}
+      onKeyDown={(e: React.KeyboardEvent<HTMLElement>) => {
+        if (e.key === 'Enter' && onEdit) {
+          e.preventDefault();
+          onEdit();
+        }
       }}
       dragHandleRender={props.renderDragHandle}
       withDragHandle={!!props.renderDragHandle}


### PR DESCRIPTION
Pressing enter key should fire the onEdit event for asset field