### PR TITLE
fix: show RT embed button for only inline resource

### DIFF
--- a/packages/rich-text/src/Toolbar/components/EmbedEntityWidget.tsx
+++ b/packages/rich-text/src/Toolbar/components/EmbedEntityWidget.tsx
@@ -78,6 +78,7 @@ export const EmbedEntityWidget = ({ isDisabled, canInsertBlocks }: EmbedEntityWi
     blockEntryEmbedEnabled ||
     blockResourceEmbedEnabled ||
     inlineEntryEmbedEnabled ||
+    inlineResourceEmbedEnabled ||
     blockAssetEmbedEnabled;
 
   return showEmbedButton ? (


### PR DESCRIPTION
Show embed button in Rich Text toolbar when inline resource is the only enabled node.