### PR TITLE
fix: add plate common dependency to rich-text

### DIFF
--- a/packages/rich-text/package.json
+++ b/packages/rich-text/package.json
@@ -52,6 +52,7 @@
     "@udecode/plate-basic-marks": "23.7.0",
     "@udecode/plate-break": "23.7.0",
     "@udecode/plate-core": "23.6.0",
+    "@udecode/plate-common": "23.7.0",
     "@udecode/plate-list": "23.7.0",
     "@udecode/plate-paragraph": "23.7.0",
     "@udecode/plate-reset-node": "23.7.0",


### PR DESCRIPTION
When using default-field-editors in an app, ConnectedRichTextField fails to render because it lacks the plate/common dependency. 

Some partner apps cannot install the correct plate version due to their environments not supporting that version.