### PR TITLE
test: pass google maps key to LocationEditor component tests

### DIFF
--- a/cypress/component/location/LocationEditor.spec.tsx
+++ b/cypress/component/location/LocationEditor.spec.tsx
@@ -7,9 +7,22 @@ import { mount } from '../mount';
 
 const renderLocationEditor = (isInitiallyDisabled = false) => {
   const [fieldSdk] = createFakeFieldAPI();
-  mount(<LocationEditor field={fieldSdk} isInitiallyDisabled={isInitiallyDisabled} />);
+  mount(
+    <LocationEditor
+      field={fieldSdk}
+      isInitiallyDisabled={isInitiallyDisabled}
+      parameters={{
+        instance: {
+          googleMapsKey: Cypress.env('googleMapsKey') ?? undefined,
+        },
+        installation: {},
+        invocation: {},
+      }}
+    />
+  );
   return fieldSdk;
 };
+
 describe('Location Editor', () => {
   const LOCATION = {
     address: 'Max-Urich-Straße 1, 13355 Berlin, Germany',


### PR DESCRIPTION
LocationEditor component tests [keep failing](https://app.circleci.com/pipelines/github/contentful/field-editors/6441/workflows/e47211c0-e270-498e-910e-d93fdc0305ec/jobs/23234) due to googleMapsKey not being set properly. These tests were recently migrated to component tests. Before they were ran on top of storybook stories which were passing the key [correctly](https://github.com/contentful/field-editors/blob/ce6b53a046d6e79718c8e196556563d81f44df84/packages/location/stories/LocationEditor.stories.tsx#L36). This migration is most likely related to these failures, but I am still not sure why they passed [here](https://github.com/contentful/field-editors/pull/1550)