### PR TITLE
feat: hyperlink edit popover modal

### DIFF
--- a/cypress/e2e/rich-text/RichTextEditor.Links.spec.ts
+++ b/cypress/e2e/rich-text/RichTextEditor.Links.spec.ts
@@ -8,7 +8,7 @@ import {
   inline,
   text,
 } from '../../../packages/rich-text/src/helpers/nodeFactory';
-import { getIframe } from '../../fixtures/utils';
+import { getIframe, openEditLink } from '../../fixtures/utils';
 import { RichTextPage } from './RichTextPage';
 
 // the sticky toolbar gets in the way of some of the tests, therefore
@@ -270,12 +270,7 @@ describe('Rich Text Editor - Links', { viewportHeight: 2000 }, () => {
 
         // Part 2:
         // Update hyperlink to entry link
-
-        richText.editor
-          .findByTestId('cf-ui-text-link')
-          .should('have.text', 'My cool website')
-          .click({ force: true });
-
+        openEditLink();
         form.linkText.should('not.exist');
         form.linkType.should('have.value', 'hyperlink').select('entry-hyperlink');
         form.linkEntityTarget.should('have.text', 'Select entry').click();
@@ -293,12 +288,7 @@ describe('Rich Text Editor - Links', { viewportHeight: 2000 }, () => {
 
         // Part 3:
         // Update entry link to asset link
-
-        richText.editor
-          .findByTestId('cf-ui-text-link')
-          .should('have.text', 'My cool website')
-          .click({ force: true });
-
+        openEditLink();
         form.linkText.should('not.exist');
         form.linkType.should('have.value', 'entry-hyperlink').select('asset-hyperlink');
         form.linkEntityTarget.should('have.text', 'Select asset').click();
@@ -316,12 +306,7 @@ describe('Rich Text Editor - Links', { viewportHeight: 2000 }, () => {
 
         // Part 4:
         // Update asset link to resource link
-
-        richText.editor
-          .findByTestId('cf-ui-text-link')
-          .should('have.text', 'My cool website')
-          .click({ force: true });
-
+        openEditLink();
         form.linkText.should('not.exist');
         form.linkType.should('have.value', 'asset-hyperlink').select('resource-hyperlink');
         form.linkEntityTarget.should('have.text', 'Select entry').click();
@@ -347,12 +332,7 @@ describe('Rich Text Editor - Links', { viewportHeight: 2000 }, () => {
 
         // Part 5:
         // Update resource link to hyperlink
-
-        richText.editor
-          .findByTestId('cf-ui-text-link')
-          .should('have.text', 'My cool website')
-          .click({ force: true });
-
+        openEditLink();
         form.linkText.should('not.exist');
         form.linkType.should('have.value', 'resource-hyperlink').select('hyperlink');
         form.linkTarget.type('https://zombo.com');

--- a/cypress/e2e/rich-text/RichTextEditor.Tracking.spec.ts
+++ b/cypress/e2e/rich-text/RichTextEditor.Tracking.spec.ts
@@ -2,7 +2,7 @@
 
 import { BLOCKS, INLINES, MARKS } from '@contentful/rich-text-types';
 
-import { getIframe } from '../../fixtures/utils';
+import { getIframe, openEditLink } from '../../fixtures/utils';
 import { RichTextPage } from './RichTextPage';
 
 // the sticky toolbar gets in the way of some of the tests, therefore
@@ -592,9 +592,7 @@ describe('Rich Text Editor - Tracking', { viewportHeight: 2000 }, () => {
 
           // Part 2:
           // Update hyperlink to entry link
-
-          richText.editor.findByTestId('cf-ui-text-link').click({ force: true });
-
+          openEditLink();
           form.linkType.select('entry-hyperlink');
           form.linkEntityTarget.click();
           form.submit.click();
@@ -609,9 +607,7 @@ describe('Rich Text Editor - Tracking', { viewportHeight: 2000 }, () => {
 
           // Part 3:
           // Update entry link to asset link
-
-          richText.editor.findByTestId('cf-ui-text-link').click({ force: true });
-
+          openEditLink();
           form.linkType.select('asset-hyperlink');
           form.linkEntityTarget.click();
           form.submit.click();
@@ -629,9 +625,7 @@ describe('Rich Text Editor - Tracking', { viewportHeight: 2000 }, () => {
 
           // Part 4:
           // Update asset link to hyperlink
-
-          richText.editor.findByTestId('cf-ui-text-link').click({ force: true });
-
+          openEditLink();
           form.linkType.select('hyperlink');
           form.linkTarget.type('https://zombo.com');
           form.submit.click();

--- a/cypress/fixtures/utils.ts
+++ b/cypress/fixtures/utils.ts
@@ -16,6 +16,15 @@ export const getIframe = (): Cypress.Chainable<JQuery<HTMLBodyElement>> => {
     .then((body) => cy.wrap(body as HTMLBodyElement));
 };
 
+export const openEditLink = () => {
+  return getIframe()
+    .findByTestId('cf-ui-popover-content')
+    .should('exist')
+    .findByLabelText('Edit link')
+    .should('exist')
+    .click();
+};
+
 export const getIframeWindow = () => {
   return cy
     .get('#storybook-preview-iframe')

--- a/packages/rich-text/src/plugins/Hyperlink/components/LinkPopover.tsx
+++ b/packages/rich-text/src/plugins/Hyperlink/components/LinkPopover.tsx
@@ -1,0 +1,87 @@
+import * as React from 'react';
+
+import { Popover, IconButton, Tooltip, Flex } from '@contentful/f36-components';
+import { EditIcon, CopyIcon } from '@contentful/f36-icons';
+
+import { styles } from './styles';
+
+type LinkPopoverProps = {
+  isLinkFocused: boolean | undefined;
+  popoverText: React.ReactNode;
+  handleEditLink: () => void;
+  handleRemoveLink: () => void;
+  children: React.ReactNode;
+  handleCopyLink?: () => void;
+};
+
+export const LinkPopover = ({
+  isLinkFocused,
+  popoverText,
+  handleEditLink,
+  handleRemoveLink,
+  children,
+  handleCopyLink,
+}: LinkPopoverProps) => (
+  // eslint-disable-next-line jsx-a11y/no-autofocus -- we don't want to autofocus the popover
+  <Popover renderOnlyWhenOpen={false} usePortal={false} autoFocus={false} isOpen={isLinkFocused}>
+    <Popover.Trigger>{children}</Popover.Trigger>
+    <Popover.Content className={styles.popover}>
+      <Flex
+        contentEditable="false"
+        alignItems="center"
+        paddingTop="spacing2Xs"
+        paddingBottom="spacing2Xs"
+        paddingRight="spacing2Xs"
+        paddingLeft="spacingXs"
+      >
+        {popoverText}
+        {handleCopyLink && (
+          <Tooltip placement="bottom" content="Copy link" usePortal>
+            <IconButton
+              className={styles.iconButton}
+              onClick={handleCopyLink}
+              size="small"
+              variant="transparent"
+              aria-label="Copy link"
+              icon={<CopyIcon size="tiny" />}
+            />
+          </Tooltip>
+        )}
+        <Tooltip placement="bottom" content="Edit link" usePortal>
+          <IconButton
+            className={styles.iconButton}
+            onClick={handleEditLink}
+            size="small"
+            variant="transparent"
+            aria-label="Edit link"
+            icon={<EditIcon size="tiny" />}
+          />
+        </Tooltip>
+        <Tooltip placement="bottom" content="Remove link" usePortal>
+          <IconButton
+            onClick={handleRemoveLink}
+            className={styles.iconButton}
+            size="small"
+            variant="transparent"
+            aria-label="Remove link"
+            icon={
+              //@TODO: Replace icon when available in f36
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 16 16"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M1.75 8C1.75 8.59674 1.98705 9.16903 2.40901 9.59099C2.83097 10.0129 3.40326 10.25 4 10.25H6.5C6.69891 10.25 6.88968 10.329 7.03033 10.4697C7.17098 10.6103 7.25 10.8011 7.25 11C7.25 11.1989 7.17098 11.3897 7.03033 11.5303C6.88968 11.671 6.69891 11.75 6.5 11.75H4C3.00544 11.75 2.05161 11.3549 1.34835 10.6517C0.645088 9.94839 0.25 8.99456 0.25 8C0.25 7.00544 0.645088 6.05161 1.34835 5.34835C2.05161 4.64509 3.00544 4.25 4 4.25H6.5C6.69891 4.25 6.88968 4.32902 7.03033 4.46967C7.17098 4.61032 7.25 4.80109 7.25 5C7.25 5.19891 7.17098 5.38968 7.03033 5.53033C6.88968 5.67098 6.69891 5.75 6.5 5.75H4C3.40326 5.75 2.83097 5.98705 2.40901 6.40901C1.98705 6.83097 1.75 7.40326 1.75 8ZM12 4.25H9.5C9.30109 4.25 9.11032 4.32902 8.96967 4.46967C8.82902 4.61032 8.75 4.80109 8.75 5C8.75 5.19891 8.82902 5.38968 8.96967 5.53033C9.11032 5.67098 9.30109 5.75 9.5 5.75H12C12.5967 5.75 13.169 5.98705 13.591 6.40901C14.0129 6.83097 14.25 7.40326 14.25 8C14.25 8.59674 14.0129 9.16903 13.591 9.59099C13.169 10.0129 12.5967 10.25 12 10.25H9.5C9.30109 10.25 9.11032 10.329 8.96967 10.4697C8.82902 10.6103 8.75 10.8011 8.75 11C8.75 11.1989 8.82902 11.3897 8.96967 11.5303C9.11032 11.671 9.30109 11.75 9.5 11.75H12C12.9946 11.75 13.9484 11.3549 14.6517 10.6517C15.3549 9.94839 15.75 8.99456 15.75 8C15.75 7.00544 15.3549 6.05161 14.6517 5.34835C13.9484 4.64509 12.9946 4.25 12 4.25Z"
+                  fill="black"
+                />
+              </svg>
+            }
+          />
+        </Tooltip>
+      </Flex>
+    </Popover.Content>
+  </Popover>
+);

--- a/packages/rich-text/src/plugins/Hyperlink/components/ResourceHyperlink.tsx
+++ b/packages/rich-text/src/plugins/Hyperlink/components/ResourceHyperlink.tsx
@@ -1,15 +1,16 @@
 import * as React from 'react';
 
 import { FieldAppSDK, Link } from '@contentful/app-sdk';
-import { Tooltip, TextLink } from '@contentful/f36-components';
+import { Text } from '@contentful/f36-components';
 
 import { useContentfulEditor } from '../../../ContentfulEditorProvider';
-import { fromDOMPoint } from '../../../internal';
+import { findNodePath, isChildPath } from '../../../internal/queries';
 import { Element, RenderElementProps } from '../../../internal/types';
-import { useLinkTracking } from '../../../plugins/links-tracking';
 import { useSdkContext } from '../../../SdkProvider';
-import { addOrEditLink } from '../HyperlinkModal';
+import { useLinkTracking } from '../../links-tracking';
 import { useResourceEntityInfo } from '../useResourceEntityInfo';
+import { handleEditLink, handleRemoveLink } from './linkHandlers';
+import { LinkPopover } from './LinkPopover';
 import { styles } from './styles';
 
 export type ResourceHyperlinkProps = {
@@ -32,41 +33,41 @@ export type ResourceHyperlinkProps = {
 export function ResourceHyperlink(props: ResourceHyperlinkProps) {
   const editor = useContentfulEditor();
   const sdk: FieldAppSDK = useSdkContext();
+  const focus = editor.selection?.focus;
   const { target } = props.element.data;
   const { onEntityFetchComplete } = useLinkTracking();
+  const pathToElement = findNodePath(editor, props.element);
+  const isLinkFocused = pathToElement && focus && isChildPath(focus.path, pathToElement);
 
   const tooltipContent = useResourceEntityInfo({ target, onEntityFetchComplete });
 
-  if (!target) return null;
-
-  function handleClick(event: React.MouseEvent<HTMLAnchorElement>) {
-    event.preventDefault();
-    event.stopPropagation();
-    if (!editor) return;
-
-    const p = fromDOMPoint(editor, [event.target as Node, 0]);
-
-    if (p) {
-      addOrEditLink(editor, sdk, editor.tracking.onViewportAction, p.path);
-    }
+  if (!target) {
+    return null;
   }
 
+  const popoverText = (
+    <Text fontColor="blue600" fontWeight="fontWeightMedium" className={styles.openLink}>
+      {tooltipContent}
+    </Text>
+  );
+
   return (
-    <Tooltip
-      content={tooltipContent}
-      targetWrapperClassName={styles.hyperlinkWrapper}
-      placement="bottom"
-      maxWidth="auto"
+    <LinkPopover
+      isLinkFocused={isLinkFocused}
+      handleEditLink={() => handleEditLink(editor, sdk, pathToElement)}
+      handleRemoveLink={() => handleRemoveLink(editor)}
+      popoverText={popoverText}
     >
-      <TextLink
-        as="a"
-        onClick={handleClick}
+      <Text
+        testId="cf-ui-text-link"
+        fontColor="blue600"
+        fontWeight="fontWeightMedium"
         className={styles.hyperlink}
         data-resource-link-type={target.sys.linkType}
         data-resource-link-urn={target.sys.urn}
       >
         {props.children}
-      </TextLink>
-    </Tooltip>
+      </Text>
+    </LinkPopover>
   );
 }

--- a/packages/rich-text/src/plugins/Hyperlink/components/linkHandlers.ts
+++ b/packages/rich-text/src/plugins/Hyperlink/components/linkHandlers.ts
@@ -1,0 +1,30 @@
+import { FieldAppSDK } from '@contentful/app-sdk';
+import { Notification } from '@contentful/f36-components';
+
+import { unwrapLink } from '../../../helpers/editor';
+import { Path, PlateEditor } from '../../../internal/types';
+import { addOrEditLink } from '../HyperlinkModal';
+
+export const handleEditLink = (
+  editor: PlateEditor,
+  sdk: FieldAppSDK,
+  pathToElement: Path | undefined
+) => {
+  if (!editor || !pathToElement) return;
+  addOrEditLink(editor, sdk, editor.tracking.onViewportAction, pathToElement);
+};
+
+export const handleRemoveLink = (editor: PlateEditor) => {
+  unwrapLink(editor);
+};
+
+export const handleCopyLink = async (uri: string | undefined) => {
+  if (uri) {
+    try {
+      await navigator.clipboard.writeText(uri);
+      Notification.success('Successfully copied URL to clipboard');
+    } catch (error) {
+      Notification.error('Failed to copy URL to clipboard');
+    }
+  }
+};

--- a/packages/rich-text/src/plugins/Hyperlink/components/styles.ts
+++ b/packages/rich-text/src/plugins/Hyperlink/components/styles.ts
@@ -9,6 +9,21 @@ export const styles = {
       fontSize: 'inherit !important',
     },
   }),
+  iconButton: css({
+    padding: `${tokens.spacing2Xs} ${tokens.spacingXs}`,
+  }),
+  openLink: css({
+    display: 'inline-block',
+    marginLeft: tokens.spacingXs,
+    marginRight: tokens.spacingXs,
+    maxWidth: '22ch',
+    whiteSpace: 'nowrap',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+  }),
+  popover: css({
+    zIndex: tokens.zIndexDefault,
+  }),
   hyperlink: css({
     fontSize: 'inherit !important',
     display: 'inline !important',


### PR DESCRIPTION
## Description
It is currently not possible to edit the text after you added a hyperlink. You can however use the arrow keys on your keyboard to edit the link. This is causing some bad UX. This PR will improve that by introducing a link popover element.

<img width="301" alt="Screenshot 2023-11-14 at 16 05 14" src="https://github.com/contentful/field-editors/assets/22968325/9553fff6-08fd-4b22-878b-c6c3c87801d7">


## Acceptance criteria:
A mouse click brings the caret to the right position so the user can change the link text, but it also opens the popup menu underneath. This popup menu has a button to remove the link, copy the link (when they are not entity links), open the link a new tab and a button to open the edit hyperlink modal. In this modal the user can edit the hyperlink href.