### PR TITLE
chore: enable automerge for dependabot

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -19,7 +19,7 @@ jobs:
       contents: write
       id-token: write
     runs-on: ubuntu-latest
-    if: ${{github.actor == 'dependabot[bot]' && !contains(steps.dependabot-metadata.outputs.dependency-names, 'slate') && !contains(steps.dependabot-metadata.outputs.dependency-names, 'plate')}}
+    if: ${{github.actor == 'dependabot[bot]' && steps.dependabot-metadata.outputs.update-type != 'version-update:semver-major' && !contains(steps.dependabot-metadata.outputs.dependency-names, 'slate') && !contains(steps.dependabot-metadata.outputs.dependency-names, 'plate')}}
     steps:
       - uses: contentful/github-auto-merge@v1
         with:

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,26 @@
+name: 'dependabot approve-and-request-merge'
+
+on: pull_request_target
+
+jobs:
+  build:
+    permissions:
+    pull-requests: read
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: dependabot-metadata
+        uses: dependabot/fetch-metadata@v1
+        with:
+          github-token: '${{ secrets.GITHUB_TOKEN }}'
+  worker:
+    permissions:
+      contents: write
+      id-token: write
+    runs-on: ubuntu-latest
+    if: ${{github.actor == 'dependabot[bot]' && !contains(steps.dependabot-metadata.outputs.dependency-names, 'slate') && !contains(steps.dependabot-metadata.outputs.dependency-names, 'plate')}}
+    steps:
+      - uses: contentful/github-auto-merge@v1
+        with:
+          VAULT_URL: ${{ secrets.VAULT_URL }}


### PR DESCRIPTION
Enables dependabot automerging for all patches and minor updates, except for plate and slate.