### PR TITLE
fix(rte): [TOL-989] command prompt not always visible and working

### DIFF
--- a/packages/rich-text/src/plugins/CommandPalette/components/CommandList.styles.ts
+++ b/packages/rich-text/src/plugins/CommandPalette/components/CommandList.styles.ts
@@ -13,6 +13,9 @@ const styles = {
       marginLeft: 0,
     },
   }),
+  menuPoper: css({
+    zIndex: tokens.zIndexModal,
+  }),
   menuContent: css({
     width: '400px',
     maxHeight: '300px',

--- a/packages/rich-text/src/plugins/CommandPalette/components/CommandList.tsx
+++ b/packages/rich-text/src/plugins/CommandPalette/components/CommandList.tsx
@@ -131,6 +131,7 @@ export const CommandList = ({ query, editor, textContainer }: CommandListProps) 
         <div
           aria-hidden={true}
           ref={popoverContainer}
+          className={styles.menuPoper}
           style={popper.styles.popper}
           {...popper.attributes.popper}
         >

--- a/packages/rich-text/src/plugins/CommandPalette/onKeyDown.spec.ts
+++ b/packages/rich-text/src/plugins/CommandPalette/onKeyDown.spec.ts
@@ -1,0 +1,32 @@
+import * as internal from '../../internal/transforms';
+import { createTestEditor } from '../../test-utils';
+import { COMMAND_PROMPT } from './constants';
+import { createOnKeyDown } from './onKeyDown';
+
+describe('onKeyDown', () => {
+  const { editor } = createTestEditor({});
+
+  const addMark = jest.spyOn(internal, 'addMark');
+  const onCommandPaletteAction = jest.spyOn(editor.tracking, 'onCommandPaletteAction');
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test.each`
+    layout      | key
+    ${'QUERTY'} | ${{ key: '/', which: 191, shiftKey: false }}
+    ${'QWERTZ'} | ${{ key: '/', which: 55, shiftKey: true }}
+  `('supports hotKeys for every keyboard layout #{layout}', ({ key }) => {
+    createOnKeyDown()(editor, {} as any)({
+      type: 'keydown',
+      ...key,
+    });
+
+    expect(addMark).toHaveBeenCalledTimes(1);
+    expect(addMark).toHaveBeenCalledWith(editor, COMMAND_PROMPT);
+
+    expect(onCommandPaletteAction).toHaveBeenCalledTimes(1);
+    expect(onCommandPaletteAction).toHaveBeenCalledWith('openRichTextCommandPalette');
+  });
+});

--- a/packages/rich-text/src/plugins/CommandPalette/onKeyDown.ts
+++ b/packages/rich-text/src/plugins/CommandPalette/onKeyDown.ts
@@ -7,7 +7,11 @@ import { COMMAND_PROMPT } from './constants';
 export const createOnKeyDown = (): KeyboardHandler => {
   return (editor) => {
     return (event) => {
-      if (isHotkey('/', event)) {
+      // Support for different keyboard layouts:
+      // `isHotKey` uses by default `event.which`, which will never generates a match for all layouts (QWERTY: `/`, QWERTZ: `shift+7`)
+      // with `byKey: true` `isHotKey` uses `event.key` which will return the interpreted key '/'
+      // It would still fail without the the optional `shift?` param, as it first checks the modKeys (`shiftKey` would be true on QWERTZ)
+      if (isHotkey('shift?+/', { byKey: true }, event)) {
         addMark(editor, COMMAND_PROMPT);
         editor.tracking.onCommandPaletteAction('openRichTextCommandPalette');
       }

--- a/packages/rich-text/src/plugins/Marks/Code.tsx
+++ b/packages/rich-text/src/plugins/Marks/Code.tsx
@@ -40,7 +40,13 @@ export const createCodePlugin = (): PlatePlugin =>
     type: MARKS.CODE,
     component: Code,
     options: {
-      hotkey: ['mod+/'],
+      // We need to define multiple hotkeys here,
+      // - mod+/ -> QWERTY keyboard layout
+      // - mod+shift+7 -> QWERTZ keyboard layout
+      // The workaround like in packages/rich-text/src/plugins/CommandPalette/onKeyDown.ts is sadly not working here,
+      // as `shift+7` is not interpreted as `/` with the `mod` key by the OS.
+      // TODO: there are a lot more different keyboard layouts out there
+      hotkey: ['mod+/', 'mod+shift+7'],
     },
     handlers: {
       onKeyDown: buildMarkEventHandler(MARKS.CODE),


### PR DESCRIPTION
- missing z-index on the poper (not visible in the web app and also some visual issues in compose)
- added support for command prompt in other keyboards (QWERTZ, ...)