### PR TITLE
chore(ci): revert publishing to semantic one

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,8 +124,7 @@ jobs:
           echo "//npm.pkg.github.com/:_authToken=${GITHUB_PACKAGES_WRITE_TOKEN}" > ~/.npmrc
           echo "@contentful:registry=https://npm.pkg.github.com" >> ~/.npmrc
       - run: yarn build
-      - run: yarn lerna version patch --force-publish --no-private --create-release github --yes
-      # - run: yarn lerna version --no-private --conventional-commits --create-release github --yes
+      - run: yarn lerna version --no-private --conventional-commits --create-release github --yes
       - run: yarn lerna publish from-git --yes
 
 workflows:


### PR DESCRIPTION
Reverts contentful/field-editors#1585
Waiting for the package bump before merging it