### PR TITLE
fix: use available CTs instead of only readable

### DIFF
--- a/packages/reference/src/common/useContentTypePermissions.ts
+++ b/packages/reference/src/common/useContentTypePermissions.ts
@@ -15,7 +15,6 @@ type ContentTypePermissionsProps = {
 
 type ContentTypePermissions = {
   creatableContentTypes: ContentType[];
-  readableContentTypes: ContentType[];
   availableContentTypes: ContentType[];
 };
 
@@ -46,7 +45,6 @@ export function useContentTypePermissions(
     return props.allContentTypes;
   }, [props.allContentTypes, props.validations.contentTypes, props.entityType]);
   const [creatableContentTypes, setCreatableContentTypes] = useState(availableContentTypes);
-  const [readableContentTypes, setReadableContentTypes] = useState(availableContentTypes);
   const { canPerformActionOnEntryOfType } = useAccessApi(props.sdk.access);
 
   useEffect(() => {
@@ -58,9 +56,7 @@ export function useContentTypePermissions(
 
     async function checkContentTypeAccess() {
       const creatable = await getContentTypes('create');
-      const readable = await getContentTypes('read');
       setCreatableContentTypes(creatable);
-      setReadableContentTypes(readable);
     }
 
     void checkContentTypeAccess();
@@ -69,7 +65,6 @@ export function useContentTypePermissions(
 
   return {
     creatableContentTypes,
-    readableContentTypes,
     availableContentTypes,
   };
 }

--- a/packages/reference/src/common/useEditorPermissions.spec.ts
+++ b/packages/reference/src/common/useEditorPermissions.spec.ts
@@ -89,7 +89,6 @@ describe('useEditorPermissions', () => {
       });
 
       expect(result.current.creatableContentTypes).toEqual([]);
-      expect(result.current.readableContentTypes).toEqual([]);
     });
   });
 
@@ -194,24 +193,6 @@ describe('useEditorPermissions', () => {
       });
 
       expect(result.current.creatableContentTypes).toEqual([allContentTypes[1]]);
-    });
-
-    it(`returns readableContentTypes from validations that can be read`, async () => {
-      const allContentTypes = [makeContentType('one'), makeContentType('two')];
-
-      const { result } = await renderEditorPermissions({
-        entityType: 'Entry',
-        allContentTypes,
-        customizeMock: (field) => {
-          field.validations = [{ linkContentType: ['two'] }];
-          return field;
-        },
-        customizeSdk: (sdk) => {
-          allowContentTypes(sdk, 'read', 'two');
-        },
-      });
-
-      expect(result.current.readableContentTypes).toEqual([allContentTypes[1]]);
     });
   });
 });

--- a/packages/reference/src/common/useEditorPermissions.ts
+++ b/packages/reference/src/common/useEditorPermissions.ts
@@ -18,8 +18,10 @@ export function useEditorPermissions(props: EditorPermissionsProps) {
   const validations = useMemo(() => fromFieldValidations(props.sdk.field), [props.sdk.field]);
   const [canCreateEntity, setCanCreateEntity] = useState(true);
   const [canLinkEntity, setCanLinkEntity] = useState(true);
-  const { creatableContentTypes, readableContentTypes, availableContentTypes } =
-    useContentTypePermissions({ ...props, validations });
+  const { creatableContentTypes, availableContentTypes } = useContentTypePermissions({
+    ...props,
+    validations,
+  });
   const { canPerformAction } = useAccessApi(sdk.access);
 
   useEffect(() => {
@@ -72,13 +74,12 @@ export function useEditorPermissions(props: EditorPermissionsProps) {
 
     void checkLinkAccess();
     // eslint-disable-next-line react-hooks/exhaustive-deps -- TODO: Evaluate the dependencies
-  }, [entityType, parameters.instance, readableContentTypes]);
+  }, [entityType, parameters.instance]);
 
   return {
     canCreateEntity,
     canLinkEntity,
     creatableContentTypes,
-    readableContentTypes,
     availableContentTypes,
     validations,
   };

--- a/packages/reference/src/components/LinkActions/helpers.ts
+++ b/packages/reference/src/components/LinkActions/helpers.ts
@@ -32,7 +32,9 @@ export async function selectSingleEntity(props: {
   if (props.entityType === 'Entry') {
     return await props.sdk.dialogs.selectSingleEntry<Entry>({
       locale: props.sdk.field.locale,
-      contentTypes: getContentTypeIds(props.editorPermissions.readableContentTypes),
+      // readable CTs do not cover cases where user has partial access to a CT entry,
+      // e.g. via tags so we're passing in all available CTs (based on field validations)
+      contentTypes: getContentTypeIds(props.editorPermissions.availableContentTypes),
     });
   } else {
     return props.sdk.dialogs.selectSingleAsset<Asset>({
@@ -65,7 +67,9 @@ export async function selectMultipleEntities(props: {
   if (props.entityType === 'Entry') {
     return await props.sdk.dialogs.selectMultipleEntries<Entry>({
       locale: props.sdk.field.locale,
-      contentTypes: getContentTypeIds(props.editorPermissions.readableContentTypes),
+      // readable CTs do not cover cases where user has partial access to a CT entry,
+      // e.g. via tags so we're passing in all available CTs (based on field validations)
+      contentTypes: getContentTypeIds(props.editorPermissions.availableContentTypes),
       min,
       max,
     });


### PR DESCRIPTION
The way reference field works, it will take the available CTs for the field - via validations - filter out the ones that user has no permissions to read and pass the remaining list to the Entity Search modal. If an empty array of CTs is provided Entity Search will render all CTs of the environment.

When a user has partial access to content types e.g. via tags these content types will not appear in the list of readable CTs and will result in an empty array to be passed to Entity Search which will then result in all available CTs to be listed overriding the field validations.

If instead we pass the available CTs then Entity Search will still respect the validations and is smart enough to filter out individual entities the user might not have permissions to read.

See the following example:
* fields allows only `Component:Text` entries to be linked via validations
* the user has access to some entries of the `Component:Text` via tags but cannot read any entry of that CT

Before all CTs would be listed:
<img width="855" alt="Screenshot 2023-12-15 at 16 38 15" src="https://github.com/contentful/field-editors/assets/2773012/2191fce3-97f9-4d36-8560-dbf708f7cdcd">
After, only the `Component:Text` is listed and only the entries that user can read:
<img width="832" alt="Screenshot 2023-12-15 at 16 46 40" src="https://github.com/contentful/field-editors/assets/2773012/e317d12d-d25b-42e2-9841-6c572386b172">

Related tickets:
* https://contentful.atlassian.net/browse/ZEND-4455
* https://contentful.atlassian.net/browse/ZEND-4432