### PR TITLE
chore: fix npm-github registry in dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,10 +4,10 @@ registries:
     type: npm-registry
     url: https://registry.npmjs.org
     token: '${{secrets.NPM_REGISTRY_REGISTRY_NPMJS_ORG_TOKEN}}'
-    npm-github:
-      type: npm-registry
-      url: https://npm.pkg.github.com
-      token: ${{secrets.NPM_REGISTRY_REGISTRY_GH_ORG_TOKEN}}
+  npm-github:
+    type: npm-registry
+    url: https://npm.pkg.github.com
+    token: ${{secrets.NPM_REGISTRY_REGISTRY_GH_ORG_TOKEN}}
 
 updates:
   - package-ecosystem: npm


### PR DESCRIPTION
Dependabot.yml had wrong indentation after GH migration which was breaking dependabot PRs