### PR TITLE
fix: 🐛 do not focus RTE on inline embed + create entry

### DIFF
--- a/packages/rich-text/src/helpers/sdkNavigatorSlideIn.spec.ts
+++ b/packages/rich-text/src/helpers/sdkNavigatorSlideIn.spec.ts
@@ -136,6 +136,18 @@ describe('watchCurrentSlide().onActive()', () => {
     });
     expect(spy).toHaveBeenCalledTimes(2);
   });
+
+  it('does not fire on a slide-in event for the same slide we are already on', () => {
+    const slide = watchCurrentSlide(api);
+    slide.onActive(spy);
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    fake.slideIn({
+      oldSlideLevel: 0,
+      newSlideLevel: 0,
+    });
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe('watchCurrentSlide().unwatch()', () => {

--- a/packages/rich-text/src/helpers/sdkNavigatorSlideIn.ts
+++ b/packages/rich-text/src/helpers/sdkNavigatorSlideIn.ts
@@ -17,17 +17,17 @@ export function watchCurrentSlide(navigator: NavigatorAPI) {
     wasClosed: wasSlideClosed,
     isActive: !wasSlideClosed && lastSlideLevel === initialSlideLevel,
   });
-  const off = navigator.onSlideInNavigation((info) => {
+  const off = navigator.onSlideInNavigation(({ oldSlideLevel, newSlideLevel }) => {
     if (initialSlideLevel === undefined) {
-      initialSlideLevel = info.oldSlideLevel;
+      initialSlideLevel = oldSlideLevel;
     }
-    lastSlideLevel = info.newSlideLevel;
-    if (info.newSlideLevel < initialSlideLevel) {
+    lastSlideLevel = newSlideLevel;
+    if (newSlideLevel < initialSlideLevel) {
       wasSlideClosed = true;
       off(); // No more point in watching, slide got closed.
       onActiveCallbacks.clear();
     }
-    if (status().isActive) {
+    if (status().isActive && newSlideLevel !== oldSlideLevel) {
       onActiveCallbacks.forEach((cb) => cb());
     }
   });

--- a/packages/rich-text/src/plugins/EmbeddedEntityInline/index.tsx
+++ b/packages/rich-text/src/plugins/EmbeddedEntityInline/index.tsx
@@ -15,8 +15,9 @@ import { useContentfulEditor } from '../../ContentfulEditorProvider';
 import { focus, moveToTheNextChar } from '../../helpers/editor';
 import { IS_CHROME } from '../../helpers/environment';
 import newEntitySelectorConfigFromRichTextField from '../../helpers/newEntitySelectorConfigFromRichTextField';
+import { watchCurrentSlide } from '../../helpers/sdkNavigatorSlideIn';
 import { findNodePath } from '../../internal/queries';
-import { setSelection, insertNodes, removeNodes } from '../../internal/transforms';
+import { insertNodes, removeNodes } from '../../internal/transforms';
 import { KeyboardHandler, PlatePlugin, Node } from '../../internal/types';
 import { Element, RenderElementProps } from '../../internal/types';
 import { TrackingPluginActions } from '../../plugins/Tracking';
@@ -66,7 +67,9 @@ function EmbeddedEntityInline(props: EmbeddedEntityInlineProps) {
   const isDisabled = useReadOnly();
 
   function handleEditClick() {
-    return sdk.navigator.openEntry(entryId, { slideIn: true });
+    return sdk.navigator.openEntry(entryId, { slideIn: { waitForClose: true } }).then(() => {
+      editor && focus(editor);
+    });
   }
 
   function handleRemoveClick() {
@@ -120,26 +123,18 @@ async function selectEntityAndInsert(
     ...newEntitySelectorConfigFromRichTextField(sdk.field, INLINES.EMBEDDED_ENTRY),
     withCreate: true,
   };
-  const selection = editor.selection;
-
+  const rteSlide = watchCurrentSlide(sdk.navigator);
   const entry = await sdk.dialogs.selectSingleEntry<Entry>(config);
-  focus(editor); // Dialog steals focus from editor, return it.
 
   if (!entry) {
     logAction('cancelCreateEmbedDialog', { nodeType: INLINES.EMBEDDED_ENTRY });
-    return;
+  } else {
+    insertNodes(editor, createInlineEntryNode(entry.sys.id));
+    logAction('insert', { nodeType: INLINES.EMBEDDED_ENTRY });
   }
-
-  const inlineEntryNode = createInlineEntryNode(entry.sys.id);
-
-  logAction('insert', { nodeType: INLINES.EMBEDDED_ENTRY });
-  // Got to wait until focus is really back on the editor or setSelection() won't work.
-  return new Promise<void>((resolve) => {
-    setTimeout(() => {
-      setSelection(editor, selection);
-      insertNodes(editor, inlineEntryNode);
-      resolve();
-    }, 0);
+  rteSlide.onActive(() => {
+    rteSlide.unwatch();
+    focus(editor);
   });
 }
 


### PR DESCRIPTION
Same as #1353 but for inline embeds. When we create a new entry for an inline embed in the web app, the slide-in editor opens. In this case we  want to focus the slided in entry editor's first field, not the rich text editor in the background tab. Only after the slide closes again, we will focus the rich text editor again.