### PR TITLE
feat: support custom plate plugins and custom toolbars

### DIFF
--- a/cypress/e2e/rich-text/RichTextEditor.CustomAddons.spec.ts
+++ b/cypress/e2e/rich-text/RichTextEditor.CustomAddons.spec.ts
@@ -1,0 +1,41 @@
+import { BLOCKS } from '@contentful/rich-text-types';
+import { lipsumBlockID } from '@contentful/field-editor-rich-text/stories/editor/customAddons';
+
+import { block, document as doc, text } from '../../../packages/rich-text/src/helpers/nodeFactory';
+import { RichTextPage } from './RichTextPage';
+
+describe('Rich Text Editor - Custom Addons', { viewportHeight: 2000 }, () => {
+    let richText: RichTextPage;
+
+    beforeEach(() => {
+        cy.viewport(1000, 2000);
+        richText = new RichTextPage();
+        richText.visit('lipsum');
+    });
+
+    describe('toolbar', () => {
+        // NOTE: We really just want to ensure that the button and component get registered and operate properly.
+        //   As a result, these tests are pretty minimal, since we don't care about the specific functionality of the custom plugin.
+        it('should be visible', () => {
+            richText.customToolbar.toolbar.should('be.visible');
+        });
+
+        it('should contain lipsum button', () => {
+            richText.customToolbar.lipsum.should('be.visible');
+        });
+
+        it('should insert component when clicked', () => {
+            richText.editor.click().type('some text');
+
+            richText.customToolbar.lipsum.click();
+
+            const expectedValue = doc(
+                block(BLOCKS.PARAGRAPH, {}, text('some text', [])),
+                block(lipsumBlockID, {}, text('', [])),
+                block(BLOCKS.PARAGRAPH, {}, text('', []))
+            );
+
+            richText.expectValue(expectedValue);
+        });
+    });
+});

--- a/cypress/e2e/rich-text/RichTextPage.ts
+++ b/cypress/e2e/rich-text/RichTextPage.ts
@@ -9,8 +9,21 @@ const isValidationEvent = ({ type }) => type === 'onSchemaErrorsChanged';
 export type EmbedType = 'entry-block' | 'asset-block' | 'resource-block' | 'entry-inline';
 
 export class RichTextPage {
-  visit() {
-    cy.visit('/?path=/docs/editors-rich-text-editor--docs&cypress');
+  visit(customAddon:string|null = null) {
+    // Support passing a requested custom addon to the storybook instance
+    const additionalParams:Array<string> = [
+        'cypress',
+    ];
+
+    // Handles both null and empty
+    if (customAddon) {
+      additionalParams.push([
+        'ctflRichTextAddon',
+        encodeURIComponent(customAddon),
+      ].join('='));
+    }
+
+    cy.visit(`/?path=/docs/editors-rich-text-editor--docs&${additionalParams.join('&')}`);
     cy.wait(500);
     this.editor.should('be.visible');
   }
@@ -79,6 +92,18 @@ export class RichTextPage {
         getIframe().findByTestId(`toolbar-toggle-embedded-${type}`).click();
       },
     };
+  }
+
+  get customToolbar() {
+    return {
+      get toolbar() {
+        return getIframe().findByTestId('custom-toolbar');
+      },
+
+      get lipsum() {
+        return getIframe().findByTestId('custom-toolbar-lipsum-button');
+      },
+    }
   }
 
   get forms() {

--- a/packages/rich-text/src/RichTextEditor.tsx
+++ b/packages/rich-text/src/RichTextEditor.tsx
@@ -11,7 +11,7 @@ import noop from 'lodash/noop';
 
 import { ContentfulEditorIdProvider, getContentfulEditorId } from './ContentfulEditorProvider';
 import { toSlateValue } from './helpers/toSlateValue';
-import { PlatePlugin } from './internal';
+import { CustomToolbarProps, PlatePlugin } from './internal';
 import { normalizeInitialValue } from './internal/misc';
 import { getPlugins, disableCorePlugins, CustomPlatePluginCallback } from './plugins';
 import { RichTextTrackingActionHandler } from './plugins/Tracking';
@@ -33,10 +33,7 @@ type ConnectedProps = {
   actionsDisabled?: boolean;
   restrictedMarks?: string[];
   customPlugins?: Array<(constructionArgs: CustomPlatePluginCallback) => PlatePlugin>;
-  customToolbars?: React.JSXElementConstructor<{
-    isDisabled?: boolean;
-    [index: string]: unknown;
-  }>[];
+  customToolbars?: Array<React.JSXElementConstructor<CustomToolbarProps>>;
 };
 
 export const ConnectedRichTextEditor = (props: ConnectedProps) => {
@@ -80,14 +77,11 @@ export const ConnectedRichTextEditor = (props: ConnectedProps) => {
               <StickyToolbarWrapper isDisabled={props.isDisabled}>
                 <Toolbar isDisabled={props.isDisabled} />
                 {/* Custom toolbars are placed underneath Contentful's built-in one */}
-                {props?.customToolbars?.length &&
-                  props.customToolbars.map((ToolbarComponent, index) => {
-                    return (
-                      <React.Fragment key={index}>
-                        <ToolbarComponent isDisabled={props.isDisabled} />
-                      </React.Fragment>
-                    );
-                  })}
+                {props?.customToolbars?.map((ToolbarComponent, index) => {
+                  return (
+                    <ToolbarComponent id={`RTEditor-Custom-Toolbar-${index}`} key={index} isDisabled={props.isDisabled || false} />
+                  );
+                })}
               </StickyToolbarWrapper>
             )}
             <SyncEditorChanges incomingValue={initialValue} onChange={props.onChange} />

--- a/packages/rich-text/src/RichTextEditor.tsx
+++ b/packages/rich-text/src/RichTextEditor.tsx
@@ -13,7 +13,7 @@ import { ContentfulEditorIdProvider, getContentfulEditorId } from './ContentfulE
 import { toSlateValue } from './helpers/toSlateValue';
 import { PlatePlugin } from './internal';
 import { normalizeInitialValue } from './internal/misc';
-import { getPlugins, disableCorePlugins } from './plugins';
+import { getPlugins, disableCorePlugins, CustomPlatePluginCallback } from './plugins';
 import { RichTextTrackingActionHandler } from './plugins/Tracking';
 import { styles } from './RichTextEditor.styles';
 import { SdkProvider } from './SdkProvider';
@@ -32,7 +32,7 @@ type ConnectedProps = {
   isToolbarHidden?: boolean;
   actionsDisabled?: boolean;
   restrictedMarks?: string[];
-  customPlugins?: PlatePlugin[];
+  customPlugins?: Array<(constructionArgs: CustomPlatePluginCallback) => PlatePlugin>;
   customToolbars?: React.JSXElementConstructor<{
     isDisabled?: boolean;
     [index: string]: unknown;

--- a/packages/rich-text/src/RichTextEditor.tsx
+++ b/packages/rich-text/src/RichTextEditor.tsx
@@ -11,6 +11,7 @@ import noop from 'lodash/noop';
 
 import { ContentfulEditorIdProvider, getContentfulEditorId } from './ContentfulEditorProvider';
 import { toSlateValue } from './helpers/toSlateValue';
+import { PlatePlugin } from './internal';
 import { normalizeInitialValue } from './internal/misc';
 import { getPlugins, disableCorePlugins } from './plugins';
 import { RichTextTrackingActionHandler } from './plugins/Tracking';
@@ -31,6 +32,11 @@ type ConnectedProps = {
   isToolbarHidden?: boolean;
   actionsDisabled?: boolean;
   restrictedMarks?: string[];
+  customPlugins?: PlatePlugin[];
+  customToolbars?: React.JSXElementConstructor<{
+    isDisabled?: boolean;
+    [index: string]: unknown;
+  }>[];
 };
 
 export const ConnectedRichTextEditor = (props: ConnectedProps) => {
@@ -38,8 +44,8 @@ export const ConnectedRichTextEditor = (props: ConnectedProps) => {
 
   const id = getContentfulEditorId(sdk);
   const plugins = React.useMemo(
-    () => getPlugins(sdk, onAction ?? noop, restrictedMarks),
-    [sdk, onAction, restrictedMarks]
+    () => getPlugins(sdk, onAction ?? noop, restrictedMarks, props?.customPlugins ?? []),
+    [sdk, onAction, restrictedMarks, props?.customPlugins]
   );
 
   const initialValue = React.useMemo(() => {
@@ -73,6 +79,15 @@ export const ConnectedRichTextEditor = (props: ConnectedProps) => {
             {!props.isToolbarHidden && (
               <StickyToolbarWrapper isDisabled={props.isDisabled}>
                 <Toolbar isDisabled={props.isDisabled} />
+                {/* Custom toolbars are placed underneath Contentful's built-in one */}
+                {props?.customToolbars?.length &&
+                  props.customToolbars.map((ToolbarComponent, index) => {
+                    return (
+                      <React.Fragment key={index}>
+                        <ToolbarComponent isDisabled={props.isDisabled} />
+                      </React.Fragment>
+                    );
+                  })}
               </StickyToolbarWrapper>
             )}
             <SyncEditorChanges incomingValue={initialValue} onChange={props.onChange} />

--- a/packages/rich-text/src/helpers/editor.ts
+++ b/packages/rich-text/src/helpers/editor.ts
@@ -52,7 +52,10 @@ export function isRootLevel(path: Path): boolean {
 }
 
 type NodeEntry = [Element, Path];
-type NodeType = BLOCKS | INLINES;
+
+// String here is unfortunately required in order for custom plugins that make a new block to be valid
+//   Alternate here is to force custom plugins to opt-into ts-ignore every time they want to use these helpers
+type NodeType = BLOCKS | INLINES | string;
 export function getNodeEntryFromSelection(
   editor: PlateEditor,
   nodeTypeOrTypes: NodeType | NodeType[],

--- a/packages/rich-text/src/internal/types/plugins.ts
+++ b/packages/rich-text/src/internal/types/plugins.ts
@@ -7,6 +7,11 @@ import { Value, PlateEditor } from './editor';
 
 export type KeyboardHandler<P = p.PluginOptions> = p.KeyboardHandler<P, Value, PlateEditor>;
 
+export interface CustomToolbarProps {
+  [index:string]: unknown;
+  isDisabled: boolean;
+}
+
 export interface PlatePlugin extends p.PlatePlugin<p.AnyObject, Value, PlateEditor> {
   softBreak?: SoftBreakRule[];
   exitBreak?: ExitBreakRule[];

--- a/packages/rich-text/src/plugins/index.ts
+++ b/packages/rich-text/src/plugins/index.ts
@@ -2,7 +2,7 @@ import { FieldExtensionSDK } from '@contentful/app-sdk';
 import { PlateProps } from '@udecode/plate-core';
 import { createDeserializeDocxPlugin } from '@udecode/plate-serializer-docx';
 
-import { PlatePlugin } from '../internal/types';
+import { CustomToolbarProps, PlatePlugin } from '../internal/types';
 import { createSoftBreakPlugin, createExitBreakPlugin, createResetNodePlugin } from './Break';
 import { createCommandPalettePlugin } from './CommandPalette';
 import { isCommandPromptPluginEnabled } from './CommandPalette/useCommands';
@@ -28,10 +28,22 @@ import { createTextPlugin } from './Text';
 import { createTrackingPlugin, RichTextTrackingActionHandler } from './Tracking';
 import { createTrailingParagraphPlugin } from './TrailingParagraph';
 import { createVoidsPlugin } from './Voids';
+import * as React from "react";
 
 export interface CustomPlatePluginCallback {
   sdk: FieldExtensionSDK;
   restrictedMarks: Array<string>;
+}
+
+// Used purely for tests
+export interface CustomAddonConfiguration {
+  [index: string]: CustomAddon;
+}
+
+// Used purely for tests
+export interface CustomAddon {
+  plugin?: (constructionArgs: CustomPlatePluginCallback) => PlatePlugin;
+  toolbar?: React.JSXElementConstructor<CustomToolbarProps>;
 }
 
 export const getPlugins = (

--- a/packages/rich-text/src/plugins/index.ts
+++ b/packages/rich-text/src/plugins/index.ts
@@ -29,11 +29,16 @@ import { createTrackingPlugin, RichTextTrackingActionHandler } from './Tracking'
 import { createTrailingParagraphPlugin } from './TrailingParagraph';
 import { createVoidsPlugin } from './Voids';
 
+export interface CustomPlatePluginCallback {
+  sdk: FieldExtensionSDK;
+  restrictedMarks: Array<string>;
+}
+
 export const getPlugins = (
   sdk: FieldExtensionSDK,
   onAction: RichTextTrackingActionHandler,
   restrictedMarks?: string[],
-  customPlugins?: PlatePlugin[]
+  customPlugins?: Array<(constructionArgs: CustomPlatePluginCallback) => PlatePlugin>
 ): PlatePlugin[] => [
   createDeserializeDocxPlugin(),
 
@@ -83,7 +88,14 @@ export const getPlugins = (
 
   // We need to check if the plugins are defined before use because it is an
   // optional parameter.
-  ...(Array.isArray(customPlugins) ? customPlugins : []),
+  ...(Array.isArray(customPlugins)
+    ? customPlugins.map((customPluginCallback) => {
+        return customPluginCallback.call(this, {
+          sdk,
+          restrictedMarks: restrictedMarks || [],
+        });
+      })
+    : []),
 ];
 
 export const disableCorePlugins: PlateProps['disableCorePlugins'] = {

--- a/packages/rich-text/src/plugins/index.ts
+++ b/packages/rich-text/src/plugins/index.ts
@@ -32,7 +32,8 @@ import { createVoidsPlugin } from './Voids';
 export const getPlugins = (
   sdk: FieldExtensionSDK,
   onAction: RichTextTrackingActionHandler,
-  restrictedMarks?: string[]
+  restrictedMarks?: string[],
+  customPlugins?: PlatePlugin[]
 ): PlatePlugin[] => [
   createDeserializeDocxPlugin(),
 
@@ -79,6 +80,10 @@ export const getPlugins = (
   createExitBreakPlugin(),
   createResetNodePlugin(),
   createNormalizerPlugin(),
+
+  // We need to check if the plugins are defined before use because it is an
+  // optional parameter.
+  ...(Array.isArray(customPlugins) ? customPlugins : []),
 ];
 
 export const disableCorePlugins: PlateProps['disableCorePlugins'] = {

--- a/packages/rich-text/stories/editor/customAddons/index.ts
+++ b/packages/rich-text/stories/editor/customAddons/index.ts
@@ -1,0 +1,1 @@
+export * from './lipsum'

--- a/packages/rich-text/stories/editor/customAddons/lipsum.tsx
+++ b/packages/rich-text/stories/editor/customAddons/lipsum.tsx
@@ -1,0 +1,162 @@
+import React from 'react';
+import * as Slate from 'slate-react';
+
+import { Flex, Button, Tooltip } from '@contentful/f36-components';
+import { TextIcon } from '@contentful/f36-icons';
+import tokens from '@contentful/f36-tokens';
+import { css, cx } from 'emotion';
+
+import {
+    CustomToolbarProps,
+    getText,
+    insertNodes,
+    PlateEditor,
+    PlatePlugin,
+    removeNodes,
+    setNodes,
+} from '../../../src/internal';
+import { useContentfulEditor } from '../../../src/ContentfulEditorProvider';
+import { focus, getNodeEntryFromSelection, moveToTheNextLine } from '../../../src/helpers/editor';
+import { CustomAddonConfiguration } from '../../../src/plugins';
+
+// Somewhat copied from the native toolbar so the test looks reasonably normal
+const styles:Record<'toolbar'|'container'|'renderContainer'|'renderSelected', string> = {
+    container: css({
+        margin: `0 0 ${tokens.spacingL}`,
+    }),
+    toolbar: css({
+        // This allows us to hide the bottom border from the native toolbar, making the custom one, in this case, look seamless
+        marginTop: -1,
+        border: `1px solid ${tokens.gray400}`,
+        borderTop: 0,
+        backgroundColor: tokens.gray100,
+        padding: tokens.spacingXs,
+    }),
+    renderContainer: css({
+        //
+        border: `1px solid rgb(155 149 132)`,
+        background: `rgb(247 239 214)`,
+        padding: tokens.spacingM,
+        borderRadius: tokens.spacingL,
+    }),
+    renderSelected: css({
+        border: `1px solid ${tokens.blue400}`,
+        boxShadow: `0 0 0 2px ${tokens.blue400}`,
+    }),
+};
+
+export const lipsumBlockID = 'custom_lipsum';
+
+const LipsumToolbar = ({ isDisabled }: CustomToolbarProps) => {
+    const editor = useContentfulEditor();
+
+    const handleClick = React.useCallback(() => {
+        if (!editor?.selection) {
+            return;
+        }
+
+        const lipsum = {
+            type: lipsumBlockID,
+            data: {},
+            children: [{ text: '' }],
+            isVoid: true,
+        };
+
+        // Borrowed without modifications from the HR plugin
+        const hasText = !!getText(editor, editor.selection.focus.path);
+        hasText ? insertNodes(editor, lipsum) : setNodes(editor, lipsum);
+
+        // Move focus to the next paragraph (added by TrailingParagraph plugin)
+        moveToTheNextLine(editor);
+
+        focus(editor);
+    }, [editor]);
+
+    if (!editor) {
+        return null;
+    }
+
+    return <Flex aria-disabled={isDisabled} className={styles.toolbar} testId="custom-toolbar">
+        <Tooltip
+            content="Insert Lorem ipsum Text"
+            testId="custom-toolbar"
+            placement={'bottom'}
+            usePortal={true}
+            isDisabled={isDisabled}
+        >
+            <Button
+                isDisabled={isDisabled}
+                title="Insert Lipsum text"
+                testId="custom-toolbar-lipsum-button"
+                startIcon={<TextIcon />}
+                variant="transparent"
+                onClick={handleClick}
+            >Insert Lipsum text</Button>
+        </Tooltip>
+    </Flex>
+}
+
+export const lipsumComponent = (props: Slate.RenderLeafProps) => {
+    const isSelected = Slate.useSelected();
+
+    return (
+        <div
+            {...props.attributes}
+            className={styles.container}
+            data-void-element={lipsumBlockID}>
+            <div
+                draggable={true}
+                // Moving `contentEditable` to this div makes it to be selectable when being the first void element, e.g pressing ctrl + a to select everything
+                contentEditable={false}>
+                <div className={cx(styles.renderContainer, (isSelected ? styles.renderSelected : undefined))}>
+                    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+                </div>
+            </div>
+            {props.children}
+        </div>
+    );
+}
+
+/**
+ * Taken almost identically from HR Events.  We need to delete the node, treating its contents as a void instead of editable text
+ *
+ * @param editor
+ */
+export const withLipsumEvents = (editor: PlateEditor) => {
+    return (event: React.KeyboardEvent) => {
+        if (!editor) {
+            return;
+        }
+
+        const [, pathToSelectedLipsumNode] = getNodeEntryFromSelection(editor, lipsumBlockID);
+
+        if (pathToSelectedLipsumNode) {
+            const isBackspace = event.key === 'Backspace';
+            const isDelete = event.key === 'Delete';
+
+            if (isBackspace || isDelete) {
+                event.preventDefault();
+
+                removeNodes(editor, { at: pathToSelectedLipsumNode });
+            }
+        }
+    };
+}
+
+const LipsumPlugin = (): PlatePlugin => ({
+    key: lipsumBlockID,
+    type: lipsumBlockID,
+    isVoid: true,
+    isElement: true,
+    component: lipsumComponent,
+    handlers: {
+        onKeyDown: withLipsumEvents,
+    },
+});
+
+export const lipsumPlugin:CustomAddonConfiguration = {
+    lipsum: {
+        plugin: LipsumPlugin,
+        toolbar: LipsumToolbar,
+    },
+};


### PR DESCRIPTION
### Description

Replaces #702 

Adds 2 new props to the Rich text Editor:

1. `customPlugins`
2. `customToolbars`

These properties aim to make it more simple to add custom Plate plugins and add custom Toolbar elements to the existing Rich Text editors without needing to maintain a separate, modified, fork of the Rich text editor perpetually.

### Notes

- These new props are fully backwards compatible, meaning there is no change whatsoever to dcustomers using the native Rich Text Editor.
- Plugins are registered with access to the SDK to enable features that require SDK assistance, such as lookups, etc.
- Plugins are registered after Contentful's list of native plugins to ensure that they are in the correct state before custom features are registrered.
- Custom toolbars are placed below Contentful's native one, within the sticky toolbar wrapper, to keep custom functionality separate from Contentful's native toolbar while enabling customers to enable quick access to custom tooling.
- There is a new 3 test test suite added to ensure that the capabilities of the new props are operating properly (The tests **do not** aim to test that the custom slate plugin operates correctly in all cases.  Instead, the tests just aim to ensure that a toolbar and a custom plate plugin can be registered and operates accordingly).
- Storybook was modified to accept a new parameter, `ctflRichTextAddon`, that will attempt to load up a custom toolbar and plugin from the specified export name.  Currently, the example `lipsum` plugin is the only one that exists.
  - Providing this parameter, even if there is no plugin to load by that name, will display a warning that the validator for the Rich text events stream is disabled.
  - This new parameter was chosen over putting another custom toolbar into the Rich Text Editor in Storybook to ensure that Contentful doesn't need to work around the functionality when developing updates to the editor.

### Screenshots
#### Default Rich Text Editor in Storybook (Unchanged default behavior confirmation):
![89fd30ec-5860-e37e-e493-ae8505efb1e3](https://github.com/contentful/field-editors/assets/87489968/b76fe604-174b-428f-8a72-10611c1c86ec)

#### Rich Text Editor with custom features enabled in Storybook:
![c0cedda1-acd6-2d31-e301-db271c0a702f](https://github.com/contentful/field-editors/assets/87489968/5d952697-4643-4563-8353-9c3bcde5a8a1)

#### Rendered custom Plate plugin contents in Storybook:
![5421f3ed-4536-40e2-f744-1bc6304c8cb8](https://github.com/contentful/field-editors/assets/87489968/de208d52-fc37-4c25-bfb7-a4bd559daba4)
