### PR TITLE
fix: remove command mark after space [TOL-945]

### DIFF
--- a/packages/rich-text/src/plugins/CommandPalette/onKeyDown.ts
+++ b/packages/rich-text/src/plugins/CommandPalette/onKeyDown.ts
@@ -36,6 +36,10 @@ export const createOnKeyDown = (): KeyboardHandler => {
         }
       }
 
+      if (isHotkey('space', event)) {
+        removeMark(editor, COMMAND_PROMPT, range);
+      }
+
       if (isHotkey('escape', event)) {
         removeMark(editor, COMMAND_PROMPT, range);
         editor.tracking.onCommandPaletteAction('cancelRichTextCommandPalette');

--- a/packages/rich-text/src/plugins/CommandPalette/onKeyDown.ts
+++ b/packages/rich-text/src/plugins/CommandPalette/onKeyDown.ts
@@ -1,6 +1,7 @@
 import isHotkey from 'is-hotkey';
 
 import { getRange, getAboveNode, isMarkActive, addMark, removeMark } from '../../internal';
+import { focusEditor } from '../../internal/misc';
 import { KeyboardHandler, NodeEntry } from '../../internal/types';
 import { COMMAND_PROMPT } from './constants';
 
@@ -36,13 +37,11 @@ export const createOnKeyDown = (): KeyboardHandler => {
         }
       }
 
-      if (isHotkey('space', event)) {
-        removeMark(editor, COMMAND_PROMPT, range);
-      }
-
       if (isHotkey('escape', event)) {
+        event.stopPropagation();
         removeMark(editor, COMMAND_PROMPT, range);
         editor.tracking.onCommandPaletteAction('cancelRichTextCommandPalette');
+        focusEditor(editor);
       }
     };
   };


### PR DESCRIPTION
A customer reached out that they are having troubles with the rich text commands plugin.
They have content that contains a slash /. Entering the slash forces the RTE to start a new span (because of the rich text commands plugin) and the slash is not connected to previous content anymore.
They have a workaround for this, to press ESC; But this also blurs the editor and they have to click on the RTE again.

This PR removes the span (rich text commands mark) when the user types a space after typing a slash /.

The only downside to this approach is that the search functionality will not work anymore when you type a space (since the rich text command gets removed).