### PR TITLE
fix: tooltip link placement richtext [ZEND-4296]

### DIFF
--- a/packages/rich-text/src/plugins/Hyperlink/components/UrlHyperlink.tsx
+++ b/packages/rich-text/src/plugins/Hyperlink/components/UrlHyperlink.tsx
@@ -46,10 +46,11 @@ export function UrlHyperlink(props: HyperlinkElementProps) {
 
   return (
     <Tooltip
+      usePortal
       content={uri}
       targetWrapperClassName={styles.hyperlinkWrapper}
       placement="bottom"
-      maxWidth="auto"
+      maxWidth="min-content"
     >
       <TextLink
         as="a"


### PR DESCRIPTION
## Description
Fix issue with tooltips behaving weirdly in some cases for links in rich text

## Demo

Before:

https://github.com/contentful/field-editors/assets/22968325/5e4d9625-88df-4b3b-8fdb-43d63c002aae

After:

https://github.com/contentful/field-editors/assets/22968325/87c885a9-a166-418f-b282-78603867be56


## Implementation details
- use portal to display tooltip
- min-width instead of auto width (otherwise the width would stretch because of the portal positioning)