### PR TITLE
fix: type doesn't enforce children prop [SPA-1278]

### DIFF
--- a/packages/reference/src/components/CreateEntryLinkButton/CreateEntryMenuTrigger.tsx
+++ b/packages/reference/src/components/CreateEntryLinkButton/CreateEntryMenuTrigger.tsx
@@ -72,7 +72,7 @@ interface CreateEntryMenuTrigger {
   };
   customDropdownItems?: React.ReactNode;
   children: CreateEntryMenuTriggerChild;
-  menuProps?: MenuProps;
+  menuProps?: Omit<MenuProps, 'children'>;
 }
 
 export const CreateEntryMenuTrigger = ({


### PR DESCRIPTION
Currently, the `menuProps` enforce you pass `children` even though it has no effect.

Fix from https://github.com/contentful/field-editors/pull/1441