### PR TITLE
feat: add RTE structure preview in playground

### DIFF
--- a/packages/rich-text/package.json
+++ b/packages/rich-text/package.json
@@ -72,6 +72,7 @@
     "@contentful/rich-text-react-renderer": "^15.11.0",
     "@types/is-hotkey": "^0.1.6",
     "@udecode/plate-test-utils": "^3.2.0",
-    "react": ">=16.14.0"
+    "react": ">=16.14.0",
+    "prism-react-renderer": "^1.3.5"
   }
 }

--- a/packages/rich-text/src/RichTextEditor.mdx
+++ b/packages/rich-text/src/RichTextEditor.mdx
@@ -5,7 +5,7 @@ menu: Editors
 ---
 
 import { Playground } from 'docz';
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { RichTextEditor } from './index';
 import {
   createFakeFieldAPI,
@@ -18,6 +18,7 @@ import {
 import { ValidationErrors } from '@contentful/field-editor-validation-errors';
 import { documentToReactComponents } from '@contentful/rich-text-react-renderer';
 import { validateRichTextDocument } from './test-utils/validation';
+import { RichTextTestPreview } from './test-utils/RichTextTestPreview';
 import { css } from 'emotion';
 import { assets, entries } from '../../reference/src/__fixtures__/fixtures';
 import { MARKS } from '@contentful/rich-text-types';
@@ -62,6 +63,7 @@ import { RichTextEditor } from '@contentful/field-editor-rich-text';
 
     const initialValue = JSON.parse(window.localStorage.getItem('initialValue')) || undefined
     const fieldValidations = JSON.parse(window.localStorage.getItem('fieldValidations')) || undefined
+    const [currentValue, setCurrentValue] = useState({})
     const [field, mitt] = useMemo(() => createFakeFieldAPI(mock => {
       // Overriding mark validation here to show all marks if no fieldValidations set
       mock.validations = !!fieldValidations ? fieldValidations : [
@@ -146,6 +148,7 @@ import { RichTextEditor } from '@contentful/field-editor-rich-text';
     // Validate on change
     React.useEffect(() => {
       field.onValueChanged((value) => {
+        setCurrentValue(value)
         if (!value) {
           return mitt.emit('onSchemaErrorsChanged', []);
         }
@@ -181,6 +184,7 @@ import { RichTextEditor } from '@contentful/field-editor-rich-text';
           restrictedMarks={JSON.parse(window.localStorage.getItem('restrictedMarks')) || []}
         />
         <ValidationErrors field={field} locales={[]} />
+        <RichTextTestPreview value={JSON.stringify(currentValue, null, 2)} />
         <ActionsPlayground mitt={mitt} renderValue={renderRT} />
       </div>
     );

--- a/packages/rich-text/src/test-utils/RichTextTestPreview.tsx
+++ b/packages/rich-text/src/test-utils/RichTextTestPreview.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+import Highlight, { defaultProps } from 'prism-react-renderer';
+import theme from 'prism-react-renderer/themes/github';
+
+type Props = {
+  value: string;
+};
+
+export const RichTextTestPreview = ({ value }: Props) => {
+  return (
+    <Highlight {...defaultProps} theme={theme} code={value} language="json">
+      {({ className, style, tokens, getLineProps, getTokenProps }) => (
+        <pre className={className} style={style}>
+          {tokens.map((line, i) => (
+            <div {...getLineProps({ line, key: i })} key={i}>
+              {line.map((token, key) => (
+                <span {...getTokenProps({ token, key })} key={key} />
+              ))}
+            </div>
+          ))}
+        </pre>
+      )}
+    </Highlight>
+  );
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -20014,6 +20014,11 @@ prism-react-renderer@^0.1.0:
   resolved "https://registry.yarnpkg.com/prism-react-renderer/-/prism-react-renderer-0.1.7.tgz#dc273d0cb6e4a498ba0775094e9a8b01a3ad2eaa"
   integrity sha512-EhnM0sYfLK103ASK0ViSv0rta//ZGB0dBA9TiFyOvA+zOj5peLmGEG01sLEDwl9sMe+gSqncInafBe1VFTCMvA==
 
+prism-react-renderer@^1.3.5:
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/prism-react-renderer/-/prism-react-renderer-1.3.5.tgz#786bb69aa6f73c32ba1ee813fbe17a0115435085"
+  integrity sha512-IJ+MSwBWKG+SM3b2SUfdrhC+gu01QkV2KmRQgREThBfSQRoufqRfxfHUxpG1WcaFjP+kojcFyO9Qqtpgt3qLCg==
+
 private@^0.1.8:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"


### PR DESCRIPTION
Add a preview of the rich text structure in the preview of the rich text editor, so users can play around with the values and learn how the structure changes

<img width="802" alt="grafik" src="https://user-images.githubusercontent.com/5839623/223422822-f4d170e3-d130-4791-be64-15b29c24937c.png">
