### PR TITLE
fix(rich-text): show the selected headline inside of lists

### DIFF
--- a/cypress/e2e/rich-text/RichTextEditor.Headings.spec.ts
+++ b/cypress/e2e/rich-text/RichTextEditor.Headings.spec.ts
@@ -165,6 +165,13 @@ describe('Rich Text Editor - Headings', { viewportHeight: 2000 }, () => {
         richText.expectValue(doc(block(type, {}, text(value)), emptyParagraph()));
         cy.unsetShouldConfirm();
       });
+
+      it('should show the correct status inside an list', () => {
+        richText.editor.click().type('some text');
+        richText.toolbar.ul.click();
+        richText.toolbar.toggleHeading(type);
+        richText.toolbar.headingsDropdown.should('have.text', label);
+      });
     });
   });
 

--- a/packages/rich-text/src/plugins/Heading/components/ToolbarHeadingButton.tsx
+++ b/packages/rich-text/src/plugins/Heading/components/ToolbarHeadingButton.tsx
@@ -69,10 +69,22 @@ export function ToolbarHeadingButton(props: ToolbarHeadingButtonProps) {
   React.useEffect(() => {
     if (!editor?.selection) return;
 
-    const [element] = getElementFromCurrentSelection(editor);
-    const type = (element as Element).type;
+    const elements = getElementFromCurrentSelection(editor);
 
-    setSelected(LABELS[type] ? type : BLOCKS.PARAGRAPH);
+    // Iterate through the elements to identify matches
+    // In lists it would otherwise never show the correct block.
+    for (const element of elements) {
+      if (typeof element === 'object' && 'type' in element) {
+        const el = element as Element;
+        const match = LABELS[el.type];
+        if (match) {
+          setSelected(el.type);
+          return;
+        }
+      }
+    }
+
+    setSelected(BLOCKS.PARAGRAPH);
   }, [editor?.operations, editor?.selection]); // eslint-disable-line -- TODO: explain this disable
 
   const [nodeTypesByEnablement, someHeadingsEnabled] = React.useMemo(() => {


### PR DESCRIPTION
We always picked the first item to check if it's a headline.
Inside lists it would be deeper nested so we need a further iteration.