### PR TITLE
fix: rich text commands listens to validations [TOL-1473]

### DIFF
--- a/cypress/e2e/rich-text/RichTextEditor.Commands.spec.ts
+++ b/cypress/e2e/rich-text/RichTextEditor.Commands.spec.ts
@@ -75,19 +75,12 @@ describe('Rich Text Editor - Commands', { viewportHeight: 2000 }, () => {
       getCommandList().findByText('Embed Example Content Type - Inline').click();
       getCommandList().findByText('Hello world').click();
 
-      const expectedValue = doc(
-        block(
-          BLOCKS.PARAGRAPH,
-          {},
-          text(),
-          block(INLINES.EMBEDDED_ENTRY, {
-            target: { sys: { id: 'exampleCT', type: 'Link', linkType: 'Entry' } },
-          }),
-          text()
-        )
-      );
-
-      richText.expectValue(expectedValue);
+      //this is used instead of snapshot value because we have randomized entry IDs
+      richText.getValue().should((doc) => {
+        expect(
+          doc.content[0].content.filter((node) => node.nodeType === INLINES.EMBEDDED_ENTRY)
+        ).to.have.length(1);
+      });
     });
 
     it('should embed asset', () => {
@@ -134,19 +127,12 @@ describe('Rich Text Editor - Commands', { viewportHeight: 2000 }, () => {
 
       richText.editor.findByTestId('embedded-entry-inline').should('exist');
 
-      const expectedValue = doc(
-        block(
-          BLOCKS.PARAGRAPH,
-          {},
-          text(),
-          block(INLINES.EMBEDDED_ENTRY, {
-            target: { sys: { id: 'exampleCT', type: 'Link', linkType: 'Entry' } },
-          }),
-          text()
-        )
-      );
-
-      richText.expectValue(expectedValue);
+      //this is used instead of snapshot value because we have randomized entry IDs
+      richText.getValue().should((doc) => {
+        expect(
+          doc.content[0].content.filter((node) => node.nodeType === INLINES.EMBEDDED_ENTRY)
+        ).to.have.length(1);
+      });
     });
 
     it('should select previous item on up arrow press', () => {
@@ -163,19 +149,13 @@ describe('Rich Text Editor - Commands', { viewportHeight: 2000 }, () => {
     it('should not delete adjacent text', () => {
       richText.editor.click().type('test/{downarrow}{enter}{enter}');
 
-      const expectedValue = doc(
-        block(
-          BLOCKS.PARAGRAPH,
-          {},
-          text('test'),
-          block(INLINES.EMBEDDED_ENTRY, {
-            target: { sys: { id: 'exampleCT', type: 'Link', linkType: 'Entry' } },
-          }),
-          text()
-        )
-      );
-
-      richText.expectValue(expectedValue);
+      //this is used instead of snapshot value because we have randomized entry IDs
+      richText.getValue().should((doc) => {
+        expect(doc.content[0].content[0].value).to.equal('test');
+        expect(
+          doc.content[0].content.filter((node) => node.nodeType === INLINES.EMBEDDED_ENTRY)
+        ).to.have.length(1);
+      });
     });
 
     it('should work inside headings', () => {

--- a/packages/rich-text/src/plugins/CommandPalette/components/CommandList.tsx
+++ b/packages/rich-text/src/plugins/CommandPalette/components/CommandList.tsx
@@ -92,13 +92,13 @@ const CommandListItems = ({
 }) => {
   return (
     <>
-      {commandItems.map((command, i) => {
+      {commandItems.map((command) => {
         return 'group' in command ? (
-          <Group key={i} commandGroup={command} selectedItem={selectedItem} />
+          <Group key={command.group} commandGroup={command} selectedItem={selectedItem} />
         ) : command.callback ? (
-          <Asset key={i} command={command} selectedItem={selectedItem} />
+          <Asset key={command.id} command={command} selectedItem={selectedItem} />
         ) : (
-          <Item key={i} command={command} />
+          <Item key={command.id} command={command} />
         );
       })}
     </>

--- a/packages/rich-text/src/plugins/CommandPalette/components/CommandList.tsx
+++ b/packages/rich-text/src/plugins/CommandPalette/components/CommandList.tsx
@@ -1,7 +1,14 @@
 import * as React from 'react';
 import { usePopper } from 'react-popper';
 
-import { Popover, Stack, SectionHeading, ScreenReaderOnly, Flex } from '@contentful/f36-components';
+import {
+  Popover,
+  Stack,
+  SectionHeading,
+  ScreenReaderOnly,
+  Flex,
+  AssetIcon,
+} from '@contentful/f36-components';
 import { Portal } from '@contentful/f36-utils';
 import { cx } from 'emotion';
 
@@ -60,8 +67,10 @@ const Asset = ({ command, selectedItem }: { command: Command; selectedItem: stri
     onClick={command.callback}
   >
     <Flex alignItems="center" gap="spacingS">
-      {command.thumbnail && (
+      {command.thumbnail ? (
         <img width="30" height="30" src={command.thumbnail} alt="" className={styles.thumbnail} />
+      ) : (
+        <AssetIcon width="30" height="30" className={styles.thumbnail} />
       )}
       <span>{command.label}</span>
     </Flex>
@@ -83,13 +92,13 @@ const CommandListItems = ({
 }) => {
   return (
     <>
-      {commandItems.map((command) => {
+      {commandItems.map((command, i) => {
         return 'group' in command ? (
-          <Group commandGroup={command} selectedItem={selectedItem} />
+          <Group key={i} commandGroup={command} selectedItem={selectedItem} />
         ) : command.callback ? (
-          <Asset command={command} selectedItem={selectedItem} />
+          <Asset key={i} command={command} selectedItem={selectedItem} />
         ) : (
-          <Item command={command} />
+          <Item key={i} command={command} />
         );
       })}
     </>

--- a/packages/rich-text/src/plugins/CommandPalette/components/CommandPrompt.tsx
+++ b/packages/rich-text/src/plugins/CommandPalette/components/CommandPrompt.tsx
@@ -1,8 +1,17 @@
 import * as React from 'react';
 
+import tokens from '@contentful/f36-tokens';
+import { css } from 'emotion';
+
 import { PlateEditor, RenderLeafProps } from '../../../internal/types';
 import { trimLeadingSlash } from '../utils/trimLeadingSlash';
 import { CommandList } from './CommandList';
+
+const styles = {
+  commandPrompt: css({
+    color: tokens.blue400,
+  }),
+};
 
 export const CommandPrompt = (props: RenderLeafProps & { editor: PlateEditor }) => {
   const query = React.useMemo(() => trimLeadingSlash(props.text.text), [props.text.text]);
@@ -11,6 +20,7 @@ export const CommandPrompt = (props: RenderLeafProps & { editor: PlateEditor }) 
 
   return (
     <span
+      className={styles.commandPrompt}
       ref={(e) => {
         setTextElement(e as HTMLSpanElement);
       }}


### PR DESCRIPTION
- Fixes: https://github.com/contentful/field-editors/issues/1346
- Inline embedded entries are working again with rich text commands
- Add missing key props to ignore warnings
- Set colour when rich text command is active
- Add asset icon when no thumbnail available for assets

Todo
- [ ] Design review