### PR TITLE
fix: improve types

### DIFF
--- a/packages/_shared/src/utils/entityHelpers.ts
+++ b/packages/_shared/src/utils/entityHelpers.ts
@@ -1,7 +1,8 @@
 import get from 'lodash/get';
 import isObject from 'lodash/isObject';
 import isString from 'lodash/isString';
-import { File, ContentType, Entry, ContentTypeField } from '../typesEntity';
+
+import { Asset, ContentType, ContentTypeField, Entry, File } from '../typesEntity';
 
 function titleOrDefault(title: string | undefined, defaultTitle: string): string {
   if (!isString(title)) {
@@ -49,13 +50,13 @@ export function getAssetTitle({
   defaultLocaleCode,
   defaultTitle,
 }: {
-  asset: Entry;
+  asset: Asset;
   localeCode: string;
   defaultLocaleCode: string;
   defaultTitle: string;
 }) {
   const title = getFieldValue({
-    entity: asset,
+    entity: { fields: { title: asset.fields?.title } },
     fieldId: 'title',
     localeCode,
     defaultLocaleCode,
@@ -71,6 +72,7 @@ export function getAssetTitle({
  */
 export const isAssetField = (field: ContentTypeField): boolean =>
   field.type === 'Link' && field.linkType === 'Asset';
+
 /**
  * Returns true if field is a Title
  */

--- a/packages/rich-text/src/plugins/Hyperlink/useEntityInfo.ts
+++ b/packages/rich-text/src/plugins/Hyperlink/useEntityInfo.ts
@@ -1,6 +1,13 @@
-import { useState, useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
-import { FieldExtensionSDK, Link, Entry, Asset, ScheduledAction } from '@contentful/app-sdk';
+import {
+  Asset,
+  ContentEntityType,
+  Entry,
+  FieldExtensionSDK,
+  Link,
+  ScheduledAction,
+} from '@contentful/app-sdk';
 import { entityHelpers } from '@contentful/field-editor-shared';
 
 import { getEntityInfo } from './utils';
@@ -23,7 +30,7 @@ async function fetchAllData({
 }: {
   sdk: FieldExtensionSDK;
   entityId: string;
-  entityType: string;
+  entityType: ContentEntityType;
   localeCode: string;
   defaultLocaleCode: string;
 }): Promise<FetchedEntityData> {
@@ -74,7 +81,7 @@ async function fetchAllData({
 }
 
 export type EntityInfoProps = {
-  target: Link;
+  target: Link<ContentEntityType>;
   sdk: FieldExtensionSDK;
   onEntityFetchComplete?: VoidFunction;
 };


### PR DESCRIPTION
`getAssetTitle` incorrectly used type Entry as a type. Asset is not compatible with the function signature of `getFieldValue` because of the special type signature of Assets.fields.file => to fix this we now pass the title field only to `getFieldValue`. 

`useEntityInfo` now requires the target to be a `Link<ContentEntityType>` instead of a generic string.