### PR TITLE
chore: update circle ci permissions [TOL-938]

### DIFF
--- a/.contentful/vault-secrets.yaml
+++ b/.contentful/vault-secrets.yaml
@@ -6,3 +6,6 @@ services:
   circleci:
     policies:
       - semantic-release-ecosystem
+      - github-comment
+      - npm-read
+      - aws-push-artifacts

--- a/.contentful/vault-secrets.yaml
+++ b/.contentful/vault-secrets.yaml
@@ -6,6 +6,4 @@ services:
   circleci:
     policies:
       - semantic-release-ecosystem
-      - github-comment
       - npm-read
-      - aws-push-artifacts


### PR DESCRIPTION
this is required before we migrate to use the token from the vault