### PR TITLE
fix: remove lodash-es to fix cjs issues [TOL-1346]

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,5 +14,6 @@ module.exports = {
         alphabetize: { order: 'asc', ignoreCase: true },
       },
     ],
+    'no-restricted-imports': ['warn'],
   },
 };

--- a/baseJestConfig.js
+++ b/baseJestConfig.js
@@ -5,9 +5,6 @@ function getConfig(packageName) {
     testEnvironment: 'jsdom',
     modulePathIgnorePatterns: ['<rootDir>/dist/'],
     testMatch: ['**/?(*.)+(spec|test).[jt]s?(x)'],
-    moduleNameMapper: {
-      '^lodash-es$': 'lodash',
-    },
     reporters: [
       'default',
       [

--- a/cypress/component/reference/MultipleEntryReferenceEditor.spec.tsx
+++ b/cypress/component/reference/MultipleEntryReferenceEditor.spec.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { NavigatorSlideInfo } from '@contentful/app-sdk';
 import { Button, Card, Heading, Note, Paragraph } from '@contentful/f36-components';
 import { Entry } from '@contentful/field-editor-shared';
-import { cloneDeep, set } from 'lodash-es';
+import { cloneDeep, set } from 'lodash';
 
 import { CombinedLinkActions, MultipleEntryReferenceEditor } from '../../../packages/reference/src';
 import { Entity, Link } from '../../../packages/reference/src/types';

--- a/cypress/fixtures/store.ts
+++ b/cypress/fixtures/store.ts
@@ -1,5 +1,5 @@
 import { MRActions } from 'contentful-management';
-import { get, set, cloneDeep } from 'lodash-es';
+import { cloneDeep, get, set } from 'lodash';
 
 import {
   assets,

--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
     "@testing-library/react": "11.2.6",
     "@types/jest": "^29.5.1",
     "@types/lodash": "4.14.168",
-    "@types/lodash-es": "4.17.7",
     "@types/react": "^16.14.5",
     "@types/react-dom": "16.9.12",
     "@types/testing-library__cypress": "^5.0.9",

--- a/packages/_shared/package.json
+++ b/packages/_shared/package.json
@@ -42,8 +42,7 @@
     "@contentful/f36-note": "^4.2.8",
     "@contentful/f36-tokens": "^4.0.0",
     "emotion": "^10.0.17",
-    "lodash": "^4.17.15",
-    "lodash-es": "^4.17.21"
+    "lodash": "^4.17.15"
   },
   "peerDependencies": {
     "@contentful/app-sdk": "^4.2.0",

--- a/packages/_shared/src/FieldConnector.ts
+++ b/packages/_shared/src/FieldConnector.ts
@@ -1,8 +1,8 @@
 import * as React from 'react';
 
 import { FieldAPI, ValidationError } from '@contentful/app-sdk';
-import { throttle } from 'lodash-es';
 import isEqual from 'lodash/isEqual';
+import throttle from 'lodash/throttle';
 
 type Nullable = null | undefined;
 

--- a/packages/_test/package.json
+++ b/packages/_test/package.json
@@ -43,7 +43,6 @@
     "@contentful/f36-tokens": "^4.0.0",
     "emotion": "^10.0.17",
     "lodash": "^4.17.15",
-    "lodash-es": "^4.17.15",
     "mitt": "2.1.0"
   },
   "peerDependencies": {

--- a/packages/boolean/package.json
+++ b/packages/boolean/package.json
@@ -40,7 +40,6 @@
     "@contentful/field-editor-shared": "^1.3.0",
     "emotion": "^10.0.17",
     "lodash": "^4.17.15",
-    "lodash-es": "^4.17.15",
     "nanoid": "^3.1.3"
   },
   "devDependencies": {

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -39,8 +39,7 @@
     "@contentful/f36-tokens": "^4.0.0",
     "@contentful/field-editor-shared": "^1.3.0",
     "emotion": "^10.0.17",
-    "lodash": "^4.17.15",
-    "lodash-es": "^4.17.15"
+    "lodash": "^4.17.15"
   },
   "devDependencies": {
     "@contentful/field-editor-test-utils": "^1.4.0"

--- a/packages/default-field-editors/jest.config.js
+++ b/packages/default-field-editors/jest.config.js
@@ -9,6 +9,5 @@ module.exports = {
   ...baseConfig(packageName),
   moduleNameMapper: {
     '^.+\\.css$': '<rootDir>/src/__mocks__/styles.ts',
-    '^lodash-es$': 'lodash',
   },
 };

--- a/packages/dropdown/package.json
+++ b/packages/dropdown/package.json
@@ -40,7 +40,6 @@
     "@contentful/field-editor-shared": "^1.3.0",
     "emotion": "^10.0.0",
     "lodash": "^4.17.15",
-    "lodash-es": "^4.17.15",
     "nanoid": "^3.1.3"
   },
   "devDependencies": {

--- a/packages/json/package.json
+++ b/packages/json/package.json
@@ -42,8 +42,7 @@
     "@uiw/react-codemirror": "^4.11.4",
     "deep-equal": "2.0.5",
     "emotion": "^10.0.17",
-    "lodash": "^4.17.15",
-    "lodash-es": "^4.17.15"
+    "lodash": "^4.17.15"
   },
   "devDependencies": {
     "@contentful/field-editor-test-utils": "^1.4.0"

--- a/packages/list/package.json
+++ b/packages/list/package.json
@@ -39,8 +39,7 @@
     "@contentful/f36-tokens": "^4.0.0",
     "@contentful/field-editor-shared": "^1.3.0",
     "emotion": "^10.0.17",
-    "lodash": "^4.17.15",
-    "lodash-es": "^4.17.15"
+    "lodash": "^4.17.15"
   },
   "devDependencies": {
     "@contentful/field-editor-test-utils": "^1.4.0"

--- a/packages/location/package.json
+++ b/packages/location/package.json
@@ -40,8 +40,7 @@
     "deep-equal": "2.0.5",
     "emotion": "^10.0.17",
     "google-map-react": "2.2.0",
-    "lodash": "^4.17.15",
-    "lodash-es": "^4.17.15"
+    "lodash": "^4.17.15"
   },
   "devDependencies": {
     "@contentful/field-editor-test-utils": "^1.4.0"

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -46,7 +46,6 @@
     "dompurify": "^2.2.9",
     "emotion": "^10.0.17",
     "lodash": "^4.17.15",
-    "lodash-es": "^4.17.15",
     "markdown-to-jsx": "^7.1.1"
   },
   "devDependencies": {

--- a/packages/multiple-line/package.json
+++ b/packages/multiple-line/package.json
@@ -39,8 +39,7 @@
     "@contentful/f36-tokens": "^4.0.0",
     "@contentful/field-editor-shared": "^1.3.0",
     "emotion": "^10.0.17",
-    "lodash": "^4.17.15",
-    "lodash-es": "^4.17.15"
+    "lodash": "^4.17.15"
   },
   "devDependencies": {
     "@contentful/field-editor-test-utils": "^1.4.0"

--- a/packages/multiple-line/src/MultipleLineEditor.test.tsx
+++ b/packages/multiple-line/src/MultipleLineEditor.test.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 
 import { createFakeFieldAPI, createFakeLocalesAPI } from '@contentful/field-editor-test-utils';
 import { cleanup, configure, fireEvent, render, waitFor } from '@testing-library/react';
-import identity from 'lodash/identity';
 
 import '@testing-library/jest-dom/extend-expect';
 import { MultipleLineEditor } from './MultipleLineEditor';
@@ -10,14 +9,6 @@ import { MultipleLineEditor } from './MultipleLineEditor';
 configure({
   testIdAttribute: 'data-test-id',
 });
-
-jest.mock(
-  'lodash/throttle',
-  () => ({
-    default: identity,
-  }),
-  { virtual: true }
-);
 
 describe('MultipleLineEditor', () => {
   afterEach(cleanup);

--- a/packages/radio/package.json
+++ b/packages/radio/package.json
@@ -41,7 +41,6 @@
     "@contentful/field-editor-shared": "^1.3.0",
     "emotion": "^10.0.17",
     "lodash": "^4.17.15",
-    "lodash-es": "^4.17.15",
     "nanoid": "^3.1.3"
   },
   "devDependencies": {

--- a/packages/rating/package.json
+++ b/packages/rating/package.json
@@ -39,8 +39,7 @@
     "@contentful/f36-tokens": "^4.0.0",
     "@contentful/field-editor-shared": "^1.3.0",
     "emotion": "^10.0.17",
-    "lodash": "^4.17.15",
-    "lodash-es": "^4.17.15"
+    "lodash": "^4.17.15"
   },
   "devDependencies": {
     "@contentful/field-editor-test-utils": "^1.4.0"

--- a/packages/reference/package.json
+++ b/packages/reference/package.json
@@ -48,7 +48,6 @@
     "deep-equal": "2.0.5",
     "emotion": "^10.0.17",
     "lodash": "^4.17.15",
-    "lodash-es": "^4.17.15",
     "moment": "^2.20.0",
     "p-queue": "^4.0.0",
     "react-intersection-observer": "9.4.0",

--- a/packages/single-line/package.json
+++ b/packages/single-line/package.json
@@ -39,8 +39,7 @@
     "@contentful/f36-tokens": "^4.0.0",
     "@contentful/field-editor-shared": "^1.3.0",
     "emotion": "^10.0.17",
-    "lodash": "^4.17.15",
-    "lodash-es": "^4.17.15"
+    "lodash": "^4.17.15"
   },
   "devDependencies": {
     "@contentful/field-editor-test-utils": "^1.4.0"

--- a/packages/single-line/src/SingleLineEditor.test.tsx
+++ b/packages/single-line/src/SingleLineEditor.test.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 
 import { createFakeFieldAPI, createFakeLocalesAPI } from '@contentful/field-editor-test-utils';
 import { cleanup, configure, fireEvent, render, waitFor } from '@testing-library/react';
-import identity from 'lodash/identity';
 
 import '@testing-library/jest-dom/extend-expect';
 import { SingleLineEditor } from './SingleLineEditor';
@@ -10,14 +9,6 @@ import { SingleLineEditor } from './SingleLineEditor';
 configure({
   testIdAttribute: 'data-test-id',
 });
-
-jest.mock(
-  'lodash/throttle',
-  () => ({
-    default: identity,
-  }),
-  { virtual: true }
-);
 
 describe('SingleLineEditor', () => {
   afterEach(cleanup);

--- a/packages/slug/package.json
+++ b/packages/slug/package.json
@@ -42,7 +42,6 @@
     "@types/speakingurl": "^13.0.2",
     "emotion": "^10.0.17",
     "lodash": "^4.17.15",
-    "lodash-es": "^4.17.15",
     "speakingurl": "^13.0.0",
     "use-debounce": "^7.0.0"
   },

--- a/packages/slug/src/SlugEditor.test.tsx
+++ b/packages/slug/src/SlugEditor.test.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 
 import { createFakeFieldAPI, createFakeLocalesAPI } from '@contentful/field-editor-test-utils';
 import { cleanup, configure, fireEvent, render, waitFor } from '@testing-library/react';
-import identity from 'lodash/identity';
 
 import '@testing-library/jest-dom/extend-expect';
 import { SlugEditor } from './SlugEditor';
@@ -10,14 +9,6 @@ import { SlugEditor } from './SlugEditor';
 configure({
   testIdAttribute: 'data-test-id',
 });
-
-jest.mock(
-  'lodash/throttle',
-  () => ({
-    default: identity,
-  }),
-  { virtual: true }
-);
 
 jest.mock('use-debounce', () => ({
   useDebounce: (text: string) => [text],

--- a/packages/tags/package.json
+++ b/packages/tags/package.json
@@ -42,7 +42,6 @@
     "array-move": "^3.0.0",
     "emotion": "^10.0.0",
     "lodash": "^4.17.15",
-    "lodash-es": "^4.17.15",
     "react-sortable-hoc": "^2.0.0"
   },
   "devDependencies": {

--- a/packages/url/package.json
+++ b/packages/url/package.json
@@ -39,8 +39,7 @@
     "@contentful/f36-tokens": "^4.0.0",
     "@contentful/field-editor-shared": "^1.3.0",
     "emotion": "^10.0.17",
-    "lodash": "^4.17.15",
-    "lodash-es": "^4.17.15"
+    "lodash": "^4.17.15"
   },
   "devDependencies": {
     "@contentful/field-editor-test-utils": "^1.4.0"

--- a/packages/url/src/UrlEditor.test.tsx
+++ b/packages/url/src/UrlEditor.test.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 
 import { createFakeFieldAPI } from '@contentful/field-editor-test-utils';
 import { cleanup, configure, fireEvent, render, waitFor } from '@testing-library/react';
-import identity from 'lodash/identity';
 
 import '@testing-library/jest-dom/extend-expect';
 import { UrlEditor } from './UrlEditor';
@@ -10,14 +9,6 @@ import { UrlEditor } from './UrlEditor';
 configure({
   testIdAttribute: 'data-test-id',
 });
-
-jest.mock(
-  'lodash/throttle',
-  () => ({
-    default: identity,
-  }),
-  { virtual: true }
-);
 
 describe('UrlEditor', () => {
   afterEach(cleanup);

--- a/yarn.lock
+++ b/yarn.lock
@@ -6667,22 +6667,15 @@
   dependencies:
     "@types/node" "*"
 
-"@types/lodash-es@4.17.7":
-  version "4.17.7"
-  resolved "https://registry.yarnpkg.com/@types/lodash-es/-/lodash-es-4.17.7.tgz#22edcae9f44aff08546e71db8925f05b33c7cc40"
-  integrity sha512-z0ptr6UI10VlU6l5MYhGwS4mC8DZyYer2mCoyysZtSF7p26zOX8UpbrV0YpNYLGS8K4PUFIyEr62IMFFjveSiQ==
-  dependencies:
-    "@types/lodash" "*"
-
-"@types/lodash@*", "@types/lodash@^4.14.149", "@types/lodash@^4.14.167":
-  version "4.14.195"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.195.tgz#bafc975b252eb6cea78882ce8a7b6bf22a6de632"
-  integrity sha512-Hwx9EUgdwf2GLarOjQp5ZH8ZmblzcbTBC2wtQWNKARBSxM9ezRIAUpeDTgoQRAFB0+8CNWXVA9+MaSOzOF3nPg==
-
 "@types/lodash@4.14.168":
   version "4.14.168"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.168.tgz#fe24632e79b7ade3f132891afff86caa5e5ce008"
   integrity sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q==
+
+"@types/lodash@^4.14.149", "@types/lodash@^4.14.167":
+  version "4.14.195"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.195.tgz#bafc975b252eb6cea78882ce8a7b6bf22a6de632"
+  integrity sha512-Hwx9EUgdwf2GLarOjQp5ZH8ZmblzcbTBC2wtQWNKARBSxM9ezRIAUpeDTgoQRAFB0+8CNWXVA9+MaSOzOF3nPg==
 
 "@types/markdown-to-jsx@6.11.3":
   version "6.11.3"
@@ -19051,7 +19044,7 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
-lodash-es@^4.17.15, lodash-es@^4.17.21:
+lodash-es@^4.17.15:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
   integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==


### PR DESCRIPTION
@contentful/field-editor-shared is importing lodash-es which seems to cause some issues: https://discord.com/channels/1030176999471321129/1111350294434025613/1132070425254445186

In General:
ESM can import CJS
CJS can't import ESM

@contentful/field-editor-shared is published as CJS and "ESM". Therefore it should only import CJS dependencies. FieldConnector.ts is importing from lodash-es. Also, the package depends on lodash-es. Removing the dependency and avoid importing from lodash-es to have a proper CJS package