### PR TITLE
fix: mail to links replace ampersand [TOL-923]

### DIFF
--- a/packages/markdown/src/components/MarkdownPreview.tsx
+++ b/packages/markdown/src/components/MarkdownPreview.tsx
@@ -1,9 +1,12 @@
 import React from 'react';
-import Markdown from 'markdown-to-jsx';
+
 import tokens from '@contentful/f36-tokens';
 import DOMPurify from 'dompurify';
 import { css, cx } from 'emotion';
+import Markdown from 'markdown-to-jsx';
+
 import { EditorDirection, PreviewComponents } from '../types';
+import { replaceMailtoAmp } from '../utils/replaceMailtoAmp';
 
 const styles = {
   root: css`
@@ -199,7 +202,7 @@ export const MarkdownPreview = React.memo((props: MarkdownPreviewProps) => {
   // See the list of allowed Tags here:
   // https://github.com/cure53/DOMPurify/blob/main/src/tags.js#L3-L121
   const cleanHTML = React.useMemo(() => {
-    return DOMPurify.sanitize(props.value);
+    return replaceMailtoAmp(DOMPurify.sanitize(props.value));
   }, [props.value]);
 
   return (

--- a/packages/markdown/src/utils/replaceMailtoAmp.spec.ts
+++ b/packages/markdown/src/utils/replaceMailtoAmp.spec.ts
@@ -1,0 +1,27 @@
+import { replaceMailtoAmp } from './replaceMailtoAmp';
+
+describe('replace inside mailto', () => {
+  let str =
+    '<a href="mailto:example@example.com?subject=Hello&amp;body=Hello%20world">Send Email</a>';
+
+  test('replace &amp; with &', () => {
+    const newStr = replaceMailtoAmp(str);
+    expect(newStr).toBe(
+      '<a href="mailto:example@example.com?subject=Hello&body=Hello%20world">Send Email</a>'
+    );
+  });
+
+  test('no replace if not inside mailto', () => {
+    str = '<a href="https://example.com?subject=Hello&amp;body=Hello%20world">Visit Website</a>';
+    const newStr = replaceMailtoAmp(str);
+    expect(newStr).toBe(
+      '<a href="https://example.com?subject=Hello&amp;body=Hello%20world">Visit Website</a>'
+    );
+  });
+
+  test('no replace if no &amp;', () => {
+    str = '<a href="mailto:example@example.com?subject=Hello">Send Email</a>';
+    const newStr = replaceMailtoAmp(str);
+    expect(newStr).toBe('<a href="mailto:example@example.com?subject=Hello">Send Email</a>');
+  });
+});

--- a/packages/markdown/src/utils/replaceMailtoAmp.ts
+++ b/packages/markdown/src/utils/replaceMailtoAmp.ts
@@ -1,0 +1,7 @@
+// This code will replace '&amp;' with '&' only inside the href attribute of the mailto link.
+// Otherwise the mailto link will not work correctly
+export const replaceMailtoAmp = (string: string) => {
+  return string.replace(/href="mailto:[^"]*&amp;/g, function (match) {
+    return match.replace(/&amp;/g, '&');
+  });
+};


### PR DESCRIPTION
We use `dompurify` to sanitize the markdown preview output. Dompurify uses innerHTML at some point, which transforms `&` to`&amp` inside of href links. This causes an issue with mailto links not working as expected. Everything after `&amp` gets ignored.

For example: `<a href="mailto:test@test.com?subject=test&body=test">Test</a>`
turns into:
`<a href="mailto:test@test.com?subject=test&amp;body=test">Test</a>`, which makes the `mailto` link ignore the body parameter.

I added a regex that transforms the `&amp` to `&` again inside mail to links. Unfortunately I was not able to add any exclusion inside the dompurify package (see this issue in the package: https://github.com/cure53/DOMPurify/issues/379#issuecomment-571997013)