### PR TITLE
fix: show RT embed button also for resource only

### DIFF
--- a/packages/rich-text/src/Toolbar/components/EmbedEntityWidget.tsx
+++ b/packages/rich-text/src/Toolbar/components/EmbedEntityWidget.tsx
@@ -66,7 +66,10 @@ export const EmbedEntityWidget = ({ isDisabled, canInsertBlocks }: EmbedEntityWi
   );
 
   const showEmbedButton =
-    blockEntryEmbedEnabled || inlineEntryEmbedEnabled || blockAssetEmbedEnabled;
+    blockEntryEmbedEnabled ||
+    blockResourceEmbedEnabled ||
+    inlineEntryEmbedEnabled ||
+    blockAssetEmbedEnabled;
 
   return showEmbedButton ? (
     <EmbeddedEntityDropdownButton


### PR DESCRIPTION
Show _embed_ button in Rich Text toolbar when resource block is the only enabled node.