### PR TITLE
fix: do not focus RTE when another slide is open [TOL-989]

### DIFF
--- a/packages/rich-text/src/helpers/sdkNavigatorSlideIn.spec.ts
+++ b/packages/rich-text/src/helpers/sdkNavigatorSlideIn.spec.ts
@@ -1,0 +1,187 @@
+import cloneDeep from 'lodash/cloneDeep';
+
+import { createFakeNavigatorAPI } from '../../../../cypress/fixtures/navigator';
+import { watchCurrentSlide } from './sdkNavigatorSlideIn';
+
+describe('watchCurrentSlide().info()', () => {
+  let fake, slide;
+
+  beforeEach(() => {
+    const fakeNavigator = createFakeNavigatorAPI();
+    const api = fakeNavigator[0];
+    fake = fakeNavigator[1];
+    slide = watchCurrentSlide(api);
+  });
+
+  it('considers current slide active initially', () => {
+    expect(slide.status()).toEqual({
+      wasClosed: false,
+      isActive: true,
+    });
+  });
+
+  it('no longer considers slide active after another slide opens', () => {
+    fake.slideIn({
+      oldSlideLevel: 0,
+      newSlideLevel: 1,
+    });
+    expect(slide.status()).toEqual({
+      wasClosed: false,
+      isActive: false,
+    });
+  });
+
+  it('considers the original slide active after opening and closing another slide', () => {
+    fake.slideIn({
+      oldSlideLevel: 0,
+      newSlideLevel: 1,
+    });
+    fake.slideIn({
+      oldSlideLevel: 1,
+      newSlideLevel: 0,
+    });
+    expect(slide.status()).toEqual({
+      wasClosed: false,
+      isActive: true,
+    });
+  });
+
+  it('considers slide closed after jumping to slide below', () => {
+    fake.slideIn({
+      oldSlideLevel: 1,
+      newSlideLevel: 0,
+    });
+    expect(slide.status()).toEqual({
+      wasClosed: true,
+      isActive: false,
+    });
+  });
+
+  it('still considers slide closed after jumping to slide below and opening a new one', () => {
+    fake.slideIn({
+      oldSlideLevel: 1,
+      newSlideLevel: 0,
+    });
+    fake.slideIn({
+      oldSlideLevel: 0,
+      newSlideLevel: 1,
+    });
+    expect(slide.status()).toEqual({
+      wasClosed: true,
+      isActive: false,
+    });
+  });
+
+  it('considers slide closed after opening new slide and then jumping to slide below', () => {
+    fake.slideIn({
+      oldSlideLevel: 1,
+      newSlideLevel: 2,
+    });
+    fake.slideIn({
+      oldSlideLevel: 2,
+      newSlideLevel: 0,
+    });
+    expect(slide.status()).toEqual({
+      wasClosed: true,
+      isActive: false,
+    });
+  });
+});
+
+describe('watchCurrentSlide().onActive()', () => {
+  let api, fake, spy;
+
+  beforeEach(() => {
+    const fakeNavigator = createFakeNavigatorAPI();
+    api = fakeNavigator[0];
+    fake = fakeNavigator[1];
+    spy = jest.fn();
+  });
+
+  it('fires initially if there was no slide event', () => {
+    const slide = watchCurrentSlide(api);
+    slide.onActive(spy);
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not fire initially, if new slide already opened, but fires after slide gets closed again', () => {
+    const slide = watchCurrentSlide(api);
+
+    fake.slideIn({
+      oldSlideLevel: 2,
+      newSlideLevel: 3,
+    });
+    slide.onActive(spy);
+    expect(spy).toHaveBeenCalledTimes(0);
+
+    fake.slideIn({
+      oldSlideLevel: 3,
+      newSlideLevel: 2,
+    });
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires every time slide becomes active again', () => {
+    const slide = watchCurrentSlide(api);
+    slide.onActive(spy);
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    fake.slideIn({
+      oldSlideLevel: 0,
+      newSlideLevel: 1,
+    });
+    fake.slideIn({
+      oldSlideLevel: 1,
+      newSlideLevel: 0,
+    });
+    expect(spy).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('watchCurrentSlide().unwatch()', () => {
+  let api, fake;
+
+  beforeEach(() => {
+    const fakeNavigator = createFakeNavigatorAPI();
+    api = fakeNavigator[0];
+    fake = fakeNavigator[1];
+  });
+
+  it('does not update .info() after .unwatch()', () => {
+    const slide = watchCurrentSlide(api);
+    const lastStatus = cloneDeep(slide.status());
+
+    slide.unwatch();
+
+    fake.slideIn({
+      oldSlideLevel: 1,
+      newSlideLevel: 0,
+    });
+    expect(lastStatus).toEqual(slide.status());
+  });
+
+  it('does not fire outstanding onActive after unwatch()', () => {
+    const slide = watchCurrentSlide(api);
+    const slide2 = watchCurrentSlide(api);
+    const spy = jest.fn();
+    const spy2 = jest.fn();
+
+    fake.slideIn({
+      oldSlideLevel: 0,
+      newSlideLevel: 1,
+    });
+
+    slide.onActive(spy);
+    slide2.onActive(spy2);
+
+    slide.unwatch();
+
+    fake.slideIn({
+      oldSlideLevel: 1,
+      newSlideLevel: 0,
+    });
+    expect(spy).toHaveBeenCalledTimes(0);
+    // Demonstrate that normally this would fire an event if it wasn't for the unwatch()
+    expect(spy2).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/rich-text/src/helpers/sdkNavigatorSlideIn.ts
+++ b/packages/rich-text/src/helpers/sdkNavigatorSlideIn.ts
@@ -1,0 +1,63 @@
+import { NavigatorAPI } from '@contentful/app-sdk';
+import noop from 'lodash/noop';
+
+/**
+ * Allows to observe when the current slide-in navigation slide gets e.g.
+ * re-activated after opening another slide on top. This is useful as the sdk
+ * does not give full insights into e.g. whether sdk.dialogs.selectSingleEntry()
+ * with `withCreate: true` option opens the slide-in navigation to edit the
+ * created entry after returning it.
+ */
+export function watchCurrentSlide(navigator: NavigatorAPI) {
+  const onActiveCallbacks = new Set<Function>();
+  let wasSlideClosed = false;
+  let initialSlideLevel;
+  let lastSlideLevel;
+  const status = () => ({
+    wasClosed: wasSlideClosed,
+    isActive: !wasSlideClosed && lastSlideLevel === initialSlideLevel,
+  });
+  const off = navigator.onSlideInNavigation((info) => {
+    if (initialSlideLevel === undefined) {
+      initialSlideLevel = info.oldSlideLevel;
+    }
+    lastSlideLevel = info.newSlideLevel;
+    if (info.newSlideLevel < initialSlideLevel) {
+      wasSlideClosed = true;
+      off(); // No more point in watching, slide got closed.
+      onActiveCallbacks.clear();
+    }
+    if (status().isActive) {
+      onActiveCallbacks.forEach((cb) => cb());
+    }
+  });
+
+  /**
+   * Call to unsubscribe from navigator events when the watcher is no longer
+   * needed.
+   */
+  function unwatch() {
+    off();
+    onActiveCallbacks.clear();
+  }
+
+  /**
+   * Fires immediately when the slide is currently active, or at the point when
+   * it becomes active again, if there are slides on top that get closed. Does not
+   * fire when the observed slide gets closed, and then re-opened through browser
+   * back, as this technically opens a new slide and editor instance.
+   */
+  function onActive(cb: Function) {
+    if (wasSlideClosed) return noop; // Can't re-activate already closed slide.
+    if (status().isActive) {
+      cb();
+    }
+    onActiveCallbacks.add(cb);
+    return () => onActiveCallbacks.delete(cb);
+  }
+  return {
+    status,
+    onActive,
+    unwatch,
+  };
+}


### PR DESCRIPTION
In the rich text editor, when embedding an entry or asset block, ensure that we take into account the entity selector option of `withCreate: true` which can cause the slide-in editor to open (web app).

When the slide-in editor opens, then we only want to re-focus the rich text editor after the slide-in editor (and any other slides opened on top of that) closes.