### PR TITLE
feat: increase space for space name

### DIFF
--- a/packages/reference/src/components/SpaceName/SpaceName.tsx
+++ b/packages/reference/src/components/SpaceName/SpaceName.tsx
@@ -19,7 +19,7 @@ const styles = {
     color: tokens.gray600,
     fontSize: tokens.fontSizeS,
     fontWeight: tokens.fontWeightMedium,
-    maxWidth: '80px',
+    maxWidth: '160px',
     textOverflow: 'ellipsis',
     overflow: 'hidden',
     whiteSpace: 'nowrap',


### PR DESCRIPTION
Double the space for the space name in resource link cards.

Before
<img width="751" alt="image" src="https://github.com/contentful/field-editors/assets/1296628/c88277c1-aca3-414f-b9a8-52627cc8bdc5">

After
<img width="743" alt="image" src="https://github.com/contentful/field-editors/assets/1296628/00dcc154-f9a7-42d3-b043-74adaedda55f">
 