### PR TITLE
feat: add more embedded resource block states

### DIFF
--- a/packages/reference/src/components/MissingEntityCard/MissingEntityCard.tsx
+++ b/packages/reference/src/components/MissingEntityCard/MissingEntityCard.tsx
@@ -9,11 +9,12 @@ import * as styles from './styles';
 export function MissingEntityCard(props: {
   entityType: ContentEntityType;
   asSquare?: boolean;
+  isSelected?: boolean;
   isDisabled: boolean;
   onRemove?: Function;
 }) {
   return (
-    <Card className={styles.card} testId="cf-ui-missing-entry-card">
+    <Card className={styles.card} testId="cf-ui-missing-entry-card" isSelected={props.isSelected}>
       <Flex alignItems="center" justifyContent="space-between">
         <div className={props.asSquare ? styles.squareCard : ''}>
           <SectionHeading marginBottom="none">

--- a/packages/reference/src/components/ResourceEntityErrorCard/ResourceEntityErrorCard.tsx
+++ b/packages/reference/src/components/ResourceEntityErrorCard/ResourceEntityErrorCard.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react';
+
+import { isUnsupportedError } from '../../common/EntityStore';
+import { MissingEntityCard } from '../MissingEntityCard/MissingEntityCard';
+import { UnsupportedEntityCard } from './UnsupportedEntityCard';
+
+export function ResourceEntityErrorCard(props: {
+  linkType: string;
+  error: unknown;
+  isSelected?: boolean;
+  isDisabled: boolean;
+  onRemove?: Function;
+}) {
+  if (isUnsupportedError(props.error)) {
+    return <UnsupportedEntityCard linkType={props.linkType} isSelected={props.isSelected} />;
+  }
+
+  return (
+    <MissingEntityCard
+      entityType="Entry"
+      isDisabled={props.isDisabled}
+      isSelected={props.isSelected}
+      onRemove={props.onRemove}
+    />
+  );
+}

--- a/packages/reference/src/components/ResourceEntityErrorCard/UnsupportedEntityCard.tsx
+++ b/packages/reference/src/components/ResourceEntityErrorCard/UnsupportedEntityCard.tsx
@@ -9,11 +9,11 @@ const styles = {
   }),
 };
 
-export function UnsupportedEntityCard(props: { entityType: string }) {
+export function UnsupportedEntityCard(props: { linkType: string; isSelected?: boolean }) {
   return (
-    <Card className={styles.card}>
+    <Card className={styles.card} isSelected={props.isSelected}>
       <SectionHeading marginBottom="none">
-        Resource type {props.entityType} is currently not supported
+        Resource type {props.linkType} is currently not supported
       </SectionHeading>
     </Card>
   );

--- a/packages/reference/src/components/index.ts
+++ b/packages/reference/src/components/index.ts
@@ -7,3 +7,4 @@ export { CreateEntryMenuTrigger } from './CreateEntryLinkButton/CreateEntryMenuT
 export { ScheduledIconWithTooltip } from './ScheduledIconWithTooltip/ScheduledIconWithTooltip';
 export { getScheduleTooltipContent } from './ScheduledIconWithTooltip/ScheduleTooltip';
 export { AssetThumbnail } from './AssetThumbnail/AssetThumbnail';
+export { ResourceEntityErrorCard } from './ResourceEntityErrorCard/ResourceEntityErrorCard';

--- a/packages/reference/src/index.tsx
+++ b/packages/reference/src/index.tsx
@@ -4,6 +4,7 @@ export {
   getScheduleTooltipContent,
   ScheduledIconWithTooltip,
   AssetThumbnail,
+  ResourceEntityErrorCard,
   MissingEntityCard,
   CombinedLinkActions,
 } from './components';

--- a/packages/reference/src/resources/Cards/ResourceCard.spec.tsx
+++ b/packages/reference/src/resources/Cards/ResourceCard.spec.tsx
@@ -1,0 +1,99 @@
+import * as React from 'react';
+
+import '@testing-library/jest-dom';
+
+import { createFakeCMAAdapter } from '@contentful/field-editor-test-utils';
+import { configure, render, waitFor } from '@testing-library/react';
+
+import publishedCT from '../../__fixtures__/content-type/published_content_type.json';
+import publishedEntry from '../../__fixtures__/entry/published_entry.json';
+import space from '../../__fixtures__/space/indifferent_space.json';
+import { EntityProvider } from '../../common/EntityStore';
+import { ResourceCard } from './ResourceCard';
+
+configure({
+  testIdAttribute: 'data-test-id',
+});
+
+jest.mock('react-intersection-observer', () => ({
+  useInView: jest.fn().mockReturnValue({}),
+}));
+
+const resolvableEntryUrn = 'crn:contentful:::content:spaces/space-id/entries/linked-entry-urn';
+const unknownEntryUrn = 'crn:contentful:::content:spaces/space-id/entries/unknown-entry-urn';
+
+const sdk: any = {
+  locales: {
+    default: 'en-US',
+  },
+  cmaAdapter: createFakeCMAAdapter({
+    ContentType: { get: jest.fn().mockReturnValue(publishedCT) },
+    Entry: {
+      get: jest.fn().mockImplementation(({ entryId }) => {
+        if (entryId === 'linked-entry-urn') {
+          return Promise.resolve(publishedEntry);
+        }
+        return Promise.reject(new Error());
+      }),
+    },
+    Locale: {
+      getMany: jest.fn().mockResolvedValue({ items: [{ default: true, code: 'en' }] }),
+    },
+    ScheduledAction: {
+      getMany: jest.fn().mockResolvedValue({ items: [], total: 0 }),
+    },
+    Space: { get: jest.fn().mockResolvedValue(space) },
+  }),
+  space: { onEntityChanged: jest.fn() },
+  navigator: {},
+  ids: {
+    space: 'space-id',
+    environment: 'environment-id',
+  },
+};
+
+function renderResourceCard({ linkType = 'Contentful:Entry', entryUrn = resolvableEntryUrn } = {}) {
+  return render(
+    <EntityProvider sdk={sdk}>
+      <ResourceCard
+        isDisabled={false}
+        getEntryRouteHref={() => ''}
+        resourceLink={{
+          sys: { type: 'ResourceLink', linkType: linkType as 'Contentful:Entry', urn: entryUrn },
+        }}
+      />
+    </EntityProvider>
+  );
+}
+
+describe('ResourceCard', () => {
+  it('renders entry card', async () => {
+    const { getByTestId, getByText } = renderResourceCard();
+
+    await waitFor(() => expect(getByTestId('cf-ui-entry-card')).toBeDefined());
+    expect(getByText(publishedEntry.fields.exField['en-US'])).toBeDefined();
+    expect(getByText(space.name)).toBeDefined();
+  });
+
+  it('renders skeleton when no data is provided', () => {
+    const { getByTestId } = renderResourceCard();
+
+    expect(getByTestId('cf-ui-skeleton-form')).toBeDefined();
+  });
+
+  it('renders unsupported entity card when unsupported link is passed', async () => {
+    const { getByText } = renderResourceCard({ linkType: 'Contentful:UnsupportedLink' });
+
+    await waitFor(() =>
+      expect(
+        getByText('Resource type Contentful:UnsupportedLink is currently not supported')
+      ).toBeDefined()
+    );
+  });
+
+  it('renders missing entity card when unknown error is returned', async () => {
+    const { getByTestId } = renderResourceCard({ entryUrn: unknownEntryUrn });
+
+    await waitFor(() => expect(getByTestId('cf-ui-missing-entry-card')).toBeDefined());
+  });
+});

--- a/packages/reference/src/resources/Cards/ResourceCard.tsx
+++ b/packages/reference/src/resources/Cards/ResourceCard.tsx
@@ -4,11 +4,10 @@ import { useInView } from 'react-intersection-observer';
 import { EntryCard } from '@contentful/f36-components';
 import { SetRequired } from 'type-fest';
 
-import { isUnsupportedError, useResource } from '../../common/EntityStore';
-import { MissingEntityCard } from '../../components';
+import { useResource } from '../../common/EntityStore';
+import { ResourceEntityErrorCard } from '../../components';
 import { RenderDragFn, ResourceLink } from '../../types';
 import { CardActionsHandlers, ContentfulEntryCard, EntryRoute } from './ContentfulEntryCard';
-import { UnsupportedEntityCard } from './UnsupportedEntityCard';
 
 type ResourceCardProps = {
   index?: number;
@@ -43,12 +42,13 @@ function ExistingResourceCard(
     return <ContentfulEntryCard info={data} {...props} />;
   }
 
-  if (isUnsupportedError(error)) {
-    return <UnsupportedEntityCard entityType={resourceLink.sys.linkType} />;
-  }
-
   return (
-    <MissingEntityCard entityType="Entry" isDisabled={props.isDisabled} onRemove={props.onRemove} />
+    <ResourceEntityErrorCard
+      linkType={resourceLink.sys.linkType}
+      error={error}
+      isDisabled={props.isDisabled}
+      onRemove={props.onRemove}
+    />
   );
 }
 

--- a/packages/rich-text/src/plugins/shared/__fixtures__/space.json
+++ b/packages/rich-text/src/plugins/shared/__fixtures__/space.json
@@ -1,0 +1,31 @@
+{
+  "name": "Example Space",
+  "sys": {
+    "type": "Space",
+    "id": "exampleSpace",
+    "version": 8,
+    "createdBy": {
+      "sys": {
+        "type": "Link",
+        "linkType": "User",
+        "id": "34MOMGPHEnQmheXGJJyghQ"
+      }
+    },
+    "createdAt": "2023-06-18T12:00:35Z",
+    "updatedBy": {
+      "sys": {
+        "type": "Link",
+        "linkType": "User",
+        "id": "34MOMGPHEnQmheXGJJyghQ"
+      }
+    },
+    "updatedAt": "2023-06-19T08:11:21Z",
+    "organization": {
+      "sys": {
+        "type": "Link",
+        "linkType": "Organization",
+        "id": "exampleOrg"
+      }
+    }
+  }
+}

--- a/packages/rich-text/src/plugins/shared/__tests__/FetchingWrappedResourceCard.test.tsx
+++ b/packages/rich-text/src/plugins/shared/__tests__/FetchingWrappedResourceCard.test.tsx
@@ -1,0 +1,99 @@
+import * as React from 'react';
+
+import '@testing-library/jest-dom/extend-expect';
+import { EntityProvider } from '@contentful/field-editor-reference';
+import { createFakeCMAAdapter } from '@contentful/field-editor-test-utils';
+import { configure, render, waitFor } from '@testing-library/react';
+
+import publishedCT from '../__fixtures__/published_content_type.json';
+import publishedEntry from '../__fixtures__/published_entry.json';
+import space from '../__fixtures__/space.json';
+import { FetchingWrappedResourceCard } from '../FetchingWrappedResourceCard';
+
+configure({
+  testIdAttribute: 'data-test-id',
+});
+
+let sdk: any;
+
+const resolvableEntryUrn = 'crn:contentful:::content:spaces/space-id/entries/linked-entry-urn';
+const unknownEntryUrn = 'crn:contentful:::content:spaces/space-id/entries/unknown-entry-urn';
+
+beforeEach(() => {
+  sdk = {
+    locales: {
+      default: 'en-US',
+    },
+    cmaAdapter: createFakeCMAAdapter({
+      ContentType: { get: jest.fn().mockReturnValue(publishedCT) },
+      Entry: {
+        get: jest.fn().mockImplementation(({ entryId }) => {
+          if (entryId === 'linked-entry-urn') {
+            return Promise.resolve(publishedEntry);
+          }
+          return Promise.reject(new Error());
+        }),
+      },
+      Locale: {
+        getMany: jest.fn().mockResolvedValue({ items: [{ default: true, code: 'en' }] }),
+      },
+      ScheduledAction: {
+        getMany: jest.fn().mockResolvedValue({ items: [], total: 0 }),
+      },
+      Space: { get: jest.fn().mockResolvedValue(space) },
+    }),
+    space: { onEntityChanged: jest.fn() },
+    navigator: {},
+    ids: {
+      space: 'space-id',
+      environment: 'environment-id',
+    },
+  };
+});
+
+function renderResourceCard({ linkType = 'Contentful:Entry', entryUrn = resolvableEntryUrn } = {}) {
+  return render(
+    <EntityProvider sdk={sdk}>
+      <FetchingWrappedResourceCard
+        isDisabled={false}
+        isSelected={false}
+        sdk={sdk}
+        link={{
+          type: 'ResourceLink',
+          linkType: linkType as 'Contentful:Entry',
+          urn: entryUrn,
+        }}
+      />
+    </EntityProvider>
+  );
+}
+
+test('renders entry card', async () => {
+  const { getByTestId, getByText } = renderResourceCard();
+
+  await waitFor(() => expect(getByTestId('cf-ui-entry-card')).toBeDefined());
+  expect(getByText(publishedEntry.fields.exField.en)).toBeDefined();
+  expect(getByText(space.name)).toBeDefined();
+});
+
+test('renders skeleton when no data is provided', () => {
+  const { getByTestId } = renderResourceCard();
+
+  expect(getByTestId('cf-ui-skeleton-form')).toBeDefined();
+});
+
+test('renders unsupported entity card when unsupported link is passed', async () => {
+  const { getByText } = renderResourceCard({ linkType: 'Contentful:UnsupportedLink' });
+
+  await waitFor(() =>
+    expect(
+      getByText('Resource type Contentful:UnsupportedLink is currently not supported')
+    ).toBeDefined()
+  );
+});
+
+test('renders missing entity card when unknown error is returned', async () => {
+  const { getByTestId } = renderResourceCard({ entryUrn: unknownEntryUrn });
+
+  await waitFor(() => expect(getByTestId('cf-ui-missing-entry-card')).toBeDefined());
+});


### PR DESCRIPTION
Follow-up for https://github.com/contentful/field-editors/pull/1422.

## Details
* Pass _selected_ state to _missing entity_ card.
* Render the _unsupported entity_ card for unknown resource types.
* Create reusable _ResourceEntityErrorCard_ to reduce code duplication.
* Add more tests.