### PR TITLE
feat: adding environment support in the WrappedEntryCard

### DIFF
--- a/packages/reference/src/__fixtures__/entry/published_entry_non_master.json
+++ b/packages/reference/src/__fixtures__/entry/published_entry_non_master.json
@@ -1,0 +1,23 @@
+{
+  "sys": {
+    "space": { "sys": { "type": "Link", "linkType": "Space", "id": "my-test-space" } },
+    "id": "published-entry-non-master-environment",
+    "type": "Entry",
+    "createdAt": "2020-02-05T16:16:37.052Z",
+    "updatedAt": "2020-03-25T15:00:06.808Z",
+    "environment": { "sys": { "id": "my-test-environment", "type": "Link", "linkType": "Environment" } },
+    "firstPublishedAt": "2020-02-05T16:16:43.536Z",
+    "createdBy": { "sys": { "type": "Link", "linkType": "User", "id": "34MOMGPHEnQmheXGJJyghQ" } },
+    "updatedBy": { "sys": { "type": "Link", "linkType": "User", "id": "34MOMGPHEnQmheXGJJyghQ" } },
+    "publishedCounter": 2,
+    "version": 10,
+    "publishedVersion": 10,
+    "contentType": {
+      "sys": { "type": "Link", "linkType": "ContentType", "id": "exampleCT" }
+    }
+  },
+  "fields": {
+    "exField": { "en-US": "The best article ever", "de-DE": "Der beste Artikel aller Zeiten" },
+    "exDesc": { "en-US": "Description of the best article", "de-DE": "Beschreibung des besten Artikels" }
+  }
+}

--- a/packages/reference/src/components/SpaceName/SpaceName.tsx
+++ b/packages/reference/src/components/SpaceName/SpaceName.tsx
@@ -5,19 +5,20 @@ import { FolderOpenTrimmedIcon } from '@contentful/f36-icons';
 import tokens from '@contentful/f36-tokens';
 import { css } from 'emotion';
 
-interface SpaceNameProps {
+interface SourceProps {
   spaceName: string;
+  environmentName?: string;
 }
 
 const styles = {
   spaceIcon: css({
     flexShrink: 0,
-    fill: tokens.purple600,
+    fill: tokens.gray600,
   }),
   spaceName: css({
-    color: tokens.gray700,
+    color: tokens.gray600,
     fontSize: tokens.fontSizeS,
-    fontWeight: tokens.fontWeightDemiBold,
+    fontWeight: tokens.fontWeightMedium,
     maxWidth: '80px',
     textOverflow: 'ellipsis',
     overflow: 'hidden',
@@ -25,9 +26,12 @@ const styles = {
   }),
 };
 
-export function SpaceName(props: SpaceNameProps) {
+export function SpaceName(props: SourceProps) {
+  let content = `Space: ${props.spaceName}`;
+  if (props.environmentName) content += ` (Env.: ${props.environmentName})`;
+
   return (
-    <Tooltip placement="top" as="div" content={`Space: ${props.spaceName}`}>
+    <Tooltip placement="top" as="div" content={content}>
       <Flex alignItems="center" gap="spacingXs" marginRight="spacingS">
         <FolderOpenTrimmedIcon className={styles.spaceIcon} size="tiny" aria-label="Source space" />
         <Text className={styles.spaceName}>{props.spaceName}</Text>

--- a/packages/reference/src/entries/WrappedEntryCard/WrappedEntryCard.tsx
+++ b/packages/reference/src/entries/WrappedEntryCard/WrappedEntryCard.tsx
@@ -114,12 +114,16 @@ export function WrappedEntryCard(props: WrappedEntryCardProps) {
       status={status}
       icon={
         props.spaceName ? (
-          <SpaceName spaceName={props.spaceName} />
+          <SpaceName
+            spaceName={props.spaceName}
+            environmentName={props.entry.sys.environment.sys.id}
+          />
         ) : (
           <ScheduledIconWithTooltip
             getEntityScheduledActions={props.getEntityScheduledActions}
             entityType="Entry"
-            entityId={props.entry.sys.id}>
+            entityId={props.entry.sys.id}
+          >
             <ClockIcon
               className={styles.scheduleIcon}
               size="small"
@@ -141,7 +145,8 @@ export function WrappedEntryCard(props: WrappedEntryCardProps) {
                   testId="edit"
                   onClick={() => {
                     props.onEdit && props.onEdit();
-                  }}>
+                  }}
+                >
                   Edit
                 </MenuItem>
               ) : null,
@@ -151,7 +156,8 @@ export function WrappedEntryCard(props: WrappedEntryCardProps) {
                   testId="delete"
                   onClick={() => {
                     props.onRemove && props.onRemove();
-                  }}>
+                  }}
+                >
                   Remove
                 </MenuItem>
               ) : null,
@@ -162,7 +168,8 @@ export function WrappedEntryCard(props: WrappedEntryCardProps) {
                 <MenuItem
                   key="move-top"
                   onClick={() => props.onMoveTop && props.onMoveTop()}
-                  testId="move-top">
+                  testId="move-top"
+                >
                   Move to top
                 </MenuItem>
               ) : null,
@@ -170,7 +177,8 @@ export function WrappedEntryCard(props: WrappedEntryCardProps) {
                 <MenuItem
                   key="move-bottom"
                   onClick={() => props.onMoveBottom && props.onMoveBottom()}
-                  testId="move-bottom">
+                  testId="move-bottom"
+                >
                   Move to bottom
                 </MenuItem>
               ) : null,

--- a/packages/reference/src/resources/Cards/ResourceCard.spec.tsx
+++ b/packages/reference/src/resources/Cards/ResourceCard.spec.tsx
@@ -22,7 +22,7 @@ jest.mock('react-intersection-observer', () => ({
 
 // explicit master
 const resolvableEntryUrn = 'crn:contentful:::content:spaces/space-id/entries/linked-entry-urn';
-const resolvableEntryUrnWithImplicitMaster =
+const resolvableEntryUrnWithExplicitMaster =
   'crn:contentful:::content:spaces/space-id/environments/master/entries/linked-entry-urn';
 const resolvableEntryUrnWithAnotherEnvironment =
   'crn:contentful:::content:spaces/space-id/environments/my-test-environment/entries/linked-entry-urn';
@@ -94,7 +94,7 @@ describe('ResourceCard', () => {
 
   it('renders entry card with explicit master crn', async () => {
     const { getByTestId, getByText } = renderResourceCard({
-      entryUrn: resolvableEntryUrnWithImplicitMaster,
+      entryUrn: resolvableEntryUrnWithExplicitMaster,
     });
 
     await waitFor(() => expect(getByTestId('cf-ui-entry-card')).toBeDefined());

--- a/packages/reference/src/resources/Cards/ResourceCard.spec.tsx
+++ b/packages/reference/src/resources/Cards/ResourceCard.spec.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import '@testing-library/jest-dom';
 
 import { createFakeCMAAdapter } from '@contentful/field-editor-test-utils';
-import { configure, render, waitFor } from '@testing-library/react';
+import { configure, fireEvent, render, waitFor } from '@testing-library/react';
 
 import publishedCT from '../../__fixtures__/content-type/published_content_type.json';
 import publishedEntryNonMasterEnvironment from '../../__fixtures__/entry/published_entry_non_master.json';
@@ -86,20 +86,26 @@ function renderResourceCard({ linkType = 'Contentful:Entry', entryUrn = resolvab
 describe('ResourceCard', () => {
   it('renders entry card with implicit master crn', async () => {
     const { getByTestId, getByText } = renderResourceCard();
+    const tooltipContent = `Space: ${space.name} (Env.: ${publishedEntry.sys.environment.sys.id})`;
 
     await waitFor(() => expect(getByTestId('cf-ui-entry-card')).toBeDefined());
     expect(getByText(publishedEntry.fields.exField['en-US'])).toBeDefined();
     expect(getByText(space.name)).toBeDefined();
+    fireEvent.mouseEnter(getByText(space.name));
+    await waitFor(() => expect(getByText(tooltipContent)).toBeDefined());
   });
 
   it('renders entry card with explicit master crn', async () => {
     const { getByTestId, getByText } = renderResourceCard({
       entryUrn: resolvableEntryUrnWithExplicitMaster,
     });
+    const tooltipContent = `Space: ${space.name} (Env.: ${publishedEntry.sys.environment.sys.id})`;
 
     await waitFor(() => expect(getByTestId('cf-ui-entry-card')).toBeDefined());
     expect(getByText(publishedEntry.fields.exField['en-US'])).toBeDefined();
     expect(getByText(space.name)).toBeDefined();
+    fireEvent.mouseEnter(getByText(space.name));
+    await waitFor(() => expect(getByText(tooltipContent)).toBeDefined());
   });
 
   it('renders entry card with a non master environment', async () => {
@@ -108,8 +114,12 @@ describe('ResourceCard', () => {
     });
 
     await waitFor(() => expect(getByTestId('cf-ui-entry-card')).toBeDefined());
+    const tooltipContent = `Space: ${space.name} (Env.: ${publishedEntryNonMasterEnvironment.sys.environment.sys.id})`;
+
     expect(getByText(publishedEntryNonMasterEnvironment.fields.exField['en-US'])).toBeDefined();
     expect(getByText(space.name)).toBeDefined();
+    fireEvent.mouseEnter(getByText(space.name));
+    await waitFor(() => expect(getByText(tooltipContent)).toBeDefined());
   });
 
   it('renders skeleton when no data is provided', () => {

--- a/packages/reference/src/resources/Cards/ResourceCard.spec.tsx
+++ b/packages/reference/src/resources/Cards/ResourceCard.spec.tsx
@@ -6,6 +6,7 @@ import { createFakeCMAAdapter } from '@contentful/field-editor-test-utils';
 import { configure, render, waitFor } from '@testing-library/react';
 
 import publishedCT from '../../__fixtures__/content-type/published_content_type.json';
+import publishedEntryNonMasterEnvironment from '../../__fixtures__/entry/published_entry_non_master.json';
 import publishedEntry from '../../__fixtures__/entry/published_entry.json';
 import space from '../../__fixtures__/space/indifferent_space.json';
 import { EntityProvider } from '../../common/EntityStore';
@@ -19,7 +20,12 @@ jest.mock('react-intersection-observer', () => ({
   useInView: jest.fn().mockReturnValue({}),
 }));
 
+// explicit master
 const resolvableEntryUrn = 'crn:contentful:::content:spaces/space-id/entries/linked-entry-urn';
+const resolvableEntryUrnWithImplicitMaster =
+  'crn:contentful:::content:spaces/space-id/environments/master/entries/linked-entry-urn';
+const resolvableEntryUrnWithAnotherEnvironment =
+  'crn:contentful:::content:spaces/space-id/environments/my-test-environment/entries/linked-entry-urn';
 const unknownEntryUrn = 'crn:contentful:::content:spaces/space-id/entries/unknown-entry-urn';
 
 const sdk: any = {
@@ -29,9 +35,20 @@ const sdk: any = {
   cmaAdapter: createFakeCMAAdapter({
     ContentType: { get: jest.fn().mockReturnValue(publishedCT) },
     Entry: {
-      get: jest.fn().mockImplementation(({ entryId }) => {
-        if (entryId === 'linked-entry-urn') {
+      get: jest.fn().mockImplementation(({ spaceId, environmentId, entryId }) => {
+        if (
+          spaceId === 'space-id' &&
+          environmentId === 'master' &&
+          entryId === 'linked-entry-urn'
+        ) {
           return Promise.resolve(publishedEntry);
+        }
+        if (
+          spaceId === 'space-id' &&
+          environmentId === 'my-test-environment' &&
+          entryId === 'linked-entry-urn'
+        ) {
+          return Promise.resolve(publishedEntryNonMasterEnvironment);
         }
         return Promise.reject(new Error());
       }),
@@ -67,11 +84,31 @@ function renderResourceCard({ linkType = 'Contentful:Entry', entryUrn = resolvab
 }
 
 describe('ResourceCard', () => {
-  it('renders entry card', async () => {
+  it('renders entry card with implicit master crn', async () => {
     const { getByTestId, getByText } = renderResourceCard();
 
     await waitFor(() => expect(getByTestId('cf-ui-entry-card')).toBeDefined());
     expect(getByText(publishedEntry.fields.exField['en-US'])).toBeDefined();
+    expect(getByText(space.name)).toBeDefined();
+  });
+
+  it('renders entry card with explicit master crn', async () => {
+    const { getByTestId, getByText } = renderResourceCard({
+      entryUrn: resolvableEntryUrnWithImplicitMaster,
+    });
+
+    await waitFor(() => expect(getByTestId('cf-ui-entry-card')).toBeDefined());
+    expect(getByText(publishedEntry.fields.exField['en-US'])).toBeDefined();
+    expect(getByText(space.name)).toBeDefined();
+  });
+
+  it('renders entry card with a non master environment', async () => {
+    const { getByTestId, getByText } = renderResourceCard({
+      entryUrn: resolvableEntryUrnWithAnotherEnvironment,
+    });
+
+    await waitFor(() => expect(getByTestId('cf-ui-entry-card')).toBeDefined());
+    expect(getByText(publishedEntryNonMasterEnvironment.fields.exField['en-US'])).toBeDefined();
     expect(getByText(space.name)).toBeDefined();
   });
 
@@ -93,6 +130,12 @@ describe('ResourceCard', () => {
 
   it('renders missing entity card when unknown error is returned', async () => {
     const { getByTestId } = renderResourceCard({ entryUrn: unknownEntryUrn });
+
+    await waitFor(() => expect(getByTestId('cf-ui-missing-entry-card')).toBeDefined());
+  });
+
+  it('renders missing entity card when crn is invalid', async () => {
+    const { getByTestId } = renderResourceCard({ entryUrn: '' });
 
     await waitFor(() => expect(getByTestId('cf-ui-missing-entry-card')).toBeDefined());
   });


### PR DESCRIPTION
in this PR we want to be able to correctly fetch an entry from a crn that contains environment information whether it is an implicit master (crn contains`/environments/master`) or any other non master environment (crn contains `/environments/staging` for example). We also would. like to show the environment information in the tooltip of the wrapped entry card as shown in the screenshot below: 

![Screenshot 2023-08-10 at 10 54 38](https://github.com/contentful/field-editors/assets/26111745/8a320a3b-5b1d-40c1-8af6-e83c4b14bc4e)
