### PR TITLE
feat: file info new UI []

### DIFF
--- a/packages/reference/src/assets/WrappedAssetCard/AssetCardActions.tsx
+++ b/packages/reference/src/assets/WrappedAssetCard/AssetCardActions.tsx
@@ -1,10 +1,47 @@
 import * as React from 'react';
 
 import { Menu, Text } from '@contentful/f36-components';
+import tokens from '@contentful/f36-tokens';
 import { shortenStorageUnit } from '@contentful/field-editor-shared';
+import { css } from 'emotion';
 import get from 'lodash/get';
 
 import { File } from '../../types';
+
+const styles = {
+  dragHandle: css({
+    alignSelf: 'stretch',
+  }),
+  fileInformation: {
+    menuItem: css({
+      opacity: 1,
+    }),
+    dl: css({
+      backgroundColor: tokens.gray100,
+      borderRadius: tokens.borderRadiusMedium,
+      padding: tokens.spacingXs,
+      width: '200px',
+      lineHeight: tokens.lineHeightS,
+      fontSize: tokens.fontSizeS,
+      dt: {
+        font: 'inherit',
+        color: tokens.gray700,
+        marginRight: tokens.spacingXs,
+        paddingTop: tokens.spacing2Xs,
+        paddingBottom: tokens.spacing2Xs,
+        float: 'left',
+        clear: 'left',
+      },
+      dd: {
+        font: 'inherit',
+        marginLeft: 0,
+        color: tokens.gray900,
+        paddingTop: tokens.spacing2Xs,
+        paddingBottom: tokens.spacing2Xs,
+      },
+    }),
+  },
+};
 
 function downloadAsset(url: string) {
   window.open(url, '_blank', 'noopener,noreferrer');
@@ -16,21 +53,42 @@ export function renderAssetInfo(props: { entityFile: File }) {
   const mimeType = get(entityFile, 'contentType');
   const fileSize = get(entityFile, 'details.size');
   const image = get(entityFile, 'details.image');
+
   return [
     <Menu.SectionTitle key="file-section">File info</Menu.SectionTitle>,
-    fileName && (
-      <Menu.Item key="file-name">
-        <Text isTruncated>{fileName}</Text>
-      </Menu.Item>
-    ),
-    mimeType && (
-      <Menu.Item key="file-type">
-        <Text isTruncated>{mimeType}</Text>
-      </Menu.Item>
-    ),
-    fileSize && <Menu.Item key="file-size">{shortenStorageUnit(fileSize, 'B')}</Menu.Item>,
-    image && <Menu.Item key="file-dimentions">{`${image.width} × ${image.height}`}</Menu.Item>,
-  ].filter((item) => item);
+    <Menu.Item key="file-information" className={styles.fileInformation.menuItem} isDisabled>
+      <dl className={styles.fileInformation.dl}>
+        {fileName && (
+          <>
+            <dt>File Name:</dt>
+            <Text as="dd" isTruncated>
+              {fileName}
+            </Text>
+          </>
+        )}
+        {mimeType && (
+          <>
+            <dt>File Type:</dt>
+            <Text as="dd" isTruncated>
+              {mimeType}
+            </Text>
+          </>
+        )}
+        {fileSize && (
+          <>
+            <dt>Size:</dt>
+            <dd>{shortenStorageUnit(fileSize, 'B')}</dd>
+          </>
+        )}
+        {image && (
+          <>
+            <dt>Dimensions:</dt>
+            <dd>{`${image.width} × ${image.height}`}</dd>
+          </>
+        )}
+      </dl>
+    </Menu.Item>,
+  ];
 }
 
 export function renderActions(props: {


### PR DESCRIPTION
## Description
Provide a new UI for the file information in the Asset menu. It follows a similar UI to the Cloudinary Contentful App (https://www.contentful.com/developers/changelog/#cloudinary-app-improvements-external-references-support-and-enhanced-user-experience).

## Before
File information properties are clickable but don't do anything. It does not make sense.
<img width="400" alt="Screenshot 2023-10-23 at 13 17 08" src="https://github.com/contentful/field-editors/assets/22968325/f81936eb-3854-4cac-bd71-37b5f32ea63f">

## After
Render a description list element with the file information and disable it as a menu item.
<img width="455" alt="Screenshot 2023-10-23 at 13 25 42" src="https://github.com/contentful/field-editors/assets/22968325/83417883-b152-421c-b02d-2d031f5fe097">
