### PR TITLE
fix: rich text commands issue []

### DIFF
--- a/packages/rich-text/src/plugins/CommandPalette/components/CommandList.tsx
+++ b/packages/rich-text/src/plugins/CommandPalette/components/CommandList.tsx
@@ -77,8 +77,15 @@ const Asset = ({ command, selectedItem }: { command: Command; selectedItem: stri
   </button>
 );
 
-const Item = ({ command }: { command: Command }) => (
-  <button key={command.id} id={command.id} className={styles.menuItem}>
+const Item = ({ command, selectedItem }: { command: Command; selectedItem: string }) => (
+  <button
+    key={command.id}
+    id={command.id}
+    className={cx(styles.menuItem, {
+      [styles.menuItemSelected]: command.id === selectedItem,
+    })}
+    onClick={command.callback}
+  >
     {command.label}
   </button>
 );
@@ -95,10 +102,10 @@ const CommandListItems = ({
       {commandItems.map((command) => {
         return 'group' in command ? (
           <Group key={command.group} commandGroup={command} selectedItem={selectedItem} />
-        ) : command.callback ? (
+        ) : command.asset ? (
           <Asset key={command.id} command={command} selectedItem={selectedItem} />
         ) : (
-          <Item key={command.id} command={command} />
+          <Item key={command.id} command={command} selectedItem={selectedItem} />
         );
       })}
     </>


### PR DESCRIPTION
After my last PR, in some edge cases, typing slash to activate the rich text commands, would break the rich text editor.

Fixes:
- ensure that commands only contains commands relevant to allowed content types
- for some reason, we always rendered the asset component for each command. Now we correctly render Asset for Assets and Item command for entries.