### PR TITLE
fix(markdown-editor): textlink sometimes not centered in help text []

### DIFF
--- a/packages/markdown/src/components/MarkdownBottomBar.tsx
+++ b/packages/markdown/src/components/MarkdownBottomBar.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import { css } from 'emotion';
-import tokens from '@contentful/f36-tokens';
 
 import { TextLink, Paragraph } from '@contentful/f36-components';
+import tokens from '@contentful/f36-tokens';
+import { css } from 'emotion';
 
 const styles = {
   root: css({
@@ -19,6 +19,7 @@ const styles = {
     fontSize: tokens.fontSizeS,
     button: {
       fontSize: tokens.fontSizeS,
+      lineHeight: 'inherit',
     },
   }),
 };
@@ -41,7 +42,8 @@ export function MarkdownHelp(props: { onClick: () => void }) {
         testId="open-markdown-cheatsheet-button"
         onClick={() => {
           props.onClick();
-        }}>
+        }}
+      >
         markdown cheatsheet
       </TextLink>
       .


### PR DESCRIPTION
Fixes the issue that the TextLink inside the help text is not always centered.
Using flex would need more adjustments as it also affects the whitespaces.

# Current
![Screenshot 2023-02-24 at 12 01 49](https://user-images.githubusercontent.com/3918488/221163155-73ef84a3-4582-48d8-b8f2-cc6847a73047.png)

# Flex
![Screenshot 2023-02-24 at 12 00 23](https://user-images.githubusercontent.com/3918488/221163024-7ac8beda-7564-499a-af86-01999b42c15d.png)

# Line-Height
![Screenshot 2023-02-24 at 12 00 57](https://user-images.githubusercontent.com/3918488/221163071-ae3cd2f8-0365-4fad-aeb5-941b78ef541b.png)
