### PR TITLE
fix(RTE): split up sanitize regex to prevent invalid markup

### DIFF
--- a/cypress/integration/rich-text/RichTextEditor.Pasting.spec.ts
+++ b/cypress/integration/rich-text/RichTextEditor.Pasting.spec.ts
@@ -250,6 +250,45 @@ describe(
         richText.expectSnapshotValue();
       });
 
+      it('paragraphs with formattings', () => {
+        richText.editor.click().paste({
+          'text/html': `<html xmlns:o="urn:schemas-microsoft-com:office:office"
+          xmlns:w="urn:schemas-microsoft-com:office:word"
+          xmlns:m="http://schemas.microsoft.com/office/2004/12/omml"
+          xmlns="http://www.w3.org/TR/REC-html40">
+          <body lang=DE style='tab-interval:35.4pt;word-wrap:break-word'>
+          <!--StartFragment-->
+
+          <p class=MsoNormal style='margin-bottom:7.5pt;line-height:18.0pt;mso-outline-level:
+          2;background:white'><b><span style='font-size:18.0pt;font-family:"DauphinPlain",serif;
+          mso-fareast-font-family:"Times New Roman";mso-bidi-font-family:"Times New Roman";
+          color:black;mso-fareast-language:EN-GB'>What is Lorem Ipsum?<o:p></o:p></span></b></p>
+
+          <p class=MsoNormal style='text-align:justify;background:white'><b><span
+          style='font-size:10.5pt;font-family:"Open Sans",sans-serif;mso-fareast-font-family:
+          "Times New Roman";color:black;mso-fareast-language:EN-GB'>Lorem Ipsum</span></b><span
+          style='font-size:10.5pt;font-family:"Open Sans",sans-serif;mso-fareast-font-family:
+          "Times New Roman";color:black;mso-fareast-language:EN-GB'>&nbsp;is simply dummy
+          text of the printing and typesetting industry. Lorem Ipsum has been the
+          industry's standard dummy text ever since the 1500s, when an unknown printer
+          took a galley of type and scrambled it to make a type specimen book. It has
+          survived not only five centuries, but also the leap into electronic
+          typesetting, remaining essentially unchanged. <i>It was popularised in the
+          1960s with the release of Letraset sheets containing Lorem Ipsum</i> <b>passages,
+          and more recently with desktop publishing software like Aldus PageMaker
+          including </b><u>versions of Lorem Ipsum.</u><o:p></o:p></span></p>
+
+          <p class=MsoNormal><o:p>&nbsp;</o:p></p>
+
+          <!--EndFragment-->
+          </body>
+
+          </html>`,
+        });
+
+        richText.expectSnapshotValue();
+      });
+
       it('unordered list', () => {
         richText.editor.click().paste({
           'text/html':

--- a/cypress/integration/rich-text/__snapshots__/RichTextEditor.Pasting.spec.ts.snap
+++ b/cypress/integration/rich-text/__snapshots__/RichTextEditor.Pasting.spec.ts.snap
@@ -3181,3 +3181,85 @@ exports[`Rich Text Editor > Tables > Google Docs #0`] =
   "data": {},
   "nodeType": "document"
 };
+
+exports[`Rich Text Editor > Microsoft Word (.docx) deserialization > paragraphs with formattings #0`] =
+{
+  "content": [
+    {
+      "content": [
+        {
+          "data": {},
+          "marks": [
+            {
+              "type": "bold"
+            }
+          ],
+          "nodeType": "text",
+          "value": "What is Lorem Ipsum?"
+        }
+      ],
+      "data": {},
+      "nodeType": "paragraph"
+    },
+    {
+      "content": [
+        {
+          "data": {},
+          "marks": [
+            {
+              "type": "bold"
+            }
+          ],
+          "nodeType": "text",
+          "value": "Lorem Ipsum"
+        },
+        {
+          "data": {},
+          "marks": [],
+          "nodeType": "text",
+          "value": " is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. "
+        },
+        {
+          "data": {},
+          "marks": [
+            {
+              "type": "italic"
+            }
+          ],
+          "nodeType": "text",
+          "value": "It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum"
+        },
+        {
+          "data": {},
+          "marks": [],
+          "nodeType": "text",
+          "value": " "
+        },
+        {
+          "data": {},
+          "marks": [
+            {
+              "type": "bold"
+            }
+          ],
+          "nodeType": "text",
+          "value": "passages, and more recently with desktop publishing software like Aldus PageMaker including "
+        },
+        {
+          "data": {},
+          "marks": [
+            {
+              "type": "underline"
+            }
+          ],
+          "nodeType": "text",
+          "value": "versions of Lorem Ipsum."
+        }
+      ],
+      "data": {},
+      "nodeType": "paragraph"
+    }
+  ],
+  "data": {},
+  "nodeType": "document"
+};

--- a/packages/rich-text/src/plugins/PasteHTML/utils/sanitizeHTML.ts
+++ b/packages/rich-text/src/plugins/PasteHTML/utils/sanitizeHTML.ts
@@ -21,6 +21,8 @@ const stripMetaTags = (doc: Document): Document => {
   return doc;
 };
 
+type Replacer = (innerHTML: string) => string;
+
 // Attention: Order is important
 const transformers = [stripStyleTags, sanitizeSheets, stripMetaTags, sanitizeAnchors];
 
@@ -31,32 +33,50 @@ export const sanitizeHTML = (html: string): string => {
     new DOMParser().parseFromString(html, 'text/html')
   );
 
+  const replacers: Replacer[] = [
+    // remove whitespaces between some tags, as this can lead to unwanted behaviour:
+    // - table -> empty table cells
+    // - list -> leading whitespaces
+    (innerHtml) =>
+      innerHtml.replace(
+        /<(\/)?(table|thead|tbody|tr|td|th|caption|col|colgroup|ol|ul|li)(.*)>\s+<(\/)?(table|thead|tbody|tr|td|th|caption|col|colgroup|ol|ul|li)/g,
+        '<$1$2$3><$4$5'
+      ),
+    // remove empty elements before the ending block element tag
+    (innerHtml) =>
+      innerHtml.replace(
+        /(?:<[^>^/]*>)\s*(?:<\/[^>]*>)<\/(div|p|table|thead|tbody|tr|td|th|caption|col|colgroup|ol|ul|li)/g,
+        '</$1'
+      ),
+    // remove whitespaces before the ending block element tag
+    (innerHTML) =>
+      innerHTML.replace(
+        /\s*<\/(div|p|table|thead|tbody|tr|td|th|caption|col|colgroup|ol|ul|li)/g,
+        '</$1'
+      ),
+  ];
+
+  // Call this replacer only if there are tables inside, as it can have a larger performance impact
+  if (doc.querySelector('table')) {
+    // remove div container from tables
+    // capture groups explained:
+    // 1. and 3. every content/linebreaks before and after the div container
+    // 2. the table inside the container, including content and linebreaks
+    // The div container including attributes and possible linebreaks inside wil be removed
+    replacers.unshift((innerHtml) =>
+      innerHtml.replace(/(.*\s)?<div.*>\s*(<table(?:.|\s)*<\/table>)\s*<\/div>(.*\s)?/g, '$1$2$3')
+    );
+  }
+
   let previous: string;
   do {
     // save previous first before doing modifications
     previous = doc.body.innerHTML;
-    // Update the body with the cleaned up content
-    doc.body.innerHTML = doc.body.innerHTML
-      // remove div container from tables
-      // capture groups explained:
-      // 1. and 3. every content/linebreaks before and after the div container
-      // 2. the table inside the container, including content and linebreaks
-      // The div container including attributes and possible linebreaks inside wil be removed
-      .replace(/(.*\s)?<div.*>\s*(<table(?:.|\s)*<\/table>)\s*<\/div>(.*\s)?/g, '$1$2$3')
-      // remove whitespaces between some tags, as this can lead to unwanted behaviour:
-      // - table -> empty table cells
-      // - list -> leading whitespaces
-      .replace(
-        /<(\/)?(table|thead|tbody|tr|td|th|caption|col|colgroup|ol|ul|li)(.*)>\s+<(\/)?(table|thead|tbody|tr|td|th|caption|col|colgroup|ol|ul|li)/g,
-        '<$1$2$3><$4$5'
-      )
-      // remove empty elements before the ending block element tag
-      .replace(
-        /(?:<[^>^/]*>)\s*(?:<\/[^>]*>)<\/(div|p|table|thead|tbody|tr|td|th|caption|col|colgroup|ol|ul|li)/g,
-        '</$1'
-      )
-      // remove whitespaces before the ending block element tag
-      .replace(/\s*<\/(div|p|table|thead|tbody|tr|td|th|caption|col|colgroup|ol|ul|li)/g, '</$1');
+
+    doc.body.innerHTML = replacers.reduce(
+      (innerHTML, replacer) => replacer(innerHTML),
+      doc.body.innerHTML
+    );
   } while (doc.body.innerHTML !== previous);
 
   return doc.body.innerHTML;

--- a/packages/rich-text/src/plugins/PasteHTML/utils/sanitizeHTML.ts
+++ b/packages/rich-text/src/plugins/PasteHTML/utils/sanitizeHTML.ts
@@ -50,12 +50,13 @@ export const sanitizeHTML = (html: string): string => {
         /<(\/)?(table|thead|tbody|tr|td|th|caption|col|colgroup|ol|ul|li)(.*)>\s+<(\/)?(table|thead|tbody|tr|td|th|caption|col|colgroup|ol|ul|li)/g,
         '<$1$2$3><$4$5'
       )
-      // Removes empty elements before the closing tag of the capture group
-      // <p><span> </span></p> -> <p></p>
+      // remove empty elements before the ending block element tag
       .replace(
-        /(?:<[^>^/]*>)?\s*(?:<\/[^>]*>)?<\/(div|p|table|thead|tbody|tr|td|th|caption|col|colgroup|ol|ul|li)/g,
+        /(?:<[^>^/]*>)\s*(?:<\/[^>]*>)<\/(div|p|table|thead|tbody|tr|td|th|caption|col|colgroup|ol|ul|li)/g,
         '</$1'
-      );
+      )
+      // remove whitespaces before the ending block element tag
+      .replace(/\s*<\/(div|p|table|thead|tbody|tr|td|th|caption|col|colgroup|ol|ul|li)/g, '</$1');
   } while (doc.body.innerHTML !== previous);
 
   return doc.body.innerHTML;


### PR DESCRIPTION
The previously introduced regex for cleaning up unwanted linebreaks and whitespaces had an issue with some inline tags and produced therefore invalid markup.
We now split up the regex into two replacements, this will fix the behaviour and the RTE no longer crashes the page.