### PR TITLE
fix: images overlay modal in compose [TOL-921]

### DIFF
--- a/packages/reference/src/common/SortableLinkList.tsx
+++ b/packages/reference/src/common/SortableLinkList.tsx
@@ -17,7 +17,7 @@ const styles = {
   }),
   item: css({
     marginBottom: tokens.spacingM,
-    zIndex: tokens.zIndexModalContent, // setting this to an index above 99 fixes dragged item disappearing issue
+    zIndex: tokens.zIndexModal, // setting this to an index above 99 fixes dragged item disappearing issue. Should not be higher than 100 so it does not overlap the asset modal.
   }),
 };
 type SortableContainerChildProps<IType> = Pick<


### PR DESCRIPTION
There's an image overlay happening in Compose when user is trying to add existing media to a field with multiple images setting.
![compose assets_2](https://user-images.githubusercontent.com/22968325/213685541-cd9c28cc-2137-481b-b61e-4e1d523607f5.png)