### PR TITLE
fix: fixing custom app rich text dnd [TOL-1742]

### DIFF
--- a/packages/rich-text/package.json
+++ b/packages/rich-text/package.json
@@ -67,7 +67,7 @@
     "is-plain-obj": "^3.0.0",
     "react-popper": "^2.3.0",
     "slate": "0.94.1",
-    "slate-history": "0.66.0",
+    "slate-history": "0.100.0",
     "slate-hyperscript": "0.77.0",
     "slate-react": "0.98.3"
   },

--- a/packages/rich-text/src/plugins/DragAndDrop/index.tsx
+++ b/packages/rich-text/src/plugins/DragAndDrop/index.tsx
@@ -45,11 +45,11 @@ export function createDragAndDropPlugin(): PlatePlugin {
             : false;
         });
 
-        if (!dropDisallowed) {
-          // Move the drop event to a new undo batch mitigating the bug where undo not only moves it back,
-          // but also undoes a previous action: https://github.com/ianstormtaylor/slate/issues/4694
-          editor.history.undos.push([]);
-        }
+        // if (!dropDisallowed) {
+        //   // Move the drop event to a new undo batch mitigating the bug where undo not only moves it back,
+        //   // but also undoes a previous action: https://github.com/ianstormtaylor/slate/issues/4694
+        //   editor.history.undos.push([]);
+        // }
 
         return dropDisallowed;
       },

--- a/packages/rich-text/src/plugins/DragAndDrop/index.tsx
+++ b/packages/rich-text/src/plugins/DragAndDrop/index.tsx
@@ -1,4 +1,5 @@
 import { BLOCKS, INLINES } from '@contentful/rich-text-types';
+import { HistoryEditor } from 'slate-history';
 
 import { getNodeEntries } from '../../internal/queries';
 import { PlatePlugin } from '../../internal/types';
@@ -48,8 +49,10 @@ export function createDragAndDropPlugin(): PlatePlugin {
         if (!dropDisallowed) {
           // Move the drop event to a new undo batch mitigating the bug where undo not only moves it back,
           // but also undoes a previous action: https://github.com/ianstormtaylor/slate/issues/4694
-          // @ts-expect-error -- passing an empty undo batch as we don't want it to actually do anything
-          editor.history.undos.push(undefined);
+          (editor as unknown as HistoryEditor).history.undos.push({
+            operations: [],
+            selectionBefore: null,
+          });
         }
 
         return dropDisallowed;

--- a/packages/rich-text/src/plugins/DragAndDrop/index.tsx
+++ b/packages/rich-text/src/plugins/DragAndDrop/index.tsx
@@ -48,8 +48,7 @@ export function createDragAndDropPlugin(): PlatePlugin {
         if (!dropDisallowed) {
           // Move the drop event to a new undo batch mitigating the bug where undo not only moves it back,
           // but also undoes a previous action: https://github.com/ianstormtaylor/slate/issues/4694
-
-          // @ts-expect-error
+          // @ts-expect-error -- passing an empty undo batch as we don't want it to actually do anything
           editor.history.undos.push(undefined);
         }
 

--- a/packages/rich-text/src/plugins/DragAndDrop/index.tsx
+++ b/packages/rich-text/src/plugins/DragAndDrop/index.tsx
@@ -45,11 +45,13 @@ export function createDragAndDropPlugin(): PlatePlugin {
             : false;
         });
 
-        // if (!dropDisallowed) {
-        //   // Move the drop event to a new undo batch mitigating the bug where undo not only moves it back,
-        //   // but also undoes a previous action: https://github.com/ianstormtaylor/slate/issues/4694
-        //   editor.history.undos.push([]);
-        // }
+        if (!dropDisallowed) {
+          // Move the drop event to a new undo batch mitigating the bug where undo not only moves it back,
+          // but also undoes a previous action: https://github.com/ianstormtaylor/slate/issues/4694
+
+          // @ts-expect-error
+          editor.history.undos.push(undefined);
+        }
 
         return dropDisallowed;
       },

--- a/yarn.lock
+++ b/yarn.lock
@@ -26804,7 +26804,14 @@ slash@^4.0.0:
   resolved "https://registry.yarnpkg.com/slash/-/slash-4.0.0.tgz#2422372176c4c6c5addb5e2ada885af984b396a7"
   integrity sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==
 
-slate-history@0.66.0, slate-history@^0.66.0:
+slate-history@0.100.0:
+  version "0.100.0"
+  resolved "https://registry.yarnpkg.com/slate-history/-/slate-history-0.100.0.tgz#a8549af61182a18db2dfedff6ebab7452c841666"
+  integrity sha512-x5rUuWLNtH97hs9PrFovGgt3Qc5zkTm/5mcUB+0NR/TK923eLax4HsL6xACLHMs245nI6aJElyM1y6hN0y5W/Q==
+  dependencies:
+    is-plain-object "^5.0.0"
+
+slate-history@^0.66.0:
   version "0.66.0"
   resolved "https://registry.yarnpkg.com/slate-history/-/slate-history-0.66.0.tgz#ac63fddb903098ceb4c944433e3f75fe63acf940"
   integrity sha512-6MWpxGQZiMvSINlCbMW43E2YBSVMCMCIwQfBzGssjWw4kb0qfvj0pIdblWNRQZD0hR6WHP+dHHgGSeVdMWzfng==


### PR DESCRIPTION
![image](https://github.com/contentful/field-editors/assets/109096340/2569d4cb-80c9-4998-a810-a9b02ce74c2c)

Error being throw when dragging and dropping with custom rich text editor.
- Related to this history change & the new dndkit library

Todo
- [ ] Understand why change was introduced in the first place
- [ ] Remove or refactor as required

EDIT

Because we push a new undo as an empty array this condition doesn't short-circuit and the operations doesn't exist on the empty array. I'm not sure why this is only a problem for the App SDK and hasn't been happening the regular web app Rich Text 🤔

```
const lastOp =
lastBatch && lastBatch.operations[lastBatch.operations.length - 1]
```

https://github.com/ianstormtaylor/slate/blob/cd93871ae69721f7361e17e8b28feab004a9c855/packages/slate-history/src/with-history.ts#L72C5-L74C73