### PR TITLE
fix: location null lat/lon issue []

### DIFF
--- a/packages/location/src/LocationEditor.tsx
+++ b/packages/location/src/LocationEditor.tsx
@@ -66,12 +66,13 @@ export class LocationEditor extends React.Component<
     super(props);
 
     this.state = {
-      localValue: props.value
-        ? {
-            lng: props.value.lon,
-            lat: props.value.lat,
-          }
-        : undefined,
+      localValue:
+        props?.value?.lon && props?.value.lat
+          ? {
+              lng: props.value.lon,
+              lat: props.value.lat,
+            }
+          : undefined,
       mapsObject: null,
     };
   }
@@ -168,16 +169,18 @@ export function LocationEditorConnected(props: LocationEditorConnectedProps) {
     >
       {({ value, disabled, setValue, externalReset }) => {
         return (
-          <LocationEditor
-            // on external change reset component completely and init with initial value again
-            key={`location-editor-${externalReset}`}
-            value={value}
-            disabled={disabled}
-            setValue={setValue}
-            googleMapsKey={googleMapsKey}
-            selectedView={selectedView}
-            setSelectedView={setSelectedView}
-          />
+          <>
+            <LocationEditor
+              // on external change reset component completely and init with initial value again
+              key={`location-editor-${externalReset}`}
+              value={value}
+              disabled={disabled}
+              setValue={setValue}
+              googleMapsKey={googleMapsKey}
+              selectedView={selectedView}
+              setSelectedView={setSelectedView}
+            />
+          </>
         );
       }}
     </FieldConnector>

--- a/packages/location/src/LocationEditor.tsx
+++ b/packages/location/src/LocationEditor.tsx
@@ -67,10 +67,12 @@ export class LocationEditor extends React.Component<
 
     this.state = {
       localValue:
-        props?.value?.lon && props?.value.lat
+        // if we have only the lon or lat set, we set the other to 0.
+        // if both are not set, we set localValue to undefined.
+        props?.value?.lon || props?.value?.lat
           ? {
-              lng: props.value.lon,
-              lat: props.value.lat,
+              lng: props.value.lon ?? 0,
+              lat: props.value.lat ?? 0,
             }
           : undefined,
       mapsObject: null,

--- a/packages/location/src/LocationEditor.tsx
+++ b/packages/location/src/LocationEditor.tsx
@@ -171,18 +171,16 @@ export function LocationEditorConnected(props: LocationEditorConnectedProps) {
     >
       {({ value, disabled, setValue, externalReset }) => {
         return (
-          <>
-            <LocationEditor
-              // on external change reset component completely and init with initial value again
-              key={`location-editor-${externalReset}`}
-              value={value}
-              disabled={disabled}
-              setValue={setValue}
-              googleMapsKey={googleMapsKey}
-              selectedView={selectedView}
-              setSelectedView={setSelectedView}
-            />
-          </>
+          <LocationEditor
+            // on external change reset component completely and init with initial value again
+            key={`location-editor-${externalReset}`}
+            value={value}
+            disabled={disabled}
+            setValue={setValue}
+            googleMapsKey={googleMapsKey}
+            selectedView={selectedView}
+            setSelectedView={setSelectedView}
+          />
         );
       }}
     </FieldConnector>


### PR DESCRIPTION
Before (when lat and lon are both null):
<img width="786" alt="Screenshot 2023-11-07 at 12 15 55" src="https://github.com/contentful/field-editors/assets/109096340/4662be80-ae11-4dfb-bfec-82c01cf87522">

After (when lat and lon are both null):
<img width="755" alt="Screenshot 2023-11-07 at 12 15 26" src="https://github.com/contentful/field-editors/assets/109096340/44d1ca8c-bd0d-4e00-b46c-569246fbc16a">

- If either lat or lon is set but not the other than setting the other to 0
- If both lat or lon are not set then setting localValue to undefined to remove disabled state
- If both lat and lon are set then should show both