### PR TITLE
chore(ci): publish a new patch for all packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,7 +124,8 @@ jobs:
           echo "//npm.pkg.github.com/:_authToken=${GITHUB_PACKAGES_WRITE_TOKEN}" > ~/.npmrc
           echo "@contentful:registry=https://npm.pkg.github.com" >> ~/.npmrc
       - run: yarn build
-      - run: yarn lerna version --no-private --conventional-commits --create-release github --yes
+      - run: yarn lerna version patch --no-private --create-release github --yes
+      # - run: yarn lerna version --no-private --conventional-commits --create-release github --yes
       - run: yarn lerna publish from-git --yes
 
 workflows:


### PR DESCRIPTION
Create a new patch once for all packages, as the publishing was broken and we have now missing package versions :/

Will be then reverted after the packages were released.