### PR TITLE
fix: correct misleading action origin on paste event - rich text

### DIFF
--- a/cypress/integration/rich-text/RichTextEditor.Tracking.spec.ts
+++ b/cypress/integration/rich-text/RichTextEditor.Tracking.spec.ts
@@ -66,7 +66,7 @@ describe('Rich Text Editor - Tracking', { viewportHeight: 2000 }, () => {
           characterCountSelection: 0,
           source: 'Unknown',
         }),
-        action('paste', 'shortcut', {
+        action('paste', 'shortcut-or-viewport', {
           characterCountAfter: 25,
           characterCountBefore: 13,
           characterCountSelection: 0,

--- a/cypress/integration/rich-text/RichTextEditor.Tracking.spec.ts
+++ b/cypress/integration/rich-text/RichTextEditor.Tracking.spec.ts
@@ -49,7 +49,7 @@ describe('Rich Text Editor - Tracking', { viewportHeight: 2000 }, () => {
       richText.editor.click().paste({ 'text/plain': 'Hello World!' });
 
       richText.expectTrackingValue([
-        action('paste', 'shortcut', {
+        action('paste', 'shortcut-or-viewport', {
           characterCountAfter: 12,
           characterCountBefore: 0,
           characterCountSelection: 0,
@@ -60,7 +60,7 @@ describe('Rich Text Editor - Tracking', { viewportHeight: 2000 }, () => {
       richText.editor.click().type('{enter}').paste({ 'text/plain': 'Hello World!' });
 
       richText.expectTrackingValue([
-        action('paste', 'shortcut', {
+        action('paste', 'shortcut-or-viewport', {
           characterCountAfter: 12,
           characterCountBefore: 0,
           characterCountSelection: 0,
@@ -81,7 +81,7 @@ describe('Rich Text Editor - Tracking', { viewportHeight: 2000 }, () => {
       });
 
       richText.expectTrackingValue([
-        action('paste', 'shortcut', {
+        action('paste', 'shortcut-or-viewport', {
           characterCountAfter: 5,
           characterCountBefore: 0,
           characterCountSelection: 0,
@@ -96,7 +96,7 @@ describe('Rich Text Editor - Tracking', { viewportHeight: 2000 }, () => {
       });
 
       richText.expectTrackingValue([
-        action('paste', 'shortcut', {
+        action('paste', 'shortcut-or-viewport', {
           characterCountAfter: 88,
           characterCountBefore: 0,
           characterCountSelection: 0,
@@ -111,7 +111,7 @@ describe('Rich Text Editor - Tracking', { viewportHeight: 2000 }, () => {
       });
 
       richText.expectTrackingValue([
-        action('paste', 'shortcut', {
+        action('paste', 'shortcut-or-viewport', {
           characterCountAfter: 12,
           characterCountBefore: 0,
           characterCountSelection: 0,
@@ -126,7 +126,7 @@ describe('Rich Text Editor - Tracking', { viewportHeight: 2000 }, () => {
       });
 
       richText.expectTrackingValue([
-        action('paste', 'shortcut', {
+        action('paste', 'shortcut-or-viewport', {
           characterCountAfter: 14,
           characterCountBefore: 0,
           characterCountSelection: 0,
@@ -141,7 +141,7 @@ describe('Rich Text Editor - Tracking', { viewportHeight: 2000 }, () => {
       });
 
       richText.expectTrackingValue([
-        action('paste', 'shortcut', {
+        action('paste', 'shortcut-or-viewport', {
           characterCountAfter: 5,
           characterCountBefore: 0,
           characterCountSelection: 0,
@@ -156,7 +156,7 @@ describe('Rich Text Editor - Tracking', { viewportHeight: 2000 }, () => {
       });
 
       richText.expectTrackingValue([
-        action('paste', 'shortcut', {
+        action('paste', 'shortcut-or-viewport', {
           characterCountAfter: 5,
           characterCountBefore: 0,
           characterCountSelection: 0,

--- a/packages/rich-text/src/plugins/Tracking/createTrackingPlugin.ts
+++ b/packages/rich-text/src/plugins/Tracking/createTrackingPlugin.ts
@@ -49,6 +49,11 @@ export interface TrackingPluginActions {
     data?: Record<string, unknown>
   ) => ReturnType<RichTextTrackingActionHandler>;
 
+  onShortcutOrViewportAction: (
+    actionName: RichTextTrackingActionName,
+    data?: Record<string, unknown>
+  ) => ReturnType<RichTextTrackingActionHandler>;
+
   onToolbarAction: (
     actionName: RichTextTrackingActionName,
     data?: Record<string, unknown>
@@ -64,6 +69,7 @@ const actionOrigin = {
   TOOLBAR: 'toolbar-icon',
   SHORTCUT: 'shortcut',
   VIEWPORT: 'viewport-interaction',
+  SHORTCUT_OR_VIEWPORT: 'shortcut-or-viewport',
   COMMAND_PALETTE: 'command-palette',
 };
 
@@ -114,6 +120,9 @@ export const createTrackingPlugin = (onAction: RichTextTrackingActionHandler): P
     onShortcutAction: (actionName: RichTextTrackingActionName, data = {}) =>
       onAction(actionName, { origin: actionOrigin.SHORTCUT, ...data }),
 
+    onShortcutOrViewportAction: (actionName: RichTextTrackingActionName, data = {}) =>
+      onAction(actionName, { origin: actionOrigin.SHORTCUT_OR_VIEWPORT, ...data }),
+
     onToolbarAction: (actionName: RichTextTrackingActionName, data = {}) =>
       onAction(actionName, { origin: actionOrigin.TOOLBAR, ...data }),
 
@@ -134,13 +143,14 @@ export const createTrackingPlugin = (onAction: RichTextTrackingActionHandler): P
       editor.insertData = (data) => {
         const isCopyAndPaste = data.types.length !== 0;
         if (isCopyAndPaste) {
+          console.log('LOG: ', data);
           const characterCountSelection = window.getSelection()?.toString().length;
           const characterCountBefore = getCharacterCount(editor);
 
           setTimeout(() => {
             const characterCountAfter = getCharacterCount(editor);
 
-            trackingActions.onShortcutAction('paste', {
+            trackingActions.onShortcutOrViewportAction('paste', {
               characterCountAfter,
               characterCountBefore,
               characterCountSelection,

--- a/packages/rich-text/src/plugins/Tracking/createTrackingPlugin.ts
+++ b/packages/rich-text/src/plugins/Tracking/createTrackingPlugin.ts
@@ -143,7 +143,6 @@ export const createTrackingPlugin = (onAction: RichTextTrackingActionHandler): P
       editor.insertData = (data) => {
         const isCopyAndPaste = data.types.length !== 0;
         if (isCopyAndPaste) {
-          console.log('LOG: ', data);
           const characterCountSelection = window.getSelection()?.toString().length;
           const characterCountBefore = getCharacterCount(editor);
 


### PR DESCRIPTION
Since we can't (without a major reworking) differentiate between shortcut and viewport action origins in this case, this adds a basically "could be either" origin. Even though it doesn't add any information atm, it does clear things up on the tracking side, and if we ever for some reason add pasting to the toolbar, it will be differentiated from there.