### PR TITLE
feat: show environment in resource inline block

### DIFF
--- a/packages/rich-text/src/plugins/EmbeddedResourceInline/FetchingWrappedResourceInlineCard.tsx
+++ b/packages/rich-text/src/plugins/EmbeddedResourceInline/FetchingWrappedResourceInlineCard.tsx
@@ -7,6 +7,8 @@ import { entityHelpers } from '@contentful/field-editor-shared';
 import { FieldAppSDK } from '@contentful/field-editor-shared';
 import { INLINES } from '@contentful/rich-text-types';
 
+import { truncateTitle } from '../../plugins/shared/utils';
+
 const { getEntryTitle, getEntryStatus } = entityHelpers;
 
 interface FetchingWrappedResourceInlineCardProps {
@@ -51,13 +53,14 @@ export function FetchingWrappedResourceInlineCard(props: FetchingWrappedResource
     localeCode: defaultLocaleCode,
     defaultTitle: 'Untitled',
   });
-  const status = getEntryStatus(entry?.sys);
+  const truncatedTitle = truncateTitle(title, 40);
+  const status = getEntryStatus(entry.sys);
 
   return (
     <InlineEntryCard
       testId={INLINES.EMBEDDED_RESOURCE}
       isSelected={props.isSelected}
-      title={`${data.contentType.name}: ${title} (Space: ${space.name})`}
+      title={`${contentType.name}: ${truncatedTitle} (Space: ${space.name} – Env.: ${entry.sys.environment.sys.id})`}
       status={status}
       actions={[
         <MenuItem key="remove" onClick={props.onRemove} disabled={props.isDisabled} testId="delete">

--- a/packages/rich-text/src/plugins/Hyperlink/useResourceEntityInfo.ts
+++ b/packages/rich-text/src/plugins/Hyperlink/useResourceEntityInfo.ts
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { useResource } from '@contentful/field-editor-reference';
 import { ResourceLink } from '@contentful/rich-text-types';
 
-import { truncateTitle } from './utils';
+import { truncateTitle } from '../../plugins/shared/utils';
 
 type ResourceEntityInfoProps = {
   target: ResourceLink;

--- a/packages/rich-text/src/plugins/Hyperlink/utils.ts
+++ b/packages/rich-text/src/plugins/Hyperlink/utils.ts
@@ -4,27 +4,13 @@ import { isAncestorEmpty } from '@udecode/plate-common';
 import { getText } from '../../internal/queries';
 import { NodeEntry } from '../../internal/types';
 import { PlateEditor } from '../../internal/types';
+import { truncateTitle } from '../../plugins/shared/utils';
 import { FetchedEntityData } from './useEntityInfo';
 
 export const hasText = (editor: PlateEditor, entry: NodeEntry) => {
   const [node, path] = entry;
   return !isAncestorEmpty(editor, node as any) && getText(editor, path).trim() !== '';
 };
-
-export function truncateTitle(str: string, length: number) {
-  if (typeof str === 'string' && str.length > length) {
-    return (
-      str &&
-      str
-        .substr(0, length + 1) // +1 to look ahead and be replaced below.
-        // Get rid of orphan letters but not one letter words (I, a, 2).
-        // Try to not have “.” as last character to avoid awkward “....”.
-        .replace(/(\s+\S(?=\S)|\s*)\.?.$/, '…')
-    );
-  }
-
-  return str;
-}
 
 export function getEntityInfo(data?: FetchedEntityData) {
   if (!data) {

--- a/packages/rich-text/src/plugins/shared/utils.ts
+++ b/packages/rich-text/src/plugins/shared/utils.ts
@@ -5,3 +5,18 @@ const isResourceLink = (link: EntityLink | EntryLink | ResourceLink): link is Re
 
 export const getLinkEntityId = (link: EntityLink | ResourceLink): string =>
   isResourceLink(link) ? link.sys.urn : link.sys.id;
+
+export function truncateTitle(str: string, length: number) {
+  if (typeof str === 'string' && str.length > length) {
+    return (
+      str &&
+      str
+        .substr(0, length + 1) // +1 to look ahead and be replaced below.
+        // Get rid of orphan letters but not one letter words (I, a, 2).
+        // Try to not have “.” as last character to avoid awkward “....”.
+        .replace(/(\s+\S(?=\S)|\s*)\.?.$/, '…')
+    );
+  }
+
+  return str;
+}


### PR DESCRIPTION
Add the environment ID to the embedded resource inline entry node’s tooltip and truncate the title in the tooltip to keep it short.