### PR TITLE
fix(json-editor): consolidate tab width

### DIFF
--- a/packages/json/src/JsonEditor.tsx
+++ b/packages/json/src/JsonEditor.tsx
@@ -8,7 +8,7 @@ import { JsonEditorField } from './JsonEditorField';
 import { JsonEditorToolbar } from './JsonEditorToolbar';
 import { JsonInvalidStatus } from './JsonInvalidStatus';
 import { JSONObject } from './types';
-import { stringifyJSON, parseJSON } from './utils';
+import { stringifyJSON, parseJSON, SPACE_INDENT_COUNT } from './utils';
 
 export interface JsonEditorProps {
   /**
@@ -168,7 +168,8 @@ export default function JsonEditor(props: JsonEditorProps) {
       isInitiallyDisabled={props.isInitiallyDisabled}
       isEqualValues={(value1, value2) => {
         return deepEqual(value1, value2);
-      }}>
+      }}
+    >
       {({ value, disabled, setValue, externalReset }) => {
         return (
           <ConnectedJsonEditor
@@ -183,3 +184,5 @@ export default function JsonEditor(props: JsonEditorProps) {
     </FieldConnector>
   );
 }
+
+JsonEditor.tabWidth = SPACE_INDENT_COUNT;

--- a/packages/json/src/JsonEditorField.tsx
+++ b/packages/json/src/JsonEditorField.tsx
@@ -1,10 +1,13 @@
 import * as React from 'react';
 
 import { json } from '@codemirror/lang-json';
+import { indentUnit } from '@codemirror/language';
 import { EditorView } from '@codemirror/view';
 import tokens from '@contentful/f36-tokens';
 import CodeMirror from '@uiw/react-codemirror';
 import { css, cx } from 'emotion';
+
+import { SPACE_INDENT_COUNT } from './utils';
 
 type JsonEditorFieldProps = {
   isDisabled: boolean;
@@ -61,7 +64,11 @@ export function JsonEditorField(props: JsonEditorFieldProps) {
         value={props.value}
         onChange={props.onChange}
         theme="light"
-        extensions={[json(), EditorView.lineWrapping]}
+        extensions={[
+          json(),
+          EditorView.lineWrapping,
+          indentUnit.of(new Array(SPACE_INDENT_COUNT).fill(' ').join('')),
+        ]}
         basicSetup={{
           closeBrackets: false,
           lineNumbers: false,

--- a/packages/json/src/utils.ts
+++ b/packages/json/src/utils.ts
@@ -1,10 +1,12 @@
 import { JSONObject } from './types';
 
+export const SPACE_INDENT_COUNT = 4;
+
 export function stringifyJSON(obj: JSONObject | null | undefined): string {
   if (obj === null || obj === undefined) {
     return '';
   } else {
-    return JSON.stringify(obj, null, 4);
+    return JSON.stringify(obj, null, SPACE_INDENT_COUNT);
   }
 }
 


### PR DESCRIPTION
The JSON editor used a different tab width for indentation:
- value was parsed with 4 spaces
- codemirror used 2 spaces

This resulted always into different indentation on pressing enter