### PR TITLE
fix: [RTE] embed entries in correct place when using hotkeys

### DIFF
--- a/packages/rich-text/src/plugins/EmbeddedEntityBlock/Util.ts
+++ b/packages/rich-text/src/plugins/EmbeddedEntityBlock/Util.ts
@@ -4,7 +4,7 @@ import { focus, insertEmptyParagraph, moveToTheNextChar } from '../../helpers/ed
 import newEntitySelectorConfigFromRichTextField from '../../helpers/newEntitySelectorConfigFromRichTextField';
 import { watchCurrentSlide } from '../../helpers/sdkNavigatorSlideIn';
 import { getText, getAboveNode, getLastNodeByLevel } from '../../internal/queries';
-import { insertNodes, setNodes } from '../../internal/transforms';
+import { insertNodes, select, setNodes } from '../../internal/transforms';
 import { PlateEditor } from '../../internal/types';
 import { TrackingPluginActions } from '../../plugins/Tracking';
 
@@ -22,12 +22,14 @@ export async function selectEntityAndInsert(
     baseConfig.entityType === 'Asset' ? dialogs.selectSingleAsset : dialogs.selectSingleEntry;
   const config = { ...baseConfig, withCreate: true };
 
+  const { selection } = editor;
   const rteSlide = watchCurrentSlide(sdk.navigator);
   const entity = await selectEntity(config);
 
   if (!entity) {
     logAction('cancelCreateEmbedDialog', { nodeType });
   } else {
+    select(editor, selection);
     insertBlock(editor, nodeType, entity);
     ensureFollowingParagraph(editor);
     logAction('insert', { nodeType });

--- a/packages/rich-text/src/plugins/EmbeddedEntityInline/index.tsx
+++ b/packages/rich-text/src/plugins/EmbeddedEntityInline/index.tsx
@@ -17,7 +17,7 @@ import { IS_CHROME } from '../../helpers/environment';
 import newEntitySelectorConfigFromRichTextField from '../../helpers/newEntitySelectorConfigFromRichTextField';
 import { watchCurrentSlide } from '../../helpers/sdkNavigatorSlideIn';
 import { findNodePath } from '../../internal/queries';
-import { insertNodes, removeNodes } from '../../internal/transforms';
+import { insertNodes, removeNodes, select } from '../../internal/transforms';
 import { KeyboardHandler, PlatePlugin, Node } from '../../internal/types';
 import { Element, RenderElementProps } from '../../internal/types';
 import { TrackingPluginActions } from '../../plugins/Tracking';
@@ -123,12 +123,14 @@ async function selectEntityAndInsert(
     ...newEntitySelectorConfigFromRichTextField(sdk.field, INLINES.EMBEDDED_ENTRY),
     withCreate: true,
   };
+  const { selection } = editor;
   const rteSlide = watchCurrentSlide(sdk.navigator);
   const entry = await sdk.dialogs.selectSingleEntry<Entry>(config);
 
   if (!entry) {
     logAction('cancelCreateEmbedDialog', { nodeType: INLINES.EMBEDDED_ENTRY });
   } else {
+    select(editor, selection);
     insertNodes(editor, createInlineEntryNode(entry.sys.id));
     logAction('insert', { nodeType: INLINES.EMBEDDED_ENTRY });
   }


### PR DESCRIPTION
Removing selection in https://github.com/contentful/field-editors/pull/1354 and https://github.com/contentful/field-editors/pull/1353 introduced a regression specifically for users of hotkey insertion. Focusing improvements in those PRs are retained.