### PR TITLE
ci: add vault configuration []

### DIFF
--- a/.contentful/vault-secrets.yaml
+++ b/.contentful/vault-secrets.yaml
@@ -1,0 +1,8 @@
+version: 1
+services:
+  github-action:
+    policies:
+      - dependabot
+  circleci:
+    policies:
+      - semantic-release-ecosystem


### PR DESCRIPTION
- Enables the repo to use secrets from vault instead of environment variables in CI.