### PR TITLE
fix: use the new badge option on EntryCard for ExternalResourceCard [DANTE-1330]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,11 @@ cache-key: &cache-key
 commands:
   yarn_install:
     steps:
+      - vault/get-secrets:
+          template-preset: "packages-read"
+      - run: |
+          echo "//npm.pkg.github.com/:_authToken=${GITHUB_PACKAGES_READ_TOKEN}" > ~/.npmrc
+          echo "@contentful:registry=https://npm.pkg.github.com" >> ~/.npmrc
       - restore_cache: *cache-key
       - run: yarn install --prefer-offline --pure-lockfile
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,11 +28,6 @@ cache-key: &cache-key
 commands:
   yarn_install:
     steps:
-      - vault/get-secrets:
-          template-preset: "packages-read"
-      - run: |
-          echo "//npm.pkg.github.com/:_authToken=${GITHUB_PACKAGES_READ_TOKEN}" > ~/.npmrc
-          echo "@contentful:registry=https://npm.pkg.github.com" >> ~/.npmrc
       - restore_cache: *cache-key
       - run: yarn install --prefer-offline --pure-lockfile
       - save_cache:

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+//registry.yarnpkg.com
+@contentful:registry=https://registry.yarnpkg.com

--- a/packages/reference/package.json
+++ b/packages/reference/package.json
@@ -35,9 +35,9 @@
     "tsc": "tsc -p ./ --noEmit"
   },
   "dependencies": {
-    "@contentful/f36-components": "^4.0.27",
-    "@contentful/f36-icons": "^4.1.0",
-    "@contentful/f36-tokens": "^4.0.0",
+    "@contentful/f36-components": "^4.60.0",
+    "@contentful/f36-icons": "^4.27.0",
+    "@contentful/f36-tokens": "^4.0.4",
     "@contentful/field-editor-shared": "^1.4.5",
     "@contentful/mimetype": "^2.2.29",
     "@dnd-kit/core": "^6.0.8",

--- a/packages/reference/src/resources/ExternalResourceCard/ExternalResourceCard.tsx
+++ b/packages/reference/src/resources/ExternalResourceCard/ExternalResourceCard.tsx
@@ -99,7 +99,7 @@ export function ExternalResourceCard({
       }
       dragHandleRender={renderDragHandle}
       withDragHandle={!!renderDragHandle}
-      icon={badge}
+      badge={badge}
       actions={
         onEdit || onRemove
           ? [

--- a/packages/reference/stories/ExternalReferenceCard.stories.tsx
+++ b/packages/reference/stories/ExternalReferenceCard.stories.tsx
@@ -198,7 +198,7 @@ export const WithEditActions: Story = {
   },
 };
 
-export const WithEMultipleCardsHavingMultipleStatuses: Story = {
+export const WithMultipleCardsHavingMultipleStatuses: Story = {
   parameters: {
     controls: { hideNoControlsWarning: true },
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -8,9 +8,9 @@
   integrity sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==
 
 "@adobe/css-tools@^4.0.1":
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/@adobe/css-tools/-/css-tools-4.3.2.tgz#a6abc715fb6884851fca9dad37fc34739a04fd11"
-  integrity sha512-DA5a1C0gD/pLOvhv33YMrbf2FK3oUzwNl9oOJqE4XVjuEtt6XIakRcsd7eLiOSPkp1kTRQGICTA8cKra/vFbjw==
+  version "4.3.3"
+  resolved "https://registry.yarnpkg.com/@adobe/css-tools/-/css-tools-4.3.3.tgz#90749bde8b89cd41764224f5aac29cd4138f75ff"
+  integrity sha512-rE0Pygv0sEZ4vBWHlAgJLGDU7Pm8xoO6p3wsEceb7GYAjScrOHpEo8KK/eVkAcnSM+slAEtXjA2JpdjLp4fJQQ==
 
 "@alloc/quick-lru@^5.2.0":
   version "5.2.0"
@@ -55,7 +55,7 @@
   dependencies:
     "@babel/highlight" "^7.10.4"
 
-"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.16.0", "@babel/code-frame@^7.16.7", "@babel/code-frame@^7.21.4", "@babel/code-frame@^7.22.13", "@babel/code-frame@^7.23.5", "@babel/code-frame@^7.5.5", "@babel/code-frame@^7.8.3":
+"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.16.0", "@babel/code-frame@^7.16.7", "@babel/code-frame@^7.21.4", "@babel/code-frame@^7.23.5", "@babel/code-frame@^7.5.5", "@babel/code-frame@^7.8.3":
   version "7.23.5"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.23.5.tgz#9009b69a8c602293476ad598ff53e4562e15c244"
   integrity sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==
@@ -134,28 +134,7 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
-"@babel/core@^7.1.0", "@babel/core@^7.11.1", "@babel/core@^7.11.6", "@babel/core@^7.12.3", "@babel/core@^7.16.0", "@babel/core@^7.5.5", "@babel/core@^7.7.2", "@babel/core@^7.7.4", "@babel/core@^7.7.5", "@babel/core@^7.8.0", "@babel/core@^7.8.4":
-  version "7.23.7"
-  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.23.7.tgz#4d8016e06a14b5f92530a13ed0561730b5c6483f"
-  integrity sha512-+UpDgowcmqe36d4NwqvKsyPMlOLNGMsfMmQ5WGCu+siCe3t3dfe9njrzGfdN4qq+bcNUt0+Vw6haRxBOycs4dw==
-  dependencies:
-    "@ampproject/remapping" "^2.2.0"
-    "@babel/code-frame" "^7.23.5"
-    "@babel/generator" "^7.23.6"
-    "@babel/helper-compilation-targets" "^7.23.6"
-    "@babel/helper-module-transforms" "^7.23.3"
-    "@babel/helpers" "^7.23.7"
-    "@babel/parser" "^7.23.6"
-    "@babel/template" "^7.22.15"
-    "@babel/traverse" "^7.23.7"
-    "@babel/types" "^7.23.6"
-    convert-source-map "^2.0.0"
-    debug "^4.1.0"
-    gensync "^1.0.0-beta.2"
-    json5 "^2.2.3"
-    semver "^6.3.1"
-
-"@babel/core@^7.18.9", "@babel/core@^7.23.0", "@babel/core@^7.23.2":
+"@babel/core@^7.1.0", "@babel/core@^7.11.1", "@babel/core@^7.11.6", "@babel/core@^7.12.3", "@babel/core@^7.16.0", "@babel/core@^7.18.9", "@babel/core@^7.23.0", "@babel/core@^7.23.2", "@babel/core@^7.5.5", "@babel/core@^7.7.2", "@babel/core@^7.7.4", "@babel/core@^7.7.5", "@babel/core@^7.8.0", "@babel/core@^7.8.4":
   version "7.23.9"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.23.9.tgz#b028820718000f267870822fec434820e9b1e4d1"
   integrity sha512-5q0175NOjddqpvvzU+kDiSOAk4PfdO6FvwCWoQ6RO7rTzEe8vlo+4HVfcnAREhD4npMs0e9uZypjTwzZPCf/cw==
@@ -176,10 +155,19 @@
     json5 "^2.2.3"
     semver "^6.3.1"
 
-"@babel/eslint-parser@7.23.3", "@babel/eslint-parser@^7.16.3":
+"@babel/eslint-parser@7.23.3":
   version "7.23.3"
   resolved "https://registry.yarnpkg.com/@babel/eslint-parser/-/eslint-parser-7.23.3.tgz#7bf0db1c53b54da0c8a12627373554a0828479ca"
   integrity sha512-9bTuNlyx7oSstodm1cR1bECj4fkiknsDa1YniISkJemMY3DGhJNYBECbe6QD/q54mp2J8VO66jW3/7uP//iFCw==
+  dependencies:
+    "@nicolo-ribaudo/eslint-scope-5-internals" "5.1.1-v1"
+    eslint-visitor-keys "^2.1.0"
+    semver "^6.3.1"
+
+"@babel/eslint-parser@^7.16.3":
+  version "7.23.10"
+  resolved "https://registry.yarnpkg.com/@babel/eslint-parser/-/eslint-parser-7.23.10.tgz#2d4164842d6db798873b40e0c4238827084667a2"
+  integrity sha512-3wSYDPZVnhseRnxRJH6ZVTNknBz76AEnyC+AYYhasjP3Yy23qz0ERR7Fcd2SHmYuSFJ2kY9gaaDd3vyqU09eSw==
   dependencies:
     "@nicolo-ribaudo/eslint-scope-5-internals" "5.1.1-v1"
     eslint-visitor-keys "^2.1.0"
@@ -221,9 +209,9 @@
     semver "^6.3.1"
 
 "@babel/helper-create-class-features-plugin@^7.22.15", "@babel/helper-create-class-features-plugin@^7.23.6", "@babel/helper-create-class-features-plugin@^7.8.3":
-  version "7.23.7"
-  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.23.7.tgz#b2e6826e0e20d337143655198b79d58fdc9bd43d"
-  integrity sha512-xCoqR/8+BoNnXOY7RVSgv6X+o7pmT5q1d+gGcRlXYkI+9B31glE4jeejhKVpA04O1AtzOt7OSQ6VYKP5FcRl9g==
+  version "7.23.10"
+  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.23.10.tgz#25d55fafbaea31fd0e723820bb6cc3df72edf7ea"
+  integrity sha512-2XpP2XhkXzgxecPNEEK8Vz8Asj9aRxt08oKOqtiZoqV2UGZ5T+EkyP9sXQ9nwMxBIG34a7jmasVqoMop7VdPUw==
   dependencies:
     "@babel/helper-annotate-as-pure" "^7.22.5"
     "@babel/helper-environment-visitor" "^7.22.20"
@@ -243,17 +231,6 @@
     "@babel/helper-annotate-as-pure" "^7.22.5"
     regexpu-core "^5.3.1"
     semver "^6.3.1"
-
-"@babel/helper-define-polyfill-provider@^0.4.4":
-  version "0.4.4"
-  resolved "https://registry.yarnpkg.com/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.4.4.tgz#64df615451cb30e94b59a9696022cffac9a10088"
-  integrity sha512-QcJMILQCu2jm5TFPGA3lCpJJTeEP+mqeXooG/NZbg/h5FTFi6V0+99ahlRsW8/kRLyb24LZVCCiclDedhLKcBA==
-  dependencies:
-    "@babel/helper-compilation-targets" "^7.22.6"
-    "@babel/helper-plugin-utils" "^7.22.5"
-    debug "^4.1.1"
-    lodash.debounce "^4.0.8"
-    resolve "^1.14.2"
 
 "@babel/helper-define-polyfill-provider@^0.5.0":
   version "0.5.0"
@@ -386,16 +363,7 @@
     "@babel/template" "^7.22.15"
     "@babel/types" "^7.22.19"
 
-"@babel/helpers@^7.12.1", "@babel/helpers@^7.23.7", "@babel/helpers@^7.9.0", "@babel/helpers@^7.9.6":
-  version "7.23.8"
-  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.23.8.tgz#fc6b2d65b16847fd50adddbd4232c76378959e34"
-  integrity sha512-KDqYz4PiOWvDFrdHLPhKtCThtIcKVy6avWD2oG4GEvyQ+XDZwHD4YQd+H2vNMnq2rkdxsDkU82T+Vk8U/WXHRQ==
-  dependencies:
-    "@babel/template" "^7.22.15"
-    "@babel/traverse" "^7.23.7"
-    "@babel/types" "^7.23.6"
-
-"@babel/helpers@^7.23.9":
+"@babel/helpers@^7.12.1", "@babel/helpers@^7.23.9", "@babel/helpers@^7.9.0", "@babel/helpers@^7.9.6":
   version "7.23.9"
   resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.23.9.tgz#c3e20bbe7f7a7e10cb9b178384b4affdf5995c7d"
   integrity sha512-87ICKgU5t5SzOT7sBMfCOZQ2rHjRU+Pcb9BoILMYz600W6DkVRLFBPwQ18gwUVvggqXivaUakpnxWQGbpywbBQ==
@@ -413,12 +381,7 @@
     chalk "^2.4.2"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.1.0", "@babel/parser@^7.12.3", "@babel/parser@^7.14.7", "@babel/parser@^7.20.7", "@babel/parser@^7.22.15", "@babel/parser@^7.23.6", "@babel/parser@^7.7.0", "@babel/parser@^7.9.0", "@babel/parser@^7.9.6":
-  version "7.23.6"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.23.6.tgz#ba1c9e512bda72a47e285ae42aff9d2a635a9e3b"
-  integrity sha512-Z2uID7YJ7oNvAI20O9X0bblw7Qqs8Q2hFy0R9tAfnfLkp5MW0UH9eUvnDSnFwKZ0AvgS1ucqR4KzvVHgnke1VQ==
-
-"@babel/parser@^7.23.0", "@babel/parser@^7.23.9":
+"@babel/parser@^7.1.0", "@babel/parser@^7.12.3", "@babel/parser@^7.14.7", "@babel/parser@^7.20.7", "@babel/parser@^7.23.0", "@babel/parser@^7.23.9", "@babel/parser@^7.7.0", "@babel/parser@^7.9.0", "@babel/parser@^7.9.6":
   version "7.23.9"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.23.9.tgz#7b903b6149b0f8fa7ad564af646c4c38a77fc44b"
   integrity sha512-9tcKgqKbs3xGJ+NtKF2ndOBBLVwPjl1SHxPQkd36r3Dlirw3xWUeGaTbqr7uGZcTaxkVNwc+03SVP7aCdWrTlA==
@@ -747,16 +710,6 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.22.5"
 
-"@babel/plugin-transform-async-generator-functions@^7.23.7":
-  version "7.23.7"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.23.7.tgz#3aa0b4f2fa3788b5226ef9346cf6d16ec61f99cd"
-  integrity sha512-PdxEpL71bJp1byMG0va5gwQcXHxuEYC/BgI/e88mGTtohbZN28O5Yit0Plkkm/dBzCF/BxmbNcses1RH1T+urA==
-  dependencies:
-    "@babel/helper-environment-visitor" "^7.22.20"
-    "@babel/helper-plugin-utils" "^7.22.5"
-    "@babel/helper-remap-async-to-generator" "^7.22.20"
-    "@babel/plugin-syntax-async-generators" "^7.8.4"
-
 "@babel/plugin-transform-async-generator-functions@^7.23.9":
   version "7.23.9"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.23.9.tgz#9adaeb66fc9634a586c5df139c6240d41ed801ce"
@@ -955,17 +908,7 @@
     "@babel/helper-plugin-utils" "^7.22.5"
     "@babel/helper-simple-access" "^7.22.5"
 
-"@babel/plugin-transform-modules-systemjs@^7.23.3", "@babel/plugin-transform-modules-systemjs@^7.9.0":
-  version "7.23.3"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.23.3.tgz#fa7e62248931cb15b9404f8052581c302dd9de81"
-  integrity sha512-ZxyKGTkF9xT9YJuKQRo19ewf3pXpopuYQd8cDXqNzc3mUNbOME0RKMoZxviQk74hwzfQsEe66dE92MaZbdHKNQ==
-  dependencies:
-    "@babel/helper-hoist-variables" "^7.22.5"
-    "@babel/helper-module-transforms" "^7.23.3"
-    "@babel/helper-plugin-utils" "^7.22.5"
-    "@babel/helper-validator-identifier" "^7.22.20"
-
-"@babel/plugin-transform-modules-systemjs@^7.23.9":
+"@babel/plugin-transform-modules-systemjs@^7.23.9", "@babel/plugin-transform-modules-systemjs@^7.9.0":
   version "7.23.9"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.23.9.tgz#105d3ed46e4a21d257f83a2f9e2ee4203ceda6be"
   integrity sha512-KDlPRM6sLo4o1FkiSlXoAa8edLXFsKKIda779fbLrvmeuc3itnjCtaO6RrtoaANsIJANj+Vk1zqbZIMhkCAHVw==
@@ -1255,7 +1198,7 @@
     "@babel/helper-create-regexp-features-plugin" "^7.22.15"
     "@babel/helper-plugin-utils" "^7.22.5"
 
-"@babel/preset-env@7.23.9", "@babel/preset-env@^7.23.2":
+"@babel/preset-env@7.23.9", "@babel/preset-env@^7.11.0", "@babel/preset-env@^7.12.1", "@babel/preset-env@^7.23.2", "@babel/preset-env@^7.8.4":
   version "7.23.9"
   resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.23.9.tgz#beace3b7994560ed6bf78e4ae2073dff45387669"
   integrity sha512-3kBGTNBBk9DQiPoXYS0g0BYlwTQYUTifqgKTjxUwEUkduRT2QOa0FPGBJ+NROQhGyYO5BuTJwGvBnqKDykac6A==
@@ -1407,92 +1350,6 @@
     levenary "^1.1.1"
     semver "^5.5.0"
 
-"@babel/preset-env@^7.11.0", "@babel/preset-env@^7.12.1", "@babel/preset-env@^7.8.4":
-  version "7.23.8"
-  resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.23.8.tgz#7d6f8171ea7c221ecd28059e65ad37c20e441e3e"
-  integrity sha512-lFlpmkApLkEP6woIKprO6DO60RImpatTQKtz4sUcDjVcK8M8mQ4sZsuxaTMNOZf0sqAq/ReYW1ZBHnOQwKpLWA==
-  dependencies:
-    "@babel/compat-data" "^7.23.5"
-    "@babel/helper-compilation-targets" "^7.23.6"
-    "@babel/helper-plugin-utils" "^7.22.5"
-    "@babel/helper-validator-option" "^7.23.5"
-    "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression" "^7.23.3"
-    "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining" "^7.23.3"
-    "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly" "^7.23.7"
-    "@babel/plugin-proposal-private-property-in-object" "7.21.0-placeholder-for-preset-env.2"
-    "@babel/plugin-syntax-async-generators" "^7.8.4"
-    "@babel/plugin-syntax-class-properties" "^7.12.13"
-    "@babel/plugin-syntax-class-static-block" "^7.14.5"
-    "@babel/plugin-syntax-dynamic-import" "^7.8.3"
-    "@babel/plugin-syntax-export-namespace-from" "^7.8.3"
-    "@babel/plugin-syntax-import-assertions" "^7.23.3"
-    "@babel/plugin-syntax-import-attributes" "^7.23.3"
-    "@babel/plugin-syntax-import-meta" "^7.10.4"
-    "@babel/plugin-syntax-json-strings" "^7.8.3"
-    "@babel/plugin-syntax-logical-assignment-operators" "^7.10.4"
-    "@babel/plugin-syntax-nullish-coalescing-operator" "^7.8.3"
-    "@babel/plugin-syntax-numeric-separator" "^7.10.4"
-    "@babel/plugin-syntax-object-rest-spread" "^7.8.3"
-    "@babel/plugin-syntax-optional-catch-binding" "^7.8.3"
-    "@babel/plugin-syntax-optional-chaining" "^7.8.3"
-    "@babel/plugin-syntax-private-property-in-object" "^7.14.5"
-    "@babel/plugin-syntax-top-level-await" "^7.14.5"
-    "@babel/plugin-syntax-unicode-sets-regex" "^7.18.6"
-    "@babel/plugin-transform-arrow-functions" "^7.23.3"
-    "@babel/plugin-transform-async-generator-functions" "^7.23.7"
-    "@babel/plugin-transform-async-to-generator" "^7.23.3"
-    "@babel/plugin-transform-block-scoped-functions" "^7.23.3"
-    "@babel/plugin-transform-block-scoping" "^7.23.4"
-    "@babel/plugin-transform-class-properties" "^7.23.3"
-    "@babel/plugin-transform-class-static-block" "^7.23.4"
-    "@babel/plugin-transform-classes" "^7.23.8"
-    "@babel/plugin-transform-computed-properties" "^7.23.3"
-    "@babel/plugin-transform-destructuring" "^7.23.3"
-    "@babel/plugin-transform-dotall-regex" "^7.23.3"
-    "@babel/plugin-transform-duplicate-keys" "^7.23.3"
-    "@babel/plugin-transform-dynamic-import" "^7.23.4"
-    "@babel/plugin-transform-exponentiation-operator" "^7.23.3"
-    "@babel/plugin-transform-export-namespace-from" "^7.23.4"
-    "@babel/plugin-transform-for-of" "^7.23.6"
-    "@babel/plugin-transform-function-name" "^7.23.3"
-    "@babel/plugin-transform-json-strings" "^7.23.4"
-    "@babel/plugin-transform-literals" "^7.23.3"
-    "@babel/plugin-transform-logical-assignment-operators" "^7.23.4"
-    "@babel/plugin-transform-member-expression-literals" "^7.23.3"
-    "@babel/plugin-transform-modules-amd" "^7.23.3"
-    "@babel/plugin-transform-modules-commonjs" "^7.23.3"
-    "@babel/plugin-transform-modules-systemjs" "^7.23.3"
-    "@babel/plugin-transform-modules-umd" "^7.23.3"
-    "@babel/plugin-transform-named-capturing-groups-regex" "^7.22.5"
-    "@babel/plugin-transform-new-target" "^7.23.3"
-    "@babel/plugin-transform-nullish-coalescing-operator" "^7.23.4"
-    "@babel/plugin-transform-numeric-separator" "^7.23.4"
-    "@babel/plugin-transform-object-rest-spread" "^7.23.4"
-    "@babel/plugin-transform-object-super" "^7.23.3"
-    "@babel/plugin-transform-optional-catch-binding" "^7.23.4"
-    "@babel/plugin-transform-optional-chaining" "^7.23.4"
-    "@babel/plugin-transform-parameters" "^7.23.3"
-    "@babel/plugin-transform-private-methods" "^7.23.3"
-    "@babel/plugin-transform-private-property-in-object" "^7.23.4"
-    "@babel/plugin-transform-property-literals" "^7.23.3"
-    "@babel/plugin-transform-regenerator" "^7.23.3"
-    "@babel/plugin-transform-reserved-words" "^7.23.3"
-    "@babel/plugin-transform-shorthand-properties" "^7.23.3"
-    "@babel/plugin-transform-spread" "^7.23.3"
-    "@babel/plugin-transform-sticky-regex" "^7.23.3"
-    "@babel/plugin-transform-template-literals" "^7.23.3"
-    "@babel/plugin-transform-typeof-symbol" "^7.23.3"
-    "@babel/plugin-transform-unicode-escapes" "^7.23.3"
-    "@babel/plugin-transform-unicode-property-regex" "^7.23.3"
-    "@babel/plugin-transform-unicode-regex" "^7.23.3"
-    "@babel/plugin-transform-unicode-sets-regex" "^7.23.3"
-    "@babel/preset-modules" "0.1.6-no-external-plugins"
-    babel-plugin-polyfill-corejs2 "^0.4.7"
-    babel-plugin-polyfill-corejs3 "^0.8.7"
-    babel-plugin-polyfill-regenerator "^0.5.4"
-    core-js-compat "^3.31.0"
-    semver "^6.3.1"
-
 "@babel/preset-flow@^7.22.15":
   version "7.23.3"
   resolved "https://registry.yarnpkg.com/@babel/preset-flow/-/preset-flow-7.23.3.tgz#8084e08b9ccec287bd077ab288b286fab96ffab1"
@@ -1594,9 +1451,9 @@
   integrity sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA==
 
 "@babel/runtime-corejs3@^7.10.2":
-  version "7.23.8"
-  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.23.8.tgz#b8aa3d47570bdd08fed77fdfd69542118af0df26"
-  integrity sha512-2ZzmcDugdm0/YQKFVYsXiwUN7USPX8PM7cytpb4PFl87fM+qYPSvTZX//8tyeJB1j0YDmafBJEbl5f8NfLyuKw==
+  version "7.23.9"
+  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.23.9.tgz#1b43062a13ecb60158aecdd81bc3fab4108b7cbc"
+  integrity sha512-oeOFTrYWdWXCvXGB5orvMTJ6gCZ9I6FBjR+M38iKNXCsPxr4xT0RTdg5uz1H7QP8pp74IzPtwritEr+JscqHXQ==
   dependencies:
     core-js-pure "^3.30.2"
     regenerator-runtime "^0.14.0"
@@ -1609,22 +1466,13 @@
     regenerator-runtime "^0.13.4"
 
 "@babel/runtime@^7.0.0", "@babel/runtime@^7.10.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.13", "@babel/runtime@^7.12.5", "@babel/runtime@^7.13.10", "@babel/runtime@^7.14.6", "@babel/runtime@^7.14.8", "@babel/runtime@^7.17.2", "@babel/runtime@^7.17.8", "@babel/runtime@^7.18.6", "@babel/runtime@^7.2.0", "@babel/runtime@^7.21.0", "@babel/runtime@^7.23.2", "@babel/runtime@^7.3.4", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
-  version "7.23.8"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.23.8.tgz#8ee6fe1ac47add7122902f257b8ddf55c898f650"
-  integrity sha512-Y7KbAP984rn1VGMbGqKmBLio9V7y5Je9GvU4rQPCPinCyNfUcToxIXl06d59URp/F3LwinvODxab5N/G6qggkw==
+  version "7.23.9"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.23.9.tgz#47791a15e4603bb5f905bc0753801cf21d6345f7"
+  integrity sha512-0CX6F+BI2s9dkUqr08KFrAIZgNFj75rdBU/DjCyYLIaV/quFjkk6T+EJ2LkZHyZTbEV4L5p97mNkUsHl2wLFAw==
   dependencies:
     regenerator-runtime "^0.14.0"
 
-"@babel/template@^7.10.4", "@babel/template@^7.22.15", "@babel/template@^7.3.3", "@babel/template@^7.8.6":
-  version "7.22.15"
-  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.22.15.tgz#09576efc3830f0430f4548ef971dde1350ef2f38"
-  integrity sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==
-  dependencies:
-    "@babel/code-frame" "^7.22.13"
-    "@babel/parser" "^7.22.15"
-    "@babel/types" "^7.22.15"
-
-"@babel/template@^7.23.9":
+"@babel/template@^7.10.4", "@babel/template@^7.22.15", "@babel/template@^7.23.9", "@babel/template@^7.3.3", "@babel/template@^7.8.6":
   version "7.23.9"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.23.9.tgz#f881d0487cba2828d3259dcb9ef5005a9731011a"
   integrity sha512-+xrD2BWLpvHKNmX2QbpdpsBaWnRxahMwJjO+KZk2JOElj5nSmKezyS1B4u+QbHMTX69t4ukm6hh9lsYQ7GHCKA==
@@ -1633,23 +1481,7 @@
     "@babel/parser" "^7.23.9"
     "@babel/types" "^7.23.9"
 
-"@babel/traverse@^7.1.0", "@babel/traverse@^7.12.1", "@babel/traverse@^7.23.7", "@babel/traverse@^7.7.0", "@babel/traverse@^7.7.2", "@babel/traverse@^7.9.0", "@babel/traverse@^7.9.6":
-  version "7.23.7"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.23.7.tgz#9a7bf285c928cb99b5ead19c3b1ce5b310c9c305"
-  integrity sha512-tY3mM8rH9jM0YHFGyfC0/xf+SB5eKUu7HPj7/k3fpi9dAlsMc5YbQvDi0Sh2QTPXqMhyaAtzAr807TIyfQrmyg==
-  dependencies:
-    "@babel/code-frame" "^7.23.5"
-    "@babel/generator" "^7.23.6"
-    "@babel/helper-environment-visitor" "^7.22.20"
-    "@babel/helper-function-name" "^7.23.0"
-    "@babel/helper-hoist-variables" "^7.22.5"
-    "@babel/helper-split-export-declaration" "^7.22.6"
-    "@babel/parser" "^7.23.6"
-    "@babel/types" "^7.23.6"
-    debug "^4.3.1"
-    globals "^11.1.0"
-
-"@babel/traverse@^7.18.9", "@babel/traverse@^7.23.2", "@babel/traverse@^7.23.9":
+"@babel/traverse@^7.1.0", "@babel/traverse@^7.12.1", "@babel/traverse@^7.18.9", "@babel/traverse@^7.23.2", "@babel/traverse@^7.23.9", "@babel/traverse@^7.7.0", "@babel/traverse@^7.7.2", "@babel/traverse@^7.9.0", "@babel/traverse@^7.9.6":
   version "7.23.9"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.23.9.tgz#2f9d6aead6b564669394c5ce0f9302bb65b9d950"
   integrity sha512-I/4UJ9vs90OkBtY6iiiTORVMyIhJ4kAVmsKo9KFc8UOxMeUfi2hvtIBsET5u9GizXE6/GFSuKCTNfgCswuEjRg==
@@ -1665,16 +1497,7 @@
     debug "^4.3.1"
     globals "^11.1.0"
 
-"@babel/types@^7.0.0", "@babel/types@^7.12.1", "@babel/types@^7.12.6", "@babel/types@^7.20.7", "@babel/types@^7.22.15", "@babel/types@^7.22.19", "@babel/types@^7.22.5", "@babel/types@^7.23.0", "@babel/types@^7.23.4", "@babel/types@^7.23.6", "@babel/types@^7.3.3", "@babel/types@^7.4.4", "@babel/types@^7.7.0", "@babel/types@^7.9.0", "@babel/types@^7.9.6":
-  version "7.23.6"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.23.6.tgz#be33fdb151e1f5a56877d704492c240fc71c7ccd"
-  integrity sha512-+uarb83brBzPKN38NX1MkB6vb6+mwvR6amUulqAE7ccQw1pEl+bCia9TbdG1lsnFP7lZySvUn37CHyXQdfTwzg==
-  dependencies:
-    "@babel/helper-string-parser" "^7.23.4"
-    "@babel/helper-validator-identifier" "^7.22.20"
-    to-fast-properties "^2.0.0"
-
-"@babel/types@^7.18.9", "@babel/types@^7.23.9":
+"@babel/types@^7.0.0", "@babel/types@^7.12.1", "@babel/types@^7.12.6", "@babel/types@^7.18.9", "@babel/types@^7.20.7", "@babel/types@^7.22.15", "@babel/types@^7.22.19", "@babel/types@^7.22.5", "@babel/types@^7.23.0", "@babel/types@^7.23.4", "@babel/types@^7.23.6", "@babel/types@^7.23.9", "@babel/types@^7.3.3", "@babel/types@^7.4.4", "@babel/types@^7.7.0", "@babel/types@^7.9.0", "@babel/types@^7.9.6":
   version "7.23.9"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.23.9.tgz#1dd7b59a9a2b5c87f8b41e52770b5ecbf492e002"
   integrity sha512-dQjSq/7HaSjRM43FFGnv5keM2HsxpmyV1PfaSVm0nzzjwwTmjOe6J4bC8e3+pTEIgHaHj+1ZlLThRJ2auc/w1Q==
@@ -1730,9 +1553,9 @@
     "@lezer/json" "^1.0.0"
 
 "@codemirror/language@^6.0.0":
-  version "6.10.0"
-  resolved "https://registry.yarnpkg.com/@codemirror/language/-/language-6.10.0.tgz#2d0e818716825ee2ed0dacd04595eaa61bae8f23"
-  integrity sha512-2vaNn9aPGCRFKWcHPFksctzJ8yS5p7YoaT+jHpc0UGKzNuAIx4qy6R5wiqbP+heEEdyaABA582mNqSHzSoYdmg==
+  version "6.10.1"
+  resolved "https://registry.yarnpkg.com/@codemirror/language/-/language-6.10.1.tgz#428c932a158cb75942387acfe513c1ece1090b05"
+  integrity sha512-5GrXzrhq6k+gL5fjkAwt90nYDmjlzTIJV8THnxNFtNKWotMIlzzN+CpqxqwXOECnUdOndmSeWntVrVcv5axWRQ==
   dependencies:
     "@codemirror/state" "^6.0.0"
     "@codemirror/view" "^6.23.0"
@@ -1742,18 +1565,18 @@
     style-mod "^4.0.0"
 
 "@codemirror/lint@^6.0.0":
-  version "6.4.2"
-  resolved "https://registry.yarnpkg.com/@codemirror/lint/-/lint-6.4.2.tgz#c13be5320bde9707efdc94e8bcd3c698abae0b92"
-  integrity sha512-wzRkluWb1ptPKdzlsrbwwjYCPLgzU6N88YBAmlZi8WFyuiEduSd05MnJYNogzyc8rPK7pj6m95ptUApc8sHKVA==
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@codemirror/lint/-/lint-6.5.0.tgz#ea43b6e653dcc5bcd93456b55e9fe62e63f326d9"
+  integrity sha512-+5YyicIaaAZKU8K43IQi8TBy6mF6giGeWAH7N96Z5LC30Wm5JMjqxOYIE9mxwMG1NbhT2mA3l9hA4uuKUM3E5g==
   dependencies:
     "@codemirror/state" "^6.0.0"
     "@codemirror/view" "^6.0.0"
     crelt "^1.0.5"
 
 "@codemirror/search@^6.0.0":
-  version "6.5.5"
-  resolved "https://registry.yarnpkg.com/@codemirror/search/-/search-6.5.5.tgz#cf97e201da364da2285c2a250167af25bbd2a4a2"
-  integrity sha512-PIEN3Ke1buPod2EHbJsoQwlbpkz30qGZKcnmH1eihq9+bPQx8gelauUwLYaY4vBOuBAuEhmpDLii4rj/uO0yMA==
+  version "6.5.6"
+  resolved "https://registry.yarnpkg.com/@codemirror/search/-/search-6.5.6.tgz#8f858b9e678d675869112e475f082d1e8488db93"
+  integrity sha512-rpMgcsh7o0GuCDUXKPvww+muLA1pDJaFrpq/CCHtpQJYz8xopu4D1hPcKRoDD0YlF8gZaqTNIRa4VRBWyhyy7Q==
   dependencies:
     "@codemirror/state" "^6.0.0"
     "@codemirror/view" "^6.0.0"
@@ -1775,9 +1598,9 @@
     "@lezer/highlight" "^1.0.0"
 
 "@codemirror/view@^6.0.0", "@codemirror/view@^6.17.0", "@codemirror/view@^6.23.0":
-  version "6.23.0"
-  resolved "https://registry.yarnpkg.com/@codemirror/view/-/view-6.23.0.tgz#8054a2043273abad7f1587d15accb0623e1960ed"
-  integrity sha512-/51px9N4uW8NpuWkyUX+iam5+PM6io2fm+QmRnzwqBy5v/pwGg9T0kILFtYeum8hjuvENtgsGNKluOfqIICmeQ==
+  version "6.24.0"
+  resolved "https://registry.yarnpkg.com/@codemirror/view/-/view-6.24.0.tgz#2f780290a54cfe571b1a1468c47b483de0cf6fb2"
+  integrity sha512-zK6m5pNkdhdJl8idPP1gA4N8JKTiSsOz8U/Iw+C1ChMwyLG7+MLiNXnH/wFuAk6KeGEe33/adOiAh5jMqee03w==
   dependencies:
     "@codemirror/state" "^6.4.0"
     style-mod "^4.1.0"
@@ -1811,66 +1634,66 @@
   dependencies:
     conventional-changelog-conventionalcommits "^7.0.2"
 
-"@commitlint/config-validator@^18.5.0":
-  version "18.5.0"
-  resolved "https://registry.yarnpkg.com/@commitlint/config-validator/-/config-validator-18.5.0.tgz#3ddd3f94001ebbc5a61c7190fa7a51fab289690f"
-  integrity sha512-mDAA6WQPjh9Ida8ACdInDylBQcqeUD2gBHE+dQu+B3OIHiWiSSrq4F2+wg3nDU9EzfcQSwPwYL+QbMmiW5SmLA==
+"@commitlint/config-validator@^18.6.1":
+  version "18.6.1"
+  resolved "https://registry.yarnpkg.com/@commitlint/config-validator/-/config-validator-18.6.1.tgz#e0d71a99c984a68586c7ae7afd3f52342022fae8"
+  integrity sha512-05uiToBVfPhepcQWE1ZQBR/Io3+tb3gEotZjnI4tTzzPk16NffN6YABgwFQCLmzZefbDcmwWqJWc2XT47q7Znw==
   dependencies:
-    "@commitlint/types" "^18.4.4"
+    "@commitlint/types" "^18.6.1"
     ajv "^8.11.0"
 
-"@commitlint/ensure@^18.4.4":
-  version "18.4.4"
-  resolved "https://registry.yarnpkg.com/@commitlint/ensure/-/ensure-18.4.4.tgz#5e142e489e32f6a22865cea05ca369a95a4b77a1"
-  integrity sha512-KjD19p6julB5WrQL+Cd8p+AePwpl1XzGAjB0jnuFMKWtji9L7ucCZUKDstGjlkBZGGzH/nvdB8K+bh5K27EVUg==
+"@commitlint/ensure@^18.6.1":
+  version "18.6.1"
+  resolved "https://registry.yarnpkg.com/@commitlint/ensure/-/ensure-18.6.1.tgz#17141e083200ca94d8480dc23b0e8f8b1fd37b7f"
+  integrity sha512-BPm6+SspyxQ7ZTsZwXc7TRQL5kh5YWt3euKmEIBZnocMFkJevqs3fbLRb8+8I/cfbVcAo4mxRlpTPfz8zX7SnQ==
   dependencies:
-    "@commitlint/types" "^18.4.4"
+    "@commitlint/types" "^18.6.1"
     lodash.camelcase "^4.3.0"
     lodash.kebabcase "^4.1.1"
     lodash.snakecase "^4.1.1"
     lodash.startcase "^4.4.0"
     lodash.upperfirst "^4.3.1"
 
-"@commitlint/execute-rule@^18.4.4":
-  version "18.4.4"
-  resolved "https://registry.yarnpkg.com/@commitlint/execute-rule/-/execute-rule-18.4.4.tgz#ade986742c1944c8162a54288747e54a8c6146b5"
-  integrity sha512-a37Nd3bDQydtg9PCLLWM9ZC+GO7X5i4zJvrggJv5jBhaHsXeQ9ZWdO6ODYR+f0LxBXXNYK3geYXJrCWUCP8JEg==
+"@commitlint/execute-rule@^18.6.1":
+  version "18.6.1"
+  resolved "https://registry.yarnpkg.com/@commitlint/execute-rule/-/execute-rule-18.6.1.tgz#18175e043fe6fb5fceea7b8530316c644f93dfe6"
+  integrity sha512-7s37a+iWyJiGUeMFF6qBlyZciUkF8odSAnHijbD36YDctLhGKoYltdvuJ/AFfRm6cBLRtRk9cCVPdsEFtt/2rg==
 
 "@commitlint/format@^18.4.4":
-  version "18.4.4"
-  resolved "https://registry.yarnpkg.com/@commitlint/format/-/format-18.4.4.tgz#51996ba0a7eac14f7f8991cff8700e4a2fd86ba7"
-  integrity sha512-2v3V5hVlv0R3pe7p66IX5F7cjeVvGM5JqITRIbBCFvGHPJ/CG74rjTkAu0RBEiIhlk3eOaLjVGq3d5falPkLBA==
+  version "18.6.1"
+  resolved "https://registry.yarnpkg.com/@commitlint/format/-/format-18.6.1.tgz#5f2b8b3ae4d8d80bd9239178e97df63e5b8d280a"
+  integrity sha512-K8mNcfU/JEFCharj2xVjxGSF+My+FbUHoqR+4GqPGrHNqXOGNio47ziiR4HQUPKtiNs05o8/WyLBoIpMVOP7wg==
   dependencies:
-    "@commitlint/types" "^18.4.4"
+    "@commitlint/types" "^18.6.1"
     chalk "^4.1.0"
 
-"@commitlint/is-ignored@^18.4.4":
-  version "18.4.4"
-  resolved "https://registry.yarnpkg.com/@commitlint/is-ignored/-/is-ignored-18.4.4.tgz#3fbf2a55a960ccf037e79ad4610091a693800680"
-  integrity sha512-rXWes9owKBTjfTr6Od7YlflRg4N+ngkOH+dUZhk0qL/XQb26mHz0EgVgdixMVBac1OsohRwJaLmVHX+5F6vfmg==
+"@commitlint/is-ignored@^18.6.1":
+  version "18.6.1"
+  resolved "https://registry.yarnpkg.com/@commitlint/is-ignored/-/is-ignored-18.6.1.tgz#4ee08ba91ff3defb06e0ef19259a9c6734a8d06e"
+  integrity sha512-MOfJjkEJj/wOaPBw5jFjTtfnx72RGwqYIROABudOtJKW7isVjFe9j0t8xhceA02QebtYf4P/zea4HIwnXg8rvA==
   dependencies:
-    "@commitlint/types" "^18.4.4"
-    semver "7.5.4"
+    "@commitlint/types" "^18.6.1"
+    semver "7.6.0"
 
 "@commitlint/lint@^18.5.0":
-  version "18.5.0"
-  resolved "https://registry.yarnpkg.com/@commitlint/lint/-/lint-18.5.0.tgz#83c7434e969d04aaa84c5129c17b3dcde33d4650"
-  integrity sha512-4VbfTGTZf/aDaOn+vednMQFu5EIKfERvv7j8La3etQCra0O2QMrZL28xugTroYekawpTkiWWvLswtpVfabIbgw==
+  version "18.6.1"
+  resolved "https://registry.yarnpkg.com/@commitlint/lint/-/lint-18.6.1.tgz#fe3834636c99ee14534a8eb3832831ac362e9fd8"
+  integrity sha512-8WwIFo3jAuU+h1PkYe5SfnIOzp+TtBHpFr4S8oJWhu44IWKuVx6GOPux3+9H1iHOan/rGBaiacicZkMZuluhfQ==
   dependencies:
-    "@commitlint/is-ignored" "^18.4.4"
-    "@commitlint/parse" "^18.4.4"
-    "@commitlint/rules" "^18.4.4"
-    "@commitlint/types" "^18.4.4"
+    "@commitlint/is-ignored" "^18.6.1"
+    "@commitlint/parse" "^18.6.1"
+    "@commitlint/rules" "^18.6.1"
+    "@commitlint/types" "^18.6.1"
 
 "@commitlint/load@^18.5.0":
-  version "18.5.0"
-  resolved "https://registry.yarnpkg.com/@commitlint/load/-/load-18.5.0.tgz#b14eef9306c2500594d8a7f1e4a8d68cb2562439"
-  integrity sha512-vpyGgk7rzbFsU01NVwPNC/WetHFP0EwSYnQ1R833SJFHkEo+cWvqoVlw/VoZwBMoI6sF5/lwEdKzFDr1DHJ6+A==
+  version "18.6.1"
+  resolved "https://registry.yarnpkg.com/@commitlint/load/-/load-18.6.1.tgz#fb79ed7ee8b5897a9b5c274c1e24eda9162df816"
+  integrity sha512-p26x8734tSXUHoAw0ERIiHyW4RaI4Bj99D8YgUlVV9SedLf8hlWAfyIFhHRIhfPngLlCe0QYOdRKYFt8gy56TA==
   dependencies:
-    "@commitlint/config-validator" "^18.5.0"
-    "@commitlint/execute-rule" "^18.4.4"
-    "@commitlint/resolve-extends" "^18.5.0"
-    "@commitlint/types" "^18.4.4"
+    "@commitlint/config-validator" "^18.6.1"
+    "@commitlint/execute-rule" "^18.6.1"
+    "@commitlint/resolve-extends" "^18.6.1"
+    "@commitlint/types" "^18.6.1"
     chalk "^4.1.0"
     cosmiconfig "^8.3.6"
     cosmiconfig-typescript-loader "^5.0.0"
@@ -1879,69 +1702,69 @@
     lodash.uniq "^4.5.0"
     resolve-from "^5.0.0"
 
-"@commitlint/message@^18.4.4":
-  version "18.4.4"
-  resolved "https://registry.yarnpkg.com/@commitlint/message/-/message-18.4.4.tgz#811682a0d147a24e5c467acdb52071434df2b9f5"
-  integrity sha512-lHF95mMDYgAI1LBXveJUyg4eLaMXyOqJccCK3v55ZOEUsMPrDi8upqDjd/NmzWmESYihaOMBTAnxm+6oD1WoDQ==
+"@commitlint/message@^18.6.1":
+  version "18.6.1"
+  resolved "https://registry.yarnpkg.com/@commitlint/message/-/message-18.6.1.tgz#107bd40923ad23d2de56c92a68b179ebfb7e314e"
+  integrity sha512-VKC10UTMLcpVjMIaHHsY1KwhuTQtdIKPkIdVEwWV+YuzKkzhlI3aNy6oo1eAN6b/D2LTtZkJe2enHmX0corYRw==
 
-"@commitlint/parse@^18.4.4":
-  version "18.4.4"
-  resolved "https://registry.yarnpkg.com/@commitlint/parse/-/parse-18.4.4.tgz#5c8f515d4dbebe9b7ccfcd1701e58446e2bec6da"
-  integrity sha512-99G7dyn/OoyNWXJni0Ki0K3aJd01pEb/Im/Id6y4X7PN+kGOahjz2z/cXYYHn7xDdooqFVdiVrVLeChfgpWZ2g==
+"@commitlint/parse@^18.6.1":
+  version "18.6.1"
+  resolved "https://registry.yarnpkg.com/@commitlint/parse/-/parse-18.6.1.tgz#2946b814125e907b9c4d63d3e71d0c1b54b30b62"
+  integrity sha512-eS/3GREtvVJqGZrwAGRwR9Gdno3YcZ6Xvuaa+vUF8j++wsmxrA2En3n0ccfVO2qVOLJC41ni7jSZhQiJpMPGOQ==
   dependencies:
-    "@commitlint/types" "^18.4.4"
+    "@commitlint/types" "^18.6.1"
     conventional-changelog-angular "^7.0.0"
     conventional-commits-parser "^5.0.0"
 
 "@commitlint/read@^18.4.4":
-  version "18.4.4"
-  resolved "https://registry.yarnpkg.com/@commitlint/read/-/read-18.4.4.tgz#7f6848edd3210bf82e6aaa0cd30e72e7e669e009"
-  integrity sha512-r58JbWky4gAFPea/CZmvlqP9Ehbs+8gSEUqhIJOojKzTc3xlxFnZUDVPcEnnaqzQEEoV6C69VW7xuzdcBlu/FQ==
+  version "18.6.1"
+  resolved "https://registry.yarnpkg.com/@commitlint/read/-/read-18.6.1.tgz#8c138311ed9749427920c369f6276be136f2aa50"
+  integrity sha512-ia6ODaQFzXrVul07ffSgbZGFajpe8xhnDeLIprLeyfz3ivQU1dIoHp7yz0QIorZ6yuf4nlzg4ZUkluDrGN/J/w==
   dependencies:
-    "@commitlint/top-level" "^18.4.4"
-    "@commitlint/types" "^18.4.4"
+    "@commitlint/top-level" "^18.6.1"
+    "@commitlint/types" "^18.6.1"
     git-raw-commits "^2.0.11"
     minimist "^1.2.6"
 
-"@commitlint/resolve-extends@^18.5.0":
-  version "18.5.0"
-  resolved "https://registry.yarnpkg.com/@commitlint/resolve-extends/-/resolve-extends-18.5.0.tgz#ea955fc9455f70a5389cdc9633c78132c8008ed2"
-  integrity sha512-OxCYOMnlkOEEIkwTaRiFjHyuWBq962WBZQVHfMHej8tr3d+SfjznvqZhPmW8/SuqtfmGEiJPGWUNOxgwH+O0MA==
+"@commitlint/resolve-extends@^18.6.1":
+  version "18.6.1"
+  resolved "https://registry.yarnpkg.com/@commitlint/resolve-extends/-/resolve-extends-18.6.1.tgz#f0572c682fc24dbabe2e0f42873261e0fa42c91a"
+  integrity sha512-ifRAQtHwK+Gj3Bxj/5chhc4L2LIc3s30lpsyW67yyjsETR6ctHAHRu1FSpt0KqahK5xESqoJ92v6XxoDRtjwEQ==
   dependencies:
-    "@commitlint/config-validator" "^18.5.0"
-    "@commitlint/types" "^18.4.4"
+    "@commitlint/config-validator" "^18.6.1"
+    "@commitlint/types" "^18.6.1"
     import-fresh "^3.0.0"
     lodash.mergewith "^4.6.2"
     resolve-from "^5.0.0"
     resolve-global "^1.0.0"
 
-"@commitlint/rules@^18.4.4":
-  version "18.4.4"
-  resolved "https://registry.yarnpkg.com/@commitlint/rules/-/rules-18.4.4.tgz#859e920a4f0053ae27e4cdd65f68e7576a5ab53f"
-  integrity sha512-6Uzlsnl/GljEI+80NWjf4ThOfR8NIsbm18IfXYuCEchlwMHSxiuYG4rHSK5DNmG/+MIo8eR5VdQ0gQyt7kWzAA==
+"@commitlint/rules@^18.6.1":
+  version "18.6.1"
+  resolved "https://registry.yarnpkg.com/@commitlint/rules/-/rules-18.6.1.tgz#da25aeffe6c0e1c7625e44f46089fb8860986caf"
+  integrity sha512-kguM6HxZDtz60v/zQYOe0voAtTdGybWXefA1iidjWYmyUUspO1zBPQEmJZ05/plIAqCVyNUTAiRPWIBKLCrGew==
   dependencies:
-    "@commitlint/ensure" "^18.4.4"
-    "@commitlint/message" "^18.4.4"
-    "@commitlint/to-lines" "^18.4.4"
-    "@commitlint/types" "^18.4.4"
+    "@commitlint/ensure" "^18.6.1"
+    "@commitlint/message" "^18.6.1"
+    "@commitlint/to-lines" "^18.6.1"
+    "@commitlint/types" "^18.6.1"
     execa "^5.0.0"
 
-"@commitlint/to-lines@^18.4.4":
-  version "18.4.4"
-  resolved "https://registry.yarnpkg.com/@commitlint/to-lines/-/to-lines-18.4.4.tgz#546cf8d985459f3526359b6a63d7a5b421e1ed60"
-  integrity sha512-mwe2Roa59NCz/krniAdCygFabg7+fQCkIhXqBHw00XQ8Y7lw4poZLLxeGI3p3bLpcEOXdqIDrEGLwHmG5lBdwQ==
+"@commitlint/to-lines@^18.6.1":
+  version "18.6.1"
+  resolved "https://registry.yarnpkg.com/@commitlint/to-lines/-/to-lines-18.6.1.tgz#d28827a4a540c98eea1aae31dafd66f80b2f1b9e"
+  integrity sha512-Gl+orGBxYSNphx1+83GYeNy5N0dQsHBQ9PJMriaLQDB51UQHCVLBT/HBdOx5VaYksivSf5Os55TLePbRLlW50Q==
 
-"@commitlint/top-level@^18.4.4":
-  version "18.4.4"
-  resolved "https://registry.yarnpkg.com/@commitlint/top-level/-/top-level-18.4.4.tgz#df69ffa49fdc4541d1f05e814352d575fb0f3b0d"
-  integrity sha512-PBwW1drgeavl9CadB7IPRUk6rkUP/O8jEkxjlC+ofuh3pw0bzJdAT+Kw7M1Yc9KtTb9xTaqUB8uvRtaybHa/tQ==
+"@commitlint/top-level@^18.6.1":
+  version "18.6.1"
+  resolved "https://registry.yarnpkg.com/@commitlint/top-level/-/top-level-18.6.1.tgz#429fcb985e3beaba9b17e05c0ae61926c647baf0"
+  integrity sha512-HyiHQZUTf0+r0goTCDs/bbVv/LiiQ7AVtz6KIar+8ZrseB9+YJAIo8HQ2IC2QT1y3N1lbW6OqVEsTHjbT6hGSw==
   dependencies:
     find-up "^5.0.0"
 
-"@commitlint/types@^18.4.4":
-  version "18.4.4"
-  resolved "https://registry.yarnpkg.com/@commitlint/types/-/types-18.4.4.tgz#dae9e0ce6a6728a36b8982ff301af0170bbe0d38"
-  integrity sha512-/FykLtodD8gKs3+VNkAUwofu4LBHankclj+I8fB2jTRvG6PV7k/OUt4P+VbM7ip853qS4F0g7Z6hLNa6JeMcAQ==
+"@commitlint/types@^18.4.4", "@commitlint/types@^18.6.1":
+  version "18.6.1"
+  resolved "https://registry.yarnpkg.com/@commitlint/types/-/types-18.6.1.tgz#7eb3ab2d799d9166fbb98b96b0744581e59a4ad4"
+  integrity sha512-gwRLBLra/Dozj2OywopeuHj2ac26gjGkz2cZ+86cTJOdtWfiRRr4+e77ZDAGc6MDWxaWheI+mAV5TLWWRwqrFg==
   dependencies:
     chalk "^4.1.0"
 
@@ -1989,22 +1812,22 @@
   integrity sha512-e2OQlbOHMPZCI6BMA3OkTgOszPs2dhkbm+EXlllhBqmIvCOzLuA5iOGfoCEddkCqM8VHI+Zhdumq8XnFtSF+Jw==
 
 "@contentful/contentful-slatejs-adapter@^15.13.1", "@contentful/contentful-slatejs-adapter@^15.16.5":
-  version "15.16.8"
-  resolved "https://registry.yarnpkg.com/@contentful/contentful-slatejs-adapter/-/contentful-slatejs-adapter-15.16.8.tgz#1df8401551f658afae6639a380219e350dd654b9"
-  integrity sha512-5Ix5uEOl7XB3FiikEcV2Y1qkJXAKfSGPTNAQLBd624URJKZh+Q+PkWVqrdATUMO2LD1YekaTeBlJNdFK2PhriQ==
+  version "15.16.12"
+  resolved "https://registry.yarnpkg.com/@contentful/contentful-slatejs-adapter/-/contentful-slatejs-adapter-15.16.12.tgz#aa65e092a15877d9ca9b8adcaa0d577e176f05be"
+  integrity sha512-rB554D3CaJjZ80Z/rCtr5un7XNUL4UPYJzfm1e+dHzWl71p7gor+uOkmzZuQHq0xG+zF5dTqwdr9Sqh2OveSQA==
   dependencies:
-    "@contentful/rich-text-types" "^16.3.0"
+    "@contentful/rich-text-types" "^16.3.4"
 
-"@contentful/f36-accordion@^4.57.0", "@contentful/f36-accordion@^4.58.4":
-  version "4.58.4"
-  resolved "https://registry.yarnpkg.com/@contentful/f36-accordion/-/f36-accordion-4.58.4.tgz#76e2845f3db8af5976d0b53e7e8bcc34b60707c7"
-  integrity sha512-yXDi12ZF5YLcdlMLxyhRptuYUYAmAICQv3Zxgq6Jx8lBZfwSjyNQvuZsqy+vCQ1P3gHaCnzM56M9PB6Op2hLXQ==
+"@contentful/f36-accordion@^4.57.0", "@contentful/f36-accordion@^4.59.3":
+  version "4.59.3"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-accordion/-/f36-accordion-4.59.3.tgz#de0a39ff318e8c1f531b6fe3aacf03058b37126f"
+  integrity sha512-yiNSuWlCHMzpyP3Lks5A80LFVoCdssjYHgam/9UuLSHldx0sg84/O63Ito+tlcQDR+m0JwS+xlr7QjpqRBXkSQ==
   dependencies:
-    "@contentful/f36-collapse" "^4.58.4"
-    "@contentful/f36-core" "^4.58.4"
+    "@contentful/f36-collapse" "^4.59.3"
+    "@contentful/f36-core" "^4.59.3"
     "@contentful/f36-icons" "^4.27.0"
     "@contentful/f36-tokens" "^4.0.4"
-    "@contentful/f36-typography" "^4.58.4"
+    "@contentful/f36-typography" "^4.59.3"
     emotion "^10.0.17"
 
 "@contentful/f36-accordion@^4.60.0":
@@ -2019,16 +1842,16 @@
     "@contentful/f36-typography" "^4.60.0"
     emotion "^10.0.17"
 
-"@contentful/f36-asset@^4.57.0", "@contentful/f36-asset@^4.58.4":
-  version "4.58.4"
-  resolved "https://registry.yarnpkg.com/@contentful/f36-asset/-/f36-asset-4.58.4.tgz#69401cf3e6bf3e6e4a1c752f9934dbd68ff1e331"
-  integrity sha512-+QE+xORpWR2+J/muMUC6bZScOiMqI0jwNqNAdItErzzsrzRkknS+ZE1UCuoM8VrWC/NBmmiX41hqwP/3qaoj2A==
+"@contentful/f36-asset@^4.57.0", "@contentful/f36-asset@^4.59.3":
+  version "4.59.3"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-asset/-/f36-asset-4.59.3.tgz#5d234eb7cc48e2078f840975fe21f032ee8fdd83"
+  integrity sha512-G07cPOtvO3vZVrawS2sqRtnJFTukXtYenjHwheXMHwOJWUwvQFtKgiIUriLVSoiDlQtEc1r1Po8jXwnQTTQBBw==
   dependencies:
-    "@contentful/f36-core" "^4.58.4"
-    "@contentful/f36-icon" "^4.58.4"
+    "@contentful/f36-core" "^4.59.3"
+    "@contentful/f36-icon" "^4.59.3"
     "@contentful/f36-icons" "^4.27.0"
     "@contentful/f36-tokens" "^4.0.4"
-    "@contentful/f36-typography" "^4.58.4"
+    "@contentful/f36-typography" "^4.59.3"
     emotion "^10.0.17"
 
 "@contentful/f36-asset@^4.60.0":
@@ -2043,19 +1866,19 @@
     "@contentful/f36-typography" "^4.60.0"
     emotion "^10.0.17"
 
-"@contentful/f36-autocomplete@^4.57.0", "@contentful/f36-autocomplete@^4.58.4":
-  version "4.58.4"
-  resolved "https://registry.yarnpkg.com/@contentful/f36-autocomplete/-/f36-autocomplete-4.58.4.tgz#53494832d38f2b6a6d588f644b5a73337b56a5cd"
-  integrity sha512-dfK6iaAFWDewlYAfpx8mUzmE8MOQrKCe7IILCf35Le29dRY7M162oJCQmvFnwVBLYuZW3OaTRHIH8UbWMDjKbQ==
+"@contentful/f36-autocomplete@^4.57.0", "@contentful/f36-autocomplete@^4.59.3":
+  version "4.59.3"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-autocomplete/-/f36-autocomplete-4.59.3.tgz#a6d6253e69f01407a61fff6e40d0b53bd303099e"
+  integrity sha512-erDzdAgyBcxA5uXqLEWiTiDU15zolGZn1MjTIML4IlAYARo3W/4y7wqJ/BehCfs7stA1qWzQ8wOvefjIsHuT/Q==
   dependencies:
-    "@contentful/f36-button" "^4.58.4"
-    "@contentful/f36-core" "^4.58.4"
-    "@contentful/f36-forms" "^4.58.4"
+    "@contentful/f36-button" "^4.59.3"
+    "@contentful/f36-core" "^4.59.3"
+    "@contentful/f36-forms" "^4.59.3"
     "@contentful/f36-icons" "^4.27.0"
-    "@contentful/f36-popover" "^4.58.4"
-    "@contentful/f36-skeleton" "^4.58.4"
+    "@contentful/f36-popover" "^4.59.3"
+    "@contentful/f36-skeleton" "^4.59.3"
     "@contentful/f36-tokens" "^4.0.4"
-    "@contentful/f36-typography" "^4.58.4"
+    "@contentful/f36-typography" "^4.59.3"
     "@contentful/f36-utils" "^4.24.3"
     downshift "^6.1.12"
     emotion "^10.0.17"
@@ -2077,12 +1900,12 @@
     downshift "^6.1.12"
     emotion "^10.0.17"
 
-"@contentful/f36-badge@^4.57.0", "@contentful/f36-badge@^4.58.4":
-  version "4.58.4"
-  resolved "https://registry.yarnpkg.com/@contentful/f36-badge/-/f36-badge-4.58.4.tgz#9d3e02504ec6fce9e619ce38514f1b3d348c6f75"
-  integrity sha512-kkb5Bswrir412l49NKbx59QF1Gq45vWmOInph3sAEEesYjxt2orCD/Zi5KK3SDqIFvs7vFXhBvdm02CzRgyyow==
+"@contentful/f36-badge@^4.57.0", "@contentful/f36-badge@^4.59.3":
+  version "4.59.3"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-badge/-/f36-badge-4.59.3.tgz#fa894131e0ab0522e86f443bae636e9a01ddb1a5"
+  integrity sha512-dED7wqVX6VhgG089cfTk5kOZhRWbu3g1cqjo5+GXMRs9W+AMsYmtyjRbKWEeWQzSPiXR67pfp+fccOvOXZEMUw==
   dependencies:
-    "@contentful/f36-core" "^4.58.4"
+    "@contentful/f36-core" "^4.59.3"
     "@contentful/f36-icons" "^4.27.0"
     "@contentful/f36-tokens" "^4.0.4"
     emotion "^10.0.17"
@@ -2097,13 +1920,13 @@
     "@contentful/f36-tokens" "^4.0.4"
     emotion "^10.0.17"
 
-"@contentful/f36-button@^4.57.0", "@contentful/f36-button@^4.58.4":
-  version "4.58.4"
-  resolved "https://registry.yarnpkg.com/@contentful/f36-button/-/f36-button-4.58.4.tgz#a6b32d2948b541010c2051c882c6195a04a51ef6"
-  integrity sha512-NgQNcgoQn5oG7sGQBT4srBEnbBKYJntHzp7j2zxlCnsb4t8/v0qbkwBLKCtTTdIz2CHHjxKBA/jhia4Mx27/dg==
+"@contentful/f36-button@^4.57.0", "@contentful/f36-button@^4.59.3":
+  version "4.59.3"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-button/-/f36-button-4.59.3.tgz#2e093ef1fbec01d75f507808c8588aca1d01530e"
+  integrity sha512-dQfdC6JQNpt8hq6O6FuCT/vrk7y1glpCIaey28HhflNGgdsq2MIA4nPm8hgrJc63VJNBZKXtx3N7mCvKqOxPjg==
   dependencies:
-    "@contentful/f36-core" "^4.58.4"
-    "@contentful/f36-spinner" "^4.58.4"
+    "@contentful/f36-core" "^4.59.3"
+    "@contentful/f36-spinner" "^4.59.3"
     "@contentful/f36-tokens" "^4.0.4"
     "@contentful/f36-utils" "^4.24.3"
     emotion "^10.0.17"
@@ -2119,23 +1942,23 @@
     "@contentful/f36-utils" "^4.24.3"
     emotion "^10.0.17"
 
-"@contentful/f36-card@^4.57.0", "@contentful/f36-card@^4.58.4":
-  version "4.58.4"
-  resolved "https://registry.yarnpkg.com/@contentful/f36-card/-/f36-card-4.58.4.tgz#b8a5294a8d17f84478fd842775acc18c41485e82"
-  integrity sha512-6vfO4LfM3Y7HEDjIP/tR8rMmmjer0FuDL5AHEodFDMcodQeJjClhE/Yh38udW0ISJrrm60yqbrUPdcohF3qd6w==
+"@contentful/f36-card@^4.57.0", "@contentful/f36-card@^4.59.3":
+  version "4.59.3"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-card/-/f36-card-4.59.3.tgz#7e096fe3ef6b1b0ba3e29d754c70f6e39421ba3b"
+  integrity sha512-nCaL1DfwY9aSmjJKPBz9Uix8hf4Af288pW6P07piKQcNvL9oGhFO1c1rQlWCA4j8+cvxcklgolwmhWa9y9suAw==
   dependencies:
-    "@contentful/f36-asset" "^4.58.4"
-    "@contentful/f36-badge" "^4.58.4"
-    "@contentful/f36-button" "^4.58.4"
-    "@contentful/f36-core" "^4.58.4"
-    "@contentful/f36-drag-handle" "^4.58.4"
-    "@contentful/f36-icon" "^4.58.4"
+    "@contentful/f36-asset" "^4.59.3"
+    "@contentful/f36-badge" "^4.59.3"
+    "@contentful/f36-button" "^4.59.3"
+    "@contentful/f36-core" "^4.59.3"
+    "@contentful/f36-drag-handle" "^4.59.3"
+    "@contentful/f36-icon" "^4.59.3"
     "@contentful/f36-icons" "^4.27.0"
-    "@contentful/f36-menu" "^4.58.4"
-    "@contentful/f36-skeleton" "^4.58.4"
+    "@contentful/f36-menu" "^4.59.3"
+    "@contentful/f36-skeleton" "^4.59.3"
     "@contentful/f36-tokens" "^4.0.4"
-    "@contentful/f36-tooltip" "^4.58.4"
-    "@contentful/f36-typography" "^4.58.4"
+    "@contentful/f36-tooltip" "^4.59.3"
+    "@contentful/f36-typography" "^4.59.3"
     emotion "^10.0.17"
     truncate "^3.0.0"
 
@@ -2159,12 +1982,12 @@
     emotion "^10.0.17"
     truncate "^3.0.0"
 
-"@contentful/f36-collapse@^4.57.0", "@contentful/f36-collapse@^4.58.4":
-  version "4.58.4"
-  resolved "https://registry.yarnpkg.com/@contentful/f36-collapse/-/f36-collapse-4.58.4.tgz#876488f019911ab7483eec95b528d433df9097b5"
-  integrity sha512-yKiVlWFyRTjRFIBOp8f0IxnpDxuhXmZbpjNfycrQV53kMNCK4wYw5JZMFWyZVMCcqxucbDnnbckMCBVdCqRkfw==
+"@contentful/f36-collapse@^4.57.0", "@contentful/f36-collapse@^4.59.3":
+  version "4.59.3"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-collapse/-/f36-collapse-4.59.3.tgz#03ec33badcd1b4d779f7d040420f13521417e77a"
+  integrity sha512-htMO60Pm6AtgWQtdh6FqeRcwBxPm5CYJFg3m9SMQgFog4NsMK5nBm7Lm1JwiVxL1BgMPFihx6UkZP0gIJkP2WQ==
   dependencies:
-    "@contentful/f36-core" "^4.58.4"
+    "@contentful/f36-core" "^4.59.3"
     "@contentful/f36-tokens" "^4.0.4"
     emotion "^10.0.17"
 
@@ -2219,44 +2042,44 @@
     "@contentful/f36-utils" "^4.24.2"
 
 "@contentful/f36-components@^4.0.27", "@contentful/f36-components@^4.0.33", "@contentful/f36-components@^4.20.6", "@contentful/f36-components@^4.3.23", "@contentful/f36-components@^4.34.1":
-  version "4.58.4"
-  resolved "https://registry.yarnpkg.com/@contentful/f36-components/-/f36-components-4.58.4.tgz#390a225db8f7109090f10fa0309c90f0f49607f3"
-  integrity sha512-FkETZ4URxDWr197h3Fen4Inps75BdktODgENgyFT3Edufj6IfrdvKh20AT5EnyiS5K8kQIpbEw7ZFI+lMsbaWw==
+  version "4.59.3"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-components/-/f36-components-4.59.3.tgz#23e1db4d6f0b0ff0bbfc3318795369e5c860e59c"
+  integrity sha512-2nR3d5Dasrr+23XWiT02hY1np6YFTVo8lJhBbz4NVNxzovIq1YCH56GaHR6HngQdeURzV9Pu83SKkJWvCrCJ7Q==
   dependencies:
-    "@contentful/f36-accordion" "^4.58.4"
-    "@contentful/f36-asset" "^4.58.4"
-    "@contentful/f36-autocomplete" "^4.58.4"
-    "@contentful/f36-badge" "^4.58.4"
-    "@contentful/f36-button" "^4.58.4"
-    "@contentful/f36-card" "^4.58.4"
-    "@contentful/f36-collapse" "^4.58.4"
-    "@contentful/f36-copybutton" "^4.58.4"
-    "@contentful/f36-core" "^4.58.4"
-    "@contentful/f36-datepicker" "^4.58.4"
-    "@contentful/f36-datetime" "^4.58.4"
-    "@contentful/f36-drag-handle" "^4.58.4"
-    "@contentful/f36-empty-state" "^4.58.4"
-    "@contentful/f36-entity-list" "^4.58.4"
-    "@contentful/f36-forms" "^4.58.4"
-    "@contentful/f36-icon" "^4.58.4"
+    "@contentful/f36-accordion" "^4.59.3"
+    "@contentful/f36-asset" "^4.59.3"
+    "@contentful/f36-autocomplete" "^4.59.3"
+    "@contentful/f36-badge" "^4.59.3"
+    "@contentful/f36-button" "^4.59.3"
+    "@contentful/f36-card" "^4.59.3"
+    "@contentful/f36-collapse" "^4.59.3"
+    "@contentful/f36-copybutton" "^4.59.3"
+    "@contentful/f36-core" "^4.59.3"
+    "@contentful/f36-datepicker" "^4.59.3"
+    "@contentful/f36-datetime" "^4.59.3"
+    "@contentful/f36-drag-handle" "^4.59.3"
+    "@contentful/f36-empty-state" "^4.59.3"
+    "@contentful/f36-entity-list" "^4.59.3"
+    "@contentful/f36-forms" "^4.59.3"
+    "@contentful/f36-icon" "^4.59.3"
     "@contentful/f36-icons" "^4.27.0"
-    "@contentful/f36-list" "^4.58.4"
-    "@contentful/f36-menu" "^4.58.4"
-    "@contentful/f36-modal" "^4.58.4"
+    "@contentful/f36-list" "^4.59.3"
+    "@contentful/f36-menu" "^4.59.3"
+    "@contentful/f36-modal" "^4.59.3"
     "@contentful/f36-navbar" "^4.1.0"
-    "@contentful/f36-note" "^4.58.4"
-    "@contentful/f36-notification" "^4.58.4"
-    "@contentful/f36-pagination" "^4.58.4"
-    "@contentful/f36-pill" "^4.58.4"
-    "@contentful/f36-popover" "^4.58.4"
-    "@contentful/f36-skeleton" "^4.58.4"
-    "@contentful/f36-spinner" "^4.58.4"
-    "@contentful/f36-table" "^4.58.4"
-    "@contentful/f36-tabs" "^4.58.4"
-    "@contentful/f36-text-link" "^4.58.4"
+    "@contentful/f36-note" "^4.59.3"
+    "@contentful/f36-notification" "^4.59.3"
+    "@contentful/f36-pagination" "^4.59.3"
+    "@contentful/f36-pill" "^4.59.3"
+    "@contentful/f36-popover" "^4.59.3"
+    "@contentful/f36-skeleton" "^4.59.3"
+    "@contentful/f36-spinner" "^4.59.3"
+    "@contentful/f36-table" "^4.59.3"
+    "@contentful/f36-tabs" "^4.59.3"
+    "@contentful/f36-text-link" "^4.59.3"
     "@contentful/f36-tokens" "^4.0.4"
-    "@contentful/f36-tooltip" "^4.58.4"
-    "@contentful/f36-typography" "^4.58.4"
+    "@contentful/f36-tooltip" "^4.59.3"
+    "@contentful/f36-typography" "^4.59.3"
     "@contentful/f36-utils" "^4.24.3"
 
 "@contentful/f36-components@^4.60.0":
@@ -2300,16 +2123,16 @@
     "@contentful/f36-typography" "^4.60.0"
     "@contentful/f36-utils" "^4.24.3"
 
-"@contentful/f36-copybutton@^4.57.0", "@contentful/f36-copybutton@^4.58.4":
-  version "4.58.4"
-  resolved "https://registry.yarnpkg.com/@contentful/f36-copybutton/-/f36-copybutton-4.58.4.tgz#ea2b55fb64b81a0b2d0e47eb83d07b5fd3b09aa0"
-  integrity sha512-92W5DiExrNjDm+6fcQGp3ENWfdy5XXgxIk7zAAiAK6zZwXZ2TpSiTICgxvI1tJrybqpcGzLTCXQpnrbDlVggFQ==
+"@contentful/f36-copybutton@^4.57.0", "@contentful/f36-copybutton@^4.59.3":
+  version "4.59.3"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-copybutton/-/f36-copybutton-4.59.3.tgz#c77e35f2245a51929c76af288bda95be0742b7cf"
+  integrity sha512-JbyqCFw6KjHDQD5BdggCm4lGFi14HlIhOqvjWmvHwlt4XuEjvNy/uS8C5cPav1eB6ykdMdwp6anJDZ28bUXfBw==
   dependencies:
-    "@contentful/f36-button" "^4.58.4"
-    "@contentful/f36-core" "^4.58.4"
+    "@contentful/f36-button" "^4.59.3"
+    "@contentful/f36-core" "^4.59.3"
     "@contentful/f36-icons" "^4.27.0"
     "@contentful/f36-tokens" "^4.0.4"
-    "@contentful/f36-tooltip" "^4.58.4"
+    "@contentful/f36-tooltip" "^4.59.3"
     emotion "^10.0.17"
 
 "@contentful/f36-copybutton@^4.60.0":
@@ -2324,10 +2147,10 @@
     "@contentful/f36-tooltip" "^4.60.0"
     emotion "^10.0.17"
 
-"@contentful/f36-core@^4.45.0", "@contentful/f36-core@^4.48.0", "@contentful/f36-core@^4.57.0", "@contentful/f36-core@^4.58.4":
-  version "4.58.4"
-  resolved "https://registry.yarnpkg.com/@contentful/f36-core/-/f36-core-4.58.4.tgz#c6d57fc0d809869e16c31b1d00f1086ff0ac40aa"
-  integrity sha512-RUEl6TrC5fMZB50GACl75nk6GWI595wucTFXHlgWXYW6+qHcjJ+77/h+egkdNKzeXPsZGcX6tsYDOt58/RoAtA==
+"@contentful/f36-core@^4.45.0", "@contentful/f36-core@^4.48.0", "@contentful/f36-core@^4.57.0", "@contentful/f36-core@^4.59.3":
+  version "4.59.3"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-core/-/f36-core-4.59.3.tgz#38b4cf441000a1d9893447cdcb77e5685cb795b3"
+  integrity sha512-KWuRPFtBd3HXO1hL6VBokSQ6SC6JsnwKB7L8ukmCKuo3CeW+C7u4jlbOkLVtlvmTHwDphD+oqDJu67zdJ2EYVw==
   dependencies:
     "@contentful/f36-tokens" "^4.0.4"
     "@emotion/core" "^10.1.1"
@@ -2346,18 +2169,18 @@
     csstype "^3.1.1"
     emotion "^10.0.17"
 
-"@contentful/f36-datepicker@^4.57.0", "@contentful/f36-datepicker@^4.58.4":
-  version "4.58.4"
-  resolved "https://registry.yarnpkg.com/@contentful/f36-datepicker/-/f36-datepicker-4.58.4.tgz#9c99aa36a43c0df6bcb15b0656af293e78cf0cfa"
-  integrity sha512-wHDubFxjKUgn3oWeGCoD9dXMkK0lbRMRigY3jPnl98Mce1aGw0092fRM8iJflh1k2UqbLQppAVOGpucJcMc3Sg==
+"@contentful/f36-datepicker@^4.57.0", "@contentful/f36-datepicker@^4.59.3":
+  version "4.59.3"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-datepicker/-/f36-datepicker-4.59.3.tgz#66b54cca2f2ffd4db060135abc8431702662bbe1"
+  integrity sha512-rI5N3gPgBcQEp14UIMsok42+Omu2Waw9iyggX+3BMdmLfA4pz4WovYKWQekLlUZAnvqGINatT0KJIDIN7JCMpw==
   dependencies:
-    "@contentful/f36-button" "^4.58.4"
-    "@contentful/f36-core" "^4.58.4"
-    "@contentful/f36-forms" "^4.58.4"
+    "@contentful/f36-button" "^4.59.3"
+    "@contentful/f36-core" "^4.59.3"
+    "@contentful/f36-forms" "^4.59.3"
     "@contentful/f36-icons" "^4.27.0"
-    "@contentful/f36-popover" "^4.58.4"
+    "@contentful/f36-popover" "^4.59.3"
     "@contentful/f36-tokens" "^4.0.4"
-    "@contentful/f36-typography" "^4.58.4"
+    "@contentful/f36-typography" "^4.59.3"
     date-fns "^2.28.0"
     emotion "^10.0.17"
     react-day-picker "^8.7.1"
@@ -2380,12 +2203,12 @@
     react-day-picker "^8.7.1"
     react-focus-lock "^2.9.1"
 
-"@contentful/f36-datetime@^4.57.0", "@contentful/f36-datetime@^4.58.4":
-  version "4.58.4"
-  resolved "https://registry.yarnpkg.com/@contentful/f36-datetime/-/f36-datetime-4.58.4.tgz#da912725fd3a90873564acd1af9bf82fd8332791"
-  integrity sha512-Rx/OKXfs2CTPHhzDanB6zs6pOYrbxghATGf+X0kFInSvG3YjjZZlxelLLFIklRWhBYy1BTQJBFh44OVopVI7TQ==
+"@contentful/f36-datetime@^4.57.0", "@contentful/f36-datetime@^4.59.3":
+  version "4.59.3"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-datetime/-/f36-datetime-4.59.3.tgz#08d7dc8944c03cd4a8c317dbd178930c826e0522"
+  integrity sha512-bPThNC/j4BSlILGxTAb8k/ivAFXSh2nFUkooKQWuh3RgKQzEOqoIH4sYZOafBc96foHqp+U7J+ywkl2PdZ4gLw==
   dependencies:
-    "@contentful/f36-core" "^4.58.4"
+    "@contentful/f36-core" "^4.59.3"
     "@contentful/f36-tokens" "^4.0.4"
     dayjs "^1.11.5"
     emotion "^10.0.17"
@@ -2400,12 +2223,12 @@
     dayjs "^1.11.5"
     emotion "^10.0.17"
 
-"@contentful/f36-drag-handle@^4.57.0", "@contentful/f36-drag-handle@^4.58.4":
-  version "4.58.4"
-  resolved "https://registry.yarnpkg.com/@contentful/f36-drag-handle/-/f36-drag-handle-4.58.4.tgz#ca92d2963627acda346d6589b57585ec034670fe"
-  integrity sha512-GgAdCik9yCimf0J/K/KooAkQytHDMo+Aq4EiLitsuRyNiC73KAeyh3HlLVIeXNId1wF3SnihegOQwjR+KSwurA==
+"@contentful/f36-drag-handle@^4.57.0", "@contentful/f36-drag-handle@^4.59.3":
+  version "4.59.3"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-drag-handle/-/f36-drag-handle-4.59.3.tgz#79f0fdb006a4281cd8b09adf1d31df4a56160f4d"
+  integrity sha512-yQ8uWnjjT8pz++12hL8Qj2lFNvx43xFvWLEKMEytpt76+lAJoFqOlv4H+8XQDTlx6q87RbwD7HJPkZOZ+SBhtg==
   dependencies:
-    "@contentful/f36-core" "^4.58.4"
+    "@contentful/f36-core" "^4.59.3"
     "@contentful/f36-icons" "^4.27.0"
     "@contentful/f36-tokens" "^4.0.4"
     "@contentful/f36-utils" "^4.24.3"
@@ -2422,13 +2245,13 @@
     "@contentful/f36-utils" "^4.24.3"
     emotion "^10.0.17"
 
-"@contentful/f36-empty-state@^4.57.0", "@contentful/f36-empty-state@^4.58.4":
-  version "4.58.4"
-  resolved "https://registry.yarnpkg.com/@contentful/f36-empty-state/-/f36-empty-state-4.58.4.tgz#3aca7fb23879a9d3908f37e89bc7d8f2fd427e21"
-  integrity sha512-G2adxImI181asA8xalP8+hDWdUTzrwl7AMXvjLEKDKJeJzGOyDUgJQLvzKnwZGcNNyrNMIFHzphdvow4U7LeOQ==
+"@contentful/f36-empty-state@^4.57.0", "@contentful/f36-empty-state@^4.59.3":
+  version "4.59.3"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-empty-state/-/f36-empty-state-4.59.3.tgz#2c63de877c5a70caa27caa3f46cf551bc77e41de"
+  integrity sha512-/wE2ZaDD9LfkF5e30o/S6SaQwegIsBI2/kdxYNijygLhiUv2Up2vzmtUvnbf2xrGskxCjIo9cffGp7M15C3kOA==
   dependencies:
     "@contentful/f36-tokens" "^4.0.4"
-    "@contentful/f36-typography" "^4.58.4"
+    "@contentful/f36-typography" "^4.59.3"
     emotion "^10.0.17"
 
 "@contentful/f36-empty-state@^4.60.0":
@@ -2440,21 +2263,21 @@
     "@contentful/f36-typography" "^4.60.0"
     emotion "^10.0.17"
 
-"@contentful/f36-entity-list@^4.57.0", "@contentful/f36-entity-list@^4.58.4":
-  version "4.58.4"
-  resolved "https://registry.yarnpkg.com/@contentful/f36-entity-list/-/f36-entity-list-4.58.4.tgz#7bcc715e365c1b0e9524248f98634aee220d188b"
-  integrity sha512-I/+xNQ/936H1XtGUWvnI1bS1TT3ahdvXHnc3GqdgcOVyggdXCpUUAaa1iMP7I/jFklf2sFVwhAMXeanOZT4t8g==
+"@contentful/f36-entity-list@^4.57.0", "@contentful/f36-entity-list@^4.59.3":
+  version "4.59.3"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-entity-list/-/f36-entity-list-4.59.3.tgz#25270a7394d38695558db1077aa19f35eb415888"
+  integrity sha512-PTDJhRDQvGGq90CU1/2rqFI9TfKiEDunmvrfAXdpbgTuBvHKkMWx/8FBWDRQZXEXK0AFuam1ahLZZt9Gi/bBKA==
   dependencies:
-    "@contentful/f36-badge" "^4.58.4"
-    "@contentful/f36-button" "^4.58.4"
-    "@contentful/f36-core" "^4.58.4"
-    "@contentful/f36-drag-handle" "^4.58.4"
-    "@contentful/f36-icon" "^4.58.4"
+    "@contentful/f36-badge" "^4.59.3"
+    "@contentful/f36-button" "^4.59.3"
+    "@contentful/f36-core" "^4.59.3"
+    "@contentful/f36-drag-handle" "^4.59.3"
+    "@contentful/f36-icon" "^4.59.3"
     "@contentful/f36-icons" "^4.27.0"
-    "@contentful/f36-menu" "^4.58.4"
-    "@contentful/f36-skeleton" "^4.58.4"
+    "@contentful/f36-menu" "^4.59.3"
+    "@contentful/f36-skeleton" "^4.59.3"
     "@contentful/f36-tokens" "^4.0.4"
-    "@contentful/f36-typography" "^4.58.4"
+    "@contentful/f36-typography" "^4.59.3"
     emotion "^10.0.17"
 
 "@contentful/f36-entity-list@^4.60.0":
@@ -2474,15 +2297,15 @@
     "@contentful/f36-typography" "^4.60.0"
     emotion "^10.0.17"
 
-"@contentful/f36-forms@^4.57.0", "@contentful/f36-forms@^4.58.4":
-  version "4.58.4"
-  resolved "https://registry.yarnpkg.com/@contentful/f36-forms/-/f36-forms-4.58.4.tgz#6e84fade4e0eee9fcf408cb7bc49a47311fc58b9"
-  integrity sha512-fnsuhkN8DQn05oaSB1mEyWr66Po3wmnzZxnc3kUSFP0I/8eoB5wFV8BYbM0/D31sjW1hIuWYgMggkaKZOahfCA==
+"@contentful/f36-forms@^4.57.0", "@contentful/f36-forms@^4.59.3":
+  version "4.59.3"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-forms/-/f36-forms-4.59.3.tgz#2ea79e05afbe99079d1f3ce684fee257ddf7c3da"
+  integrity sha512-GT7Dd1LWac2pPl/vqmjbjIeoEip8CztHu6rY8qmetUS7Vl3EqSdVaSSfnYxUy+deQlnrVKWabnvhfYPgiDlaNA==
   dependencies:
-    "@contentful/f36-core" "^4.58.4"
+    "@contentful/f36-core" "^4.59.3"
     "@contentful/f36-icons" "^4.27.0"
     "@contentful/f36-tokens" "^4.0.4"
-    "@contentful/f36-typography" "^4.58.4"
+    "@contentful/f36-typography" "^4.59.3"
     "@contentful/f36-utils" "^4.24.3"
     emotion "^10.0.17"
 
@@ -2498,12 +2321,12 @@
     "@contentful/f36-utils" "^4.24.3"
     emotion "^10.0.17"
 
-"@contentful/f36-icon@^4.45.0", "@contentful/f36-icon@^4.48.0", "@contentful/f36-icon@^4.57.0", "@contentful/f36-icon@^4.58.4":
-  version "4.58.4"
-  resolved "https://registry.yarnpkg.com/@contentful/f36-icon/-/f36-icon-4.58.4.tgz#e38d17b3592bffcfac4e4da55eb8f84f541835c5"
-  integrity sha512-Wd4bn4BT+4c8N1ksHcOapTRHi7JzPxE8vcmJiF4sWN9Wbp3j0GPYkKC8NjgQQobWz6U1Ql+1ZQRFQBKr9t/87w==
+"@contentful/f36-icon@^4.45.0", "@contentful/f36-icon@^4.48.0", "@contentful/f36-icon@^4.57.0", "@contentful/f36-icon@^4.59.3":
+  version "4.59.3"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-icon/-/f36-icon-4.59.3.tgz#df64ede39dc26d594bfdb53b4f5ddb9929b20fc5"
+  integrity sha512-xhk4KzuBmtu84hJZSSy5JcbZyqv5e19gHlt+tVv3Rxx2cuZR668f1LNz0D4l1udXUEYtIWaH190Z92vCO+agpg==
   dependencies:
-    "@contentful/f36-core" "^4.58.4"
+    "@contentful/f36-core" "^4.59.3"
     "@contentful/f36-tokens" "^4.0.4"
     emotion "^10.0.17"
 
@@ -2526,12 +2349,12 @@
     "@contentful/f36-tokens" "^4.0.1"
     emotion "^10.0.17"
 
-"@contentful/f36-list@^4.57.0", "@contentful/f36-list@^4.58.4":
-  version "4.58.4"
-  resolved "https://registry.yarnpkg.com/@contentful/f36-list/-/f36-list-4.58.4.tgz#f3c015935f5c211f9afab2c1c0536c2463b4d980"
-  integrity sha512-lkU+04qhTW5GdKKHFwo4EVOLJhGFLGe7YV80m4XkyLug3OTHRFlrEq00+rzp4rfp82uINape3NwheNqugvwZXw==
+"@contentful/f36-list@^4.57.0", "@contentful/f36-list@^4.59.3":
+  version "4.59.3"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-list/-/f36-list-4.59.3.tgz#5517e1587c3ff976b88e5421b4c8ee22f51abf37"
+  integrity sha512-i/VMmQA44JDM7osSj5cDlqqsV3ugIn8g2T4QwthMkGkhx2lBoswiXVZx3qWMtgCaAH9Ko5iv0UBsrsJk77SgXQ==
   dependencies:
-    "@contentful/f36-core" "^4.58.4"
+    "@contentful/f36-core" "^4.59.3"
     "@contentful/f36-tokens" "^4.0.4"
     emotion "^10.0.17"
 
@@ -2544,16 +2367,16 @@
     "@contentful/f36-tokens" "^4.0.4"
     emotion "^10.0.17"
 
-"@contentful/f36-menu@^4.45.0", "@contentful/f36-menu@^4.57.0", "@contentful/f36-menu@^4.58.4":
-  version "4.58.4"
-  resolved "https://registry.yarnpkg.com/@contentful/f36-menu/-/f36-menu-4.58.4.tgz#f085263a39938228ee225cc7008e43ad0d1e1b0d"
-  integrity sha512-XSLeb4N0ZLGrYTsZZDew6Lyw4rNz+CciQOB/ptk0WnUuwRCFzN7Wdzf2GNxnT6thpabRv+xqJ5HLlenGYhH6Jw==
+"@contentful/f36-menu@^4.45.0", "@contentful/f36-menu@^4.57.0", "@contentful/f36-menu@^4.59.3":
+  version "4.59.3"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-menu/-/f36-menu-4.59.3.tgz#7c85baf60fea53622930c738240bb7d99e2ea2d1"
+  integrity sha512-oURXSs4MPLkNsklrwLaCQIQZu/N3XU1GOAhNuO98EMwmJfmVBaZ4AQU3h7GJbhhWjgc3uEkJOZM74pIrKgsZbA==
   dependencies:
-    "@contentful/f36-core" "^4.58.4"
+    "@contentful/f36-core" "^4.59.3"
     "@contentful/f36-icons" "^4.27.0"
-    "@contentful/f36-popover" "^4.58.4"
+    "@contentful/f36-popover" "^4.59.3"
     "@contentful/f36-tokens" "^4.0.4"
-    "@contentful/f36-typography" "^4.58.4"
+    "@contentful/f36-typography" "^4.59.3"
     "@contentful/f36-utils" "^4.24.3"
     emotion "^10.0.17"
 
@@ -2570,16 +2393,16 @@
     "@contentful/f36-utils" "^4.24.3"
     emotion "^10.0.17"
 
-"@contentful/f36-modal@^4.57.0", "@contentful/f36-modal@^4.58.4":
-  version "4.58.4"
-  resolved "https://registry.yarnpkg.com/@contentful/f36-modal/-/f36-modal-4.58.4.tgz#a1eba43732c85152c48172067402c190598a1445"
-  integrity sha512-KkOLdqt0p6d50cWqy1PXrGbrjNRJh/LDfT+kUIfMuvKAbBbdIixCWfCegz2Y9pLsZ/87qKxhwvu7KfMJTFyMOw==
+"@contentful/f36-modal@^4.57.0", "@contentful/f36-modal@^4.59.3":
+  version "4.59.3"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-modal/-/f36-modal-4.59.3.tgz#8ce8a1c8ba32475035c5763b613a43b9dc46231b"
+  integrity sha512-CWAprCQnA7TFwAulZ97KmvRF4/+bDVW6hbGOkhXtvgMfU3OzVGMIKdLBfyvyOOlGZLkB6/xXZQOC2Ubxw+PpWA==
   dependencies:
-    "@contentful/f36-button" "^4.58.4"
-    "@contentful/f36-core" "^4.58.4"
+    "@contentful/f36-button" "^4.59.3"
+    "@contentful/f36-core" "^4.59.3"
     "@contentful/f36-icons" "^4.27.0"
     "@contentful/f36-tokens" "^4.0.4"
-    "@contentful/f36-typography" "^4.58.4"
+    "@contentful/f36-typography" "^4.59.3"
     "@types/react-modal" "^3.13.1"
     emotion "^10.0.17"
     react-modal "^3.16.1"
@@ -2599,9 +2422,9 @@
     react-modal "^3.16.1"
 
 "@contentful/f36-navbar@^4.1.0":
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/@contentful/f36-navbar/-/f36-navbar-4.1.0.tgz#81c501260b4e132d233e05d5406acc1987c0cc1a"
-  integrity sha512-tFzg4px28dGq2zD+/rKsVmZ684WItZ+xNGI7et6QeAmevwIzifE1JGblJr/BC1Nn2nWLlF0LZn4URekIf7ijkA==
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-navbar/-/f36-navbar-4.1.1.tgz#139c0280f14f3a923d40bfa7290984eb60486119"
+  integrity sha512-nCLtZ7EgfKhmXWrGZYrZEQOoulOOVPOuZBk0CC4JgQRQmCYeYr2iAnM8zualISFaxX/O+GVvHPQf2hKeoeFRPA==
   dependencies:
     "@contentful/f36-core" "^4.45.0"
     "@contentful/f36-icon" "^4.45.0"
@@ -2612,17 +2435,17 @@
     "@contentful/f36-utils" "^4.23.2"
     emotion "^10.0.17"
 
-"@contentful/f36-note@^4.2.8", "@contentful/f36-note@^4.57.0", "@contentful/f36-note@^4.58.4":
-  version "4.58.4"
-  resolved "https://registry.yarnpkg.com/@contentful/f36-note/-/f36-note-4.58.4.tgz#d0d44bb523c9b8dd87fbea5c0408cfa8ce52f74e"
-  integrity sha512-0oFzxKWfHRJw2AclDeOUaKGYHYI3qLtdMt0P/sHTxxy8KnwregwmSTi4Sv94LqNTAQcX7SQAO6Q4+KvFbJIV9A==
+"@contentful/f36-note@^4.2.8", "@contentful/f36-note@^4.57.0", "@contentful/f36-note@^4.59.3":
+  version "4.59.3"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-note/-/f36-note-4.59.3.tgz#c2b542c18f03dbc12c2d5ffb443a7d3e6728c897"
+  integrity sha512-k9HLeCP9CUw5I9M7L3uy/GIsBBK6SES2yOcg/UmKCDyKl/YjbMtEASpqMfzAkrcXjeTuBcmXwKJXI7svufwazQ==
   dependencies:
-    "@contentful/f36-button" "^4.58.4"
-    "@contentful/f36-core" "^4.58.4"
-    "@contentful/f36-icon" "^4.58.4"
+    "@contentful/f36-button" "^4.59.3"
+    "@contentful/f36-core" "^4.59.3"
+    "@contentful/f36-icon" "^4.59.3"
     "@contentful/f36-icons" "^4.27.0"
     "@contentful/f36-tokens" "^4.0.4"
-    "@contentful/f36-typography" "^4.58.4"
+    "@contentful/f36-typography" "^4.59.3"
     emotion "^10.0.17"
 
 "@contentful/f36-note@^4.60.0":
@@ -2638,17 +2461,17 @@
     "@contentful/f36-typography" "^4.60.0"
     emotion "^10.0.17"
 
-"@contentful/f36-notification@^4.57.0", "@contentful/f36-notification@^4.58.4":
-  version "4.58.4"
-  resolved "https://registry.yarnpkg.com/@contentful/f36-notification/-/f36-notification-4.58.4.tgz#2e819fede3c440980c3f6aeae14145df4efba900"
-  integrity sha512-Pvne6emM1tpIhK1x6+9d0kvl56D25PfAgejEWioI+0VaIsIpXvmmYNYIgqViUtP6sxu9+fQZDivmCr1CfbB+MQ==
+"@contentful/f36-notification@^4.57.0", "@contentful/f36-notification@^4.59.3":
+  version "4.59.3"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-notification/-/f36-notification-4.59.3.tgz#fbc3cf6784755a272befe1dd5f49934e802e4c16"
+  integrity sha512-IAIPx0MfrJcMHoy8w8X4cdyPhMkhkz+A5/qvTovVBaKfjt1zyRYg8qEp3ZYDxh3T4JQeY/hTzWQ4+35uq9dm7A==
   dependencies:
-    "@contentful/f36-button" "^4.58.4"
-    "@contentful/f36-core" "^4.58.4"
+    "@contentful/f36-button" "^4.59.3"
+    "@contentful/f36-core" "^4.59.3"
     "@contentful/f36-icons" "^4.27.0"
-    "@contentful/f36-text-link" "^4.58.4"
+    "@contentful/f36-text-link" "^4.59.3"
     "@contentful/f36-tokens" "^4.0.4"
-    "@contentful/f36-typography" "^4.58.4"
+    "@contentful/f36-typography" "^4.59.3"
     "@swc/helpers" "^0.4.14"
     emotion "^10.0.17"
     react-animate-height "^3.0.4"
@@ -2668,17 +2491,17 @@
     emotion "^10.0.17"
     react-animate-height "^3.0.4"
 
-"@contentful/f36-pagination@^4.57.0", "@contentful/f36-pagination@^4.58.4":
-  version "4.58.4"
-  resolved "https://registry.yarnpkg.com/@contentful/f36-pagination/-/f36-pagination-4.58.4.tgz#33879d6e1d8264894cff8cd24c56ba34780e39df"
-  integrity sha512-2w56B1w5kkm8g/Q/NGtlF25uMwkPoDJ7gr+ry5LqcYqFSfjJzKytVd4tDzbrdNRJajn9MpqSyHVLxG6icJSBOw==
+"@contentful/f36-pagination@^4.57.0", "@contentful/f36-pagination@^4.59.3":
+  version "4.59.3"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-pagination/-/f36-pagination-4.59.3.tgz#e6e555b78e295586c6541c73d1722309e6bb60f5"
+  integrity sha512-777DP0tR5GimQXGoPu9Nmx2w9pbgk/KfZuArg2tFcTA3imda4xHLscBP34cp26YTePxajjLWjafAn5i/RqBESw==
   dependencies:
-    "@contentful/f36-button" "^4.58.4"
-    "@contentful/f36-core" "^4.58.4"
-    "@contentful/f36-forms" "^4.58.4"
+    "@contentful/f36-button" "^4.59.3"
+    "@contentful/f36-core" "^4.59.3"
+    "@contentful/f36-forms" "^4.59.3"
     "@contentful/f36-icons" "^4.27.0"
     "@contentful/f36-tokens" "^4.0.4"
-    "@contentful/f36-typography" "^4.58.4"
+    "@contentful/f36-typography" "^4.59.3"
     emotion "^10.0.17"
 
 "@contentful/f36-pagination@^4.60.0":
@@ -2694,17 +2517,17 @@
     "@contentful/f36-typography" "^4.60.0"
     emotion "^10.0.17"
 
-"@contentful/f36-pill@^4.57.0", "@contentful/f36-pill@^4.58.4":
-  version "4.58.4"
-  resolved "https://registry.yarnpkg.com/@contentful/f36-pill/-/f36-pill-4.58.4.tgz#4f804cf8f8552149ac2448d4409c64f854f54805"
-  integrity sha512-q7sJfJkuOm1kCQ2eSay7vaJ5v+r5ATArESZ0il79VV3p5HSyje4PsuEJkS2YZZ03FWcs4mv+jdXwYZx4lX5u5g==
+"@contentful/f36-pill@^4.57.0", "@contentful/f36-pill@^4.59.3":
+  version "4.59.3"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-pill/-/f36-pill-4.59.3.tgz#d7a223c7a4454f504b043d3388d225e47c50f78d"
+  integrity sha512-pAa5tOFPlTG64tbB8PiKtnf9P8fCOAP57uX1LfwaPn6QEVqlrvsH1+Vd3oerzPgyZsXxzAgojJ+QqLKzykw/Eg==
   dependencies:
-    "@contentful/f36-button" "^4.58.4"
-    "@contentful/f36-core" "^4.58.4"
-    "@contentful/f36-drag-handle" "^4.58.4"
+    "@contentful/f36-button" "^4.59.3"
+    "@contentful/f36-core" "^4.59.3"
+    "@contentful/f36-drag-handle" "^4.59.3"
     "@contentful/f36-icons" "^4.27.0"
     "@contentful/f36-tokens" "^4.0.4"
-    "@contentful/f36-tooltip" "^4.58.4"
+    "@contentful/f36-tooltip" "^4.59.3"
     emotion "^10.0.17"
 
 "@contentful/f36-pill@^4.60.0":
@@ -2720,12 +2543,12 @@
     "@contentful/f36-tooltip" "^4.60.0"
     emotion "^10.0.17"
 
-"@contentful/f36-popover@^4.57.0", "@contentful/f36-popover@^4.58.4":
-  version "4.58.4"
-  resolved "https://registry.yarnpkg.com/@contentful/f36-popover/-/f36-popover-4.58.4.tgz#7ea07dbfbefe953f8fe69a76e43d1f82005bab84"
-  integrity sha512-Y9GTYoqeh63k6iZ0ciXoRfhQlig4ZWmBF0vo/rPg2+ZfhlVwYQI6uNJbXH59Fl8VptiPCTKoGa0TogZn5dLZ5A==
+"@contentful/f36-popover@^4.57.0", "@contentful/f36-popover@^4.59.3":
+  version "4.59.3"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-popover/-/f36-popover-4.59.3.tgz#8e6cd1c0bb31dfa1202a2e420e5455b5afd1e973"
+  integrity sha512-VIdoiC8UuizDrgQb2QPXOzpuZg0YWDkrmiu2VQxNp65X1rc0x8kES7VkPvnqEAPyWQUpi4jU6cvyb/1r+UwHKw==
   dependencies:
-    "@contentful/f36-core" "^4.58.4"
+    "@contentful/f36-core" "^4.59.3"
     "@contentful/f36-tokens" "^4.0.4"
     "@contentful/f36-utils" "^4.24.3"
     "@popperjs/core" "^2.11.5"
@@ -2744,13 +2567,13 @@
     emotion "^10.0.17"
     react-popper "^2.3.0"
 
-"@contentful/f36-skeleton@^4.45.0", "@contentful/f36-skeleton@^4.57.0", "@contentful/f36-skeleton@^4.58.4":
-  version "4.58.4"
-  resolved "https://registry.yarnpkg.com/@contentful/f36-skeleton/-/f36-skeleton-4.58.4.tgz#5589ad9ff7ac0624a239ea031583e0f4c3a0c825"
-  integrity sha512-vz1XPOYxy6dsTATjmVoe55f49tbPGaDU0WCEuFeCB94cHarC9SgKWjQg9vDQydUKPOcRfcxXYCogGHywWrrkqw==
+"@contentful/f36-skeleton@^4.45.0", "@contentful/f36-skeleton@^4.57.0", "@contentful/f36-skeleton@^4.59.3":
+  version "4.59.3"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-skeleton/-/f36-skeleton-4.59.3.tgz#5c09eb5b936d9d15fe4d5360816332f059f61437"
+  integrity sha512-J06S1Cs2eQr/cNFOYDnrjl5qwCSvDgVJ0WKNcyQoJ4bO/9vwvpelYsnqm7g2qG+4X9CLbIFaxCaI5C+KLcfDow==
   dependencies:
-    "@contentful/f36-core" "^4.58.4"
-    "@contentful/f36-table" "^4.58.4"
+    "@contentful/f36-core" "^4.59.3"
+    "@contentful/f36-table" "^4.59.3"
     "@contentful/f36-tokens" "^4.0.4"
     emotion "^10.0.17"
 
@@ -2764,12 +2587,12 @@
     "@contentful/f36-tokens" "^4.0.4"
     emotion "^10.0.17"
 
-"@contentful/f36-spinner@^4.57.0", "@contentful/f36-spinner@^4.58.4":
-  version "4.58.4"
-  resolved "https://registry.yarnpkg.com/@contentful/f36-spinner/-/f36-spinner-4.58.4.tgz#c3aaa1e017e82a19756f922b1d2a330ce9770880"
-  integrity sha512-GXdA4H0t1ktCX9fcc6TaHtgbCpPuroJhvlUOg+nFbJt9Zpa6g4MjH1UIqUFASyB0j4dIFcNLawklBvfDcPKB7w==
+"@contentful/f36-spinner@^4.57.0", "@contentful/f36-spinner@^4.59.3":
+  version "4.59.3"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-spinner/-/f36-spinner-4.59.3.tgz#9b3337ee5943f8baff0315822a58a001a7017765"
+  integrity sha512-ajVYvw8u69V2weJebG2zrXDuFwMvnrWvl1TyH8i6lFvIsudc3/fmddN32WCXleVcK/zA3bRgTUICm+ROs99vXQ==
   dependencies:
-    "@contentful/f36-core" "^4.58.4"
+    "@contentful/f36-core" "^4.59.3"
     "@contentful/f36-tokens" "^4.0.4"
     emotion "^10.0.17"
 
@@ -2782,15 +2605,15 @@
     "@contentful/f36-tokens" "^4.0.4"
     emotion "^10.0.17"
 
-"@contentful/f36-table@^4.57.0", "@contentful/f36-table@^4.58.4":
-  version "4.58.4"
-  resolved "https://registry.yarnpkg.com/@contentful/f36-table/-/f36-table-4.58.4.tgz#42f5807eaa22b9884045221c4c1b383472ad24b4"
-  integrity sha512-X8kRRqa7JMQVLHYDcPPPCEmVzWML9k00V/k47qfmDKxzCKvh3bFmx28QfEI9WBuyDh1duaEiGTPlMicOXeJOmQ==
+"@contentful/f36-table@^4.57.0", "@contentful/f36-table@^4.59.3":
+  version "4.59.3"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-table/-/f36-table-4.59.3.tgz#2cb29ffa232f336497b2237b7f540b0ea2aa341a"
+  integrity sha512-iCxwQGKbPToeK4WjFNxyr5g5UUCY022/U7wvnse/7+19NpRF7I9zqO99rcP5iSs1ogoVBAVCkJohLvV2P0dX0g==
   dependencies:
-    "@contentful/f36-core" "^4.58.4"
+    "@contentful/f36-core" "^4.59.3"
     "@contentful/f36-icons" "^4.27.0"
     "@contentful/f36-tokens" "^4.0.4"
-    "@contentful/f36-typography" "^4.58.4"
+    "@contentful/f36-typography" "^4.59.3"
     emotion "^10.0.17"
 
 "@contentful/f36-table@^4.60.0":
@@ -2804,12 +2627,12 @@
     "@contentful/f36-typography" "^4.60.0"
     emotion "^10.0.17"
 
-"@contentful/f36-tabs@^4.57.0", "@contentful/f36-tabs@^4.58.4":
-  version "4.58.4"
-  resolved "https://registry.yarnpkg.com/@contentful/f36-tabs/-/f36-tabs-4.58.4.tgz#31621a1666c64a475c31f4609300be55b4e2b85a"
-  integrity sha512-3W2M978BZIvUe6k+rmHrwMejoCSXGxISX0kjpt1EJBvb9lX6nF+5WvpmTK7gUPuWLwQIcV8Lio95Pn9sYb8GyA==
+"@contentful/f36-tabs@^4.57.0", "@contentful/f36-tabs@^4.59.3":
+  version "4.59.3"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-tabs/-/f36-tabs-4.59.3.tgz#42931ff78b4ff7742556694033ffec96897171fa"
+  integrity sha512-xhb1wN1eSJEPUSYIsqYocclU0CW5/mqEdCEPHhClTBPkwl2ItdggdcdWURN8ZE9vRmH6D/vcundJtgrzTpXYXA==
   dependencies:
-    "@contentful/f36-core" "^4.58.4"
+    "@contentful/f36-core" "^4.59.3"
     "@contentful/f36-tokens" "^4.0.4"
     "@radix-ui/react-tabs" "^1.0.1"
     emotion "^10.0.17"
@@ -2824,12 +2647,12 @@
     "@radix-ui/react-tabs" "^1.0.1"
     emotion "^10.0.17"
 
-"@contentful/f36-text-link@^4.57.0", "@contentful/f36-text-link@^4.58.4":
-  version "4.58.4"
-  resolved "https://registry.yarnpkg.com/@contentful/f36-text-link/-/f36-text-link-4.58.4.tgz#753c6095186c1edef7f7a54c59526ec415f61519"
-  integrity sha512-PSrJ4qA+VSbZh2Rdo2Dm5nprONX+pXOixIjbmnglGLK9LUauWIrj4p86U92XZ7NY82XAdyOoaK0N/hJb+sdcTg==
+"@contentful/f36-text-link@^4.57.0", "@contentful/f36-text-link@^4.59.3":
+  version "4.59.3"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-text-link/-/f36-text-link-4.59.3.tgz#e467a7249cc7b504f65df9b9acee13d8edb3d035"
+  integrity sha512-b/JioG8JbdUHR5SJSy2b2HlklbI25yQl6Ls3eA7zlSCPrgE5pBBprlUXU0SW3dFb/MoQErbPjcVcOPq6zIt1ZA==
   dependencies:
-    "@contentful/f36-core" "^4.58.4"
+    "@contentful/f36-core" "^4.59.3"
     "@contentful/f36-tokens" "^4.0.4"
     emotion "^10.0.17"
 
@@ -2852,12 +2675,12 @@
   resolved "https://registry.yarnpkg.com/@contentful/f36-tokens/-/f36-tokens-4.0.4.tgz#1f2f3722fadfc232808e8a9151589527e8188ed9"
   integrity sha512-yPHNQjHVEuO+5nUoX3EbrQvLoU7ZjNc/w3RyCmYR3F/NWZCy/3n0Knhq5Jfow+CcXkVY6Ch526VlA3+ayEN2kA==
 
-"@contentful/f36-tooltip@^4.57.0", "@contentful/f36-tooltip@^4.58.4":
-  version "4.58.4"
-  resolved "https://registry.yarnpkg.com/@contentful/f36-tooltip/-/f36-tooltip-4.58.4.tgz#e9fefc1cdcf866deec688b9d8d54f8da5e7b4017"
-  integrity sha512-VuNFYBSbrUK4N1qvgqATdHanWqmPXw1RZOvZEYyHu5UCZMHMaKYARhtTU6zdKesTHilU3+rFOCNE8ZE0368Ugg==
+"@contentful/f36-tooltip@^4.57.0", "@contentful/f36-tooltip@^4.59.3":
+  version "4.59.3"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-tooltip/-/f36-tooltip-4.59.3.tgz#0ee58969d756429464754b0d5a82db23a5168431"
+  integrity sha512-PdWLh8Ch9p5Btz0by55WnkKNgjzVw0Cr9Sp0j4i0ejlgKbnICMjXmIPWQ/4FQ4/YgqOcromye2sVMKrteTYFnw==
   dependencies:
-    "@contentful/f36-core" "^4.58.4"
+    "@contentful/f36-core" "^4.59.3"
     "@contentful/f36-tokens" "^4.0.4"
     "@contentful/f36-utils" "^4.24.3"
     "@popperjs/core" "^2.11.5"
@@ -2878,12 +2701,12 @@
     emotion "^10.0.17"
     react-popper "^2.3.0"
 
-"@contentful/f36-typography@^4.57.0", "@contentful/f36-typography@^4.58.4":
-  version "4.58.4"
-  resolved "https://registry.yarnpkg.com/@contentful/f36-typography/-/f36-typography-4.58.4.tgz#67068f0ec85474143ac04cfa61e87970ca862058"
-  integrity sha512-d292/4NuLKqsFNWrP0GOQxxjszhSZKIPViHtkAvQOggOVDYBPy7MQ4vbNrtOMJNNZmbEYcHhSi+GaoUWmgCIAQ==
+"@contentful/f36-typography@^4.57.0", "@contentful/f36-typography@^4.59.3":
+  version "4.59.3"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-typography/-/f36-typography-4.59.3.tgz#b5edfd0511d631272ceb8545d1808a7787e60470"
+  integrity sha512-BNspYw9THmOv+EbXc7SIwtrKnQFdUXvv6aaKmq5GOYRcikjraVIYRn+DW8uS1qpipfWkDxYFJRWAP+uW3NrPQQ==
   dependencies:
-    "@contentful/f36-core" "^4.58.4"
+    "@contentful/f36-core" "^4.59.3"
     "@contentful/f36-tokens" "^4.0.4"
     "@contentful/f36-utils" "^4.24.3"
     emotion "^10.0.17"
@@ -3085,9 +2908,9 @@
     lodash "^4.17.20"
 
 "@contentful/mimetype@^2.2.29":
-  version "2.2.29"
-  resolved "https://registry.yarnpkg.com/@contentful/mimetype/-/mimetype-2.2.29.tgz#717b1d11d3bc94cf4a146cd07f623682f34279b0"
-  integrity sha512-ktfQegKPoBrOTMdnfQPQIGc/CWFnEBdBT0bZJITptGALIh9O2XW/kyvuYgHCyI0kZJFvAmduXnO7Zn2mhA9XyQ==
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@contentful/mimetype/-/mimetype-2.3.0.tgz#90ba9f280940f422f58cbfb839a9abd81280d200"
+  integrity sha512-6FFVVs7ziQDo0wH7/Dkrj1oELIbwIdgIDhDFDdgj75tWknr3buIxJgWhj0wt9ffvomE3KketIqI1b/KTRIClqQ==
   dependencies:
     lodash "^4.17.20"
 
@@ -3099,20 +2922,20 @@
     "@contentful/rich-text-types" "^15.15.1"
 
 "@contentful/rich-text-plain-text-renderer@^16.0.4":
-  version "16.0.7"
-  resolved "https://registry.yarnpkg.com/@contentful/rich-text-plain-text-renderer/-/rich-text-plain-text-renderer-16.0.7.tgz#2bac73d725420d7d6aae7490041bb7e45c666660"
-  integrity sha512-ryFZP3Q279kG5xfL5XmdxFv2peoivGdVq+ZglOlGPfSmpV/fXlrEW9eg/zY7vRJpLQt/XOpf2dQo4giecKPhCA==
+  version "16.0.11"
+  resolved "https://registry.yarnpkg.com/@contentful/rich-text-plain-text-renderer/-/rich-text-plain-text-renderer-16.0.11.tgz#f39a127497b63a4edcbdc48502f58dfcab970bba"
+  integrity sha512-TlAgcJaddoKtqLJigd8hULch1hWJWTeh9q3hKtUQCWXG6aoOm/9creGYz/TYECU3nhKj+dUzCUwGlmyz1bbUmA==
   dependencies:
-    "@contentful/rich-text-types" "^16.3.0"
+    "@contentful/rich-text-types" "^16.3.4"
 
 "@contentful/rich-text-react-renderer@^15.16.4":
-  version "15.19.0"
-  resolved "https://registry.yarnpkg.com/@contentful/rich-text-react-renderer/-/rich-text-react-renderer-15.19.0.tgz#9aa9f485170354cea6bbef5d63e0118b84f58c96"
-  integrity sha512-2lFDmoWocUXNxk+yvHNSUIgdhm7FCyE57KjYxuTnoC8R2nPVY+mC0I2c0aTOcP4CX/2QqZe/FAoospjU6nk1uw==
+  version "15.19.4"
+  resolved "https://registry.yarnpkg.com/@contentful/rich-text-react-renderer/-/rich-text-react-renderer-15.19.4.tgz#129a4040e9ac3115a0936dcc36a8d6868e504f85"
+  integrity sha512-pXBX0utaXLdkloQautphPi6cMWSDU99NwM8oLWwExyNhOzKB2DN0resnp/ZmXj728He7aYXX48VA1nVTRqS77g==
   dependencies:
-    "@contentful/rich-text-types" "^16.3.0"
+    "@contentful/rich-text-types" "^16.3.4"
 
-"@contentful/rich-text-types@16.3.0", "@contentful/rich-text-types@^15.12.1", "@contentful/rich-text-types@^15.15.1", "@contentful/rich-text-types@^16.0.2", "@contentful/rich-text-types@^16.3.0":
+"@contentful/rich-text-types@16.3.0", "@contentful/rich-text-types@^15.12.1", "@contentful/rich-text-types@^15.15.1", "@contentful/rich-text-types@^16.0.2", "@contentful/rich-text-types@^16.3.0", "@contentful/rich-text-types@^16.3.4":
   version "16.3.0"
   resolved "https://registry.yarnpkg.com/@contentful/rich-text-types/-/rich-text-types-16.3.0.tgz#d44145a43b32d61eb4d6a82d3001cdfddbbda42e"
   integrity sha512-OfQmAu5bxE0CgQA3WlUleVej+ifFG/iXmB2DmUl4EyWyFue1aiIvfjxQhcDRSH4n1jUNMJ6L1wInZL8uV5m3TQ==
@@ -4342,9 +4165,9 @@
   integrity sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==
 
 "@jridgewell/trace-mapping@^0.3.12", "@jridgewell/trace-mapping@^0.3.17", "@jridgewell/trace-mapping@^0.3.18", "@jridgewell/trace-mapping@^0.3.20", "@jridgewell/trace-mapping@^0.3.9":
-  version "0.3.21"
-  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.21.tgz#5dc1df7b3dc4a6209e503a924e1ca56097a2bb15"
-  integrity sha512-SRfKmRe1KvYnxjEMtxEr+J4HIeMX5YBg/qhRHpxEIGjhX1rshcHlnFUE9K0GazhVKWM7B+nARSkV8LuvJdJ5/g==
+  version "0.3.22"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.22.tgz#72a621e5de59f5f1ef792d0793a82ee20f645e4c"
+  integrity sha512-Wf963MzWtA2sjrNt+g18IAln9lKnlRp+K2eH4jjIoF1wYeq3aMREpG09xhlhdzS0EjwU7qmUJYangWa+151vZw==
   dependencies:
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
@@ -4482,9 +4305,9 @@
     "@lezer/lr" "^1.0.0"
 
 "@lezer/lr@^1.0.0":
-  version "1.3.14"
-  resolved "https://registry.yarnpkg.com/@lezer/lr/-/lr-1.3.14.tgz#59d4a3b25698bdac0ef182fa6eadab445fc4f29a"
-  integrity sha512-z5mY4LStlA3yL7aHT/rqgG614cfcvklS+8oFRFBYrs4YaWLJyKKM4+nN6KopToX0o9Hj6zmH6M5kinOYuy06ug==
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@lezer/lr/-/lr-1.4.0.tgz#ed52a75dbbfbb0d1eb63710ea84c35ee647cb67e"
+  integrity sha512-Wst46p51km8gH0ZUmeNrtpRYmdlRHUpN1DQd3GFAyKANi8WVz8c2jHYTf1CVScFaCjQw1iO3ZZdqGDxQPRErTg==
   dependencies:
     "@lezer/common" "^1.0.0"
 
@@ -5362,9 +5185,9 @@
     picomatch "^2.2.2"
 
 "@rushstack/eslint-patch@^1.1.0":
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/@rushstack/eslint-patch/-/eslint-patch-1.7.0.tgz#b5bc1e081428794f6a4d239707b359404be35ce2"
-  integrity sha512-Jh4t/593gxs0lJZ/z3NnasKlplXT2f+4y/LZYuaKZW5KAaiVFL/fThhs+17EbUd53jUVJ0QudYCBGbN/psvaqg==
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/@rushstack/eslint-patch/-/eslint-patch-1.7.2.tgz#2d4260033e199b3032a08b41348ac10de21c47e9"
+  integrity sha512-RbhOOTCNoCrbfkRyoXODZp75MlpiHMgbE5MEBZAnnnLyQNgrigEj4p0lzsMDyc1zVsJDLrivB58tgg3emX0eEA==
 
 "@samverschueren/stream-to-observable@^0.3.0":
   version "0.3.1"
@@ -5385,10 +5208,10 @@
     import-from "^3.0.0"
     lodash "^4.17.4"
 
-"@sideway/address@^4.1.4":
-  version "4.1.4"
-  resolved "https://registry.yarnpkg.com/@sideway/address/-/address-4.1.4.tgz#03dccebc6ea47fdc226f7d3d1ad512955d4783f0"
-  integrity sha512-7vwq+rOHVWjyXxVlR76Agnvhy8I9rpzjosTESvmhNeXOXdZZB15Fl+TI9x1SiHZH5Jv2wTGduSxFDIaq0m3DUw==
+"@sideway/address@^4.1.5":
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/@sideway/address/-/address-4.1.5.tgz#4bc149a0076623ced99ca8208ba780d65a99b9d5"
+  integrity sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==
   dependencies:
     "@hapi/hoek" "^9.0.0"
 
@@ -5459,9 +5282,9 @@
     type-detect "4.0.8"
 
 "@sinonjs/commons@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-3.0.0.tgz#beb434fe875d965265e04722ccfc21df7f755d72"
-  integrity sha512-jXBtWAF4vmdNmZgD5FoKsVLv3rPgDnLgPbU84LIJ3otV44vJlDRokVng5v8NFJdCf/da9legHcKaRuZs4L7faA==
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-3.0.1.tgz#1029357e44ca901a615585f6d27738dbc89084cd"
+  integrity sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==
   dependencies:
     type-detect "4.0.8"
 
@@ -5643,15 +5466,15 @@
     ts-dedent "^2.0.0"
     util-deprecate "^1.0.2"
 
-"@storybook/builder-manager@7.6.15":
-  version "7.6.15"
-  resolved "https://registry.yarnpkg.com/@storybook/builder-manager/-/builder-manager-7.6.15.tgz#32e40e03ba1cd4d7755ac2072d2d3472accedff0"
-  integrity sha512-vfpfCywiasyP7vtbgLJhjssBEwUjZhBsRsubDAzumgOochPiKKPNwsSc5NU/4ZIGaC5zRO26kUaUqFIbJdTEUQ==
+"@storybook/builder-manager@7.6.14":
+  version "7.6.14"
+  resolved "https://registry.yarnpkg.com/@storybook/builder-manager/-/builder-manager-7.6.14.tgz#fd1f0ca3862e0060c1e9e1fd78fa243ef10b182b"
+  integrity sha512-pID/g2Bnr3tjmkh8c+O6TZei3f1TWHW/UWi/skNQ3wGJ+9dqJIK2vQY5SwnXBWkmJdUqGVXaW5BvzR8jjfpTxQ==
   dependencies:
     "@fal-works/esbuild-plugin-global-externals" "^2.1.2"
-    "@storybook/core-common" "7.6.15"
-    "@storybook/manager" "7.6.15"
-    "@storybook/node-logger" "7.6.15"
+    "@storybook/core-common" "7.6.14"
+    "@storybook/manager" "7.6.14"
+    "@storybook/node-logger" "7.6.14"
     "@types/ejs" "^3.1.1"
     "@types/find-cache-dir" "^3.2.1"
     "@yarnpkg/esbuild-plugin-pnp" "^3.0.0-rc.10"
@@ -5721,35 +5544,23 @@
     telejson "^7.2.0"
     tiny-invariant "^1.3.1"
 
-"@storybook/channels@7.6.15":
-  version "7.6.15"
-  resolved "https://registry.yarnpkg.com/@storybook/channels/-/channels-7.6.15.tgz#12e57275643fd2af790fe2903dc247a348ddc472"
-  integrity sha512-UPDYRzGkygYFa8QUpEiumWrvZm4u4RKVzgiBt9C4RmHORqkkZzL9LXhaZJp2SmIz1ND5gx6KR5ze8ZnAdwxxoQ==
-  dependencies:
-    "@storybook/client-logger" "7.6.15"
-    "@storybook/core-events" "7.6.15"
-    "@storybook/global" "^5.0.0"
-    qs "^6.10.0"
-    telejson "^7.2.0"
-    tiny-invariant "^1.3.1"
-
-"@storybook/cli@7.6.15":
-  version "7.6.15"
-  resolved "https://registry.yarnpkg.com/@storybook/cli/-/cli-7.6.15.tgz#003516e816cf057c2d4f3780b24771db953f6ccf"
-  integrity sha512-2QRqCyVGDSkraHxX2JPYkkFccbu5Uo+JYFaFJo4vmMXzDurjWON+Ga2B8FCTd4A8P4C02Ca/79jgQoyBB3xoew==
+"@storybook/cli@7.6.14":
+  version "7.6.14"
+  resolved "https://registry.yarnpkg.com/@storybook/cli/-/cli-7.6.14.tgz#fda38360cf728b4d90e633cbca031daed542c5e8"
+  integrity sha512-2xqcGRPtj/OE+9ro92C5MFCT8VHdMCDDuZZRnmgPi83iqSZtYbO8xHZwz78j4TvmouHstOV1SedeWv0IsFIxLw==
   dependencies:
     "@babel/core" "^7.23.2"
     "@babel/preset-env" "^7.23.2"
     "@babel/types" "^7.23.0"
     "@ndelangen/get-tarball" "^3.0.7"
-    "@storybook/codemod" "7.6.15"
-    "@storybook/core-common" "7.6.15"
-    "@storybook/core-events" "7.6.15"
-    "@storybook/core-server" "7.6.15"
-    "@storybook/csf-tools" "7.6.15"
-    "@storybook/node-logger" "7.6.15"
-    "@storybook/telemetry" "7.6.15"
-    "@storybook/types" "7.6.15"
+    "@storybook/codemod" "7.6.14"
+    "@storybook/core-common" "7.6.14"
+    "@storybook/core-events" "7.6.14"
+    "@storybook/core-server" "7.6.14"
+    "@storybook/csf-tools" "7.6.14"
+    "@storybook/node-logger" "7.6.14"
+    "@storybook/telemetry" "7.6.14"
+    "@storybook/types" "7.6.14"
     "@types/semver" "^7.3.4"
     "@yarnpkg/fslib" "2.10.3"
     "@yarnpkg/libzip" "2.3.0"
@@ -5786,25 +5597,18 @@
   dependencies:
     "@storybook/global" "^5.0.0"
 
-"@storybook/client-logger@7.6.15":
-  version "7.6.15"
-  resolved "https://registry.yarnpkg.com/@storybook/client-logger/-/client-logger-7.6.15.tgz#fc75c91376202801f55696b8949f266c44c76578"
-  integrity sha512-n+K8IqnombqiQNnywVovS+lK61tvv/XSfgPt0cgvoF/hJZB0VDOMRjWsV+v9qQpj1TQEl1lLWeJwZMthTWupJA==
-  dependencies:
-    "@storybook/global" "^5.0.0"
-
-"@storybook/codemod@7.6.15":
-  version "7.6.15"
-  resolved "https://registry.yarnpkg.com/@storybook/codemod/-/codemod-7.6.15.tgz#dc749a31660ef5f211016198b1576f35e89647d0"
-  integrity sha512-NiEbTLCdacj6TMxC7G49IImXeMzkG8wpPr8Ayxm9HeG6q5UkiF5/DiZdqbJm2zaosOsOKWwvXg1t6Pq6Nivytg==
+"@storybook/codemod@7.6.14":
+  version "7.6.14"
+  resolved "https://registry.yarnpkg.com/@storybook/codemod/-/codemod-7.6.14.tgz#86dd6595deb0b4aebaa0ef9e153dba4445c68c7a"
+  integrity sha512-Sq/Q12KmvzaSUtmbtD26cEEGVmZLUA+iiNHbl0n65MMka6QBGG/VgSPvSgu+GEpKowbVoqfMpH4Ic16A6XsNFg==
   dependencies:
     "@babel/core" "^7.23.2"
     "@babel/preset-env" "^7.23.2"
     "@babel/types" "^7.23.0"
     "@storybook/csf" "^0.1.2"
-    "@storybook/csf-tools" "7.6.15"
-    "@storybook/node-logger" "7.6.15"
-    "@storybook/types" "7.6.15"
+    "@storybook/csf-tools" "7.6.14"
+    "@storybook/node-logger" "7.6.14"
+    "@storybook/types" "7.6.14"
     "@types/cross-spawn" "^6.0.2"
     cross-spawn "^7.0.3"
     globby "^11.0.2"
@@ -5866,35 +5670,6 @@
     resolve-from "^5.0.0"
     ts-dedent "^2.0.0"
 
-"@storybook/core-common@7.6.15":
-  version "7.6.15"
-  resolved "https://registry.yarnpkg.com/@storybook/core-common/-/core-common-7.6.15.tgz#8ba894b91c514c9dd03b20f963118c7233e4a78f"
-  integrity sha512-VGmcLJ5U1r1s8/YnLbKcyB4GnNL+/sZIPqwlcSKzDXO76HoVFv1kywf7PbASote7P3gdhLSxBdg95LH2bdIbmw==
-  dependencies:
-    "@storybook/core-events" "7.6.15"
-    "@storybook/node-logger" "7.6.15"
-    "@storybook/types" "7.6.15"
-    "@types/find-cache-dir" "^3.2.1"
-    "@types/node" "^18.0.0"
-    "@types/node-fetch" "^2.6.4"
-    "@types/pretty-hrtime" "^1.0.0"
-    chalk "^4.1.0"
-    esbuild "^0.18.0"
-    esbuild-register "^3.5.0"
-    file-system-cache "2.3.0"
-    find-cache-dir "^3.0.0"
-    find-up "^5.0.0"
-    fs-extra "^11.1.0"
-    glob "^10.0.0"
-    handlebars "^4.7.7"
-    lazy-universal-dotenv "^4.0.0"
-    node-fetch "^2.0.0"
-    picomatch "^2.3.0"
-    pkg-dir "^5.0.0"
-    pretty-hrtime "^1.0.3"
-    resolve-from "^5.0.0"
-    ts-dedent "^2.0.0"
-
 "@storybook/core-events@7.6.14":
   version "7.6.14"
   resolved "https://registry.yarnpkg.com/@storybook/core-events/-/core-events-7.6.14.tgz#4ba595ea6df1bd760e8ed5c9ec8a39a722e09339"
@@ -5902,33 +5677,26 @@
   dependencies:
     ts-dedent "^2.0.0"
 
-"@storybook/core-events@7.6.15":
-  version "7.6.15"
-  resolved "https://registry.yarnpkg.com/@storybook/core-events/-/core-events-7.6.15.tgz#8c9b78a4b09099548bace869d689ad92d237d229"
-  integrity sha512-i4YnjGecbpGyrFe0340sPhQ9QjZZEBqvMy6kF4XWt6DYLHxZmsTj1HEdvxVl4Ej7V49Vw0Dm8MepJ1d4Y8MKrQ==
-  dependencies:
-    ts-dedent "^2.0.0"
-
-"@storybook/core-server@7.6.15":
-  version "7.6.15"
-  resolved "https://registry.yarnpkg.com/@storybook/core-server/-/core-server-7.6.15.tgz#d7529ba79e8f880869ed09ab1c73f1c91fe6a70b"
-  integrity sha512-iIlxEAkrmKTSA3iGNqt/4QG7hf5suxBGYIB3DZAOfBo8EdZogMYaEmuCm5dbuaJr0mcVwlqwdhQiWb1VsR/NhA==
+"@storybook/core-server@7.6.14":
+  version "7.6.14"
+  resolved "https://registry.yarnpkg.com/@storybook/core-server/-/core-server-7.6.14.tgz#87e80529354a7c757176aa184d5a1e2688651c15"
+  integrity sha512-OSUunvjXyUiyfGet8ZBz7/Lka6dSgbbVMH7lU6wELIYCd2ZUxU5HQMl9JPesl61wWB4L3JaWFAoMRaCVI7q0xQ==
   dependencies:
     "@aw-web-design/x-default-browser" "1.4.126"
     "@discoveryjs/json-ext" "^0.5.3"
-    "@storybook/builder-manager" "7.6.15"
-    "@storybook/channels" "7.6.15"
-    "@storybook/core-common" "7.6.15"
-    "@storybook/core-events" "7.6.15"
+    "@storybook/builder-manager" "7.6.14"
+    "@storybook/channels" "7.6.14"
+    "@storybook/core-common" "7.6.14"
+    "@storybook/core-events" "7.6.14"
     "@storybook/csf" "^0.1.2"
-    "@storybook/csf-tools" "7.6.15"
+    "@storybook/csf-tools" "7.6.14"
     "@storybook/docs-mdx" "^0.1.0"
     "@storybook/global" "^5.0.0"
-    "@storybook/manager" "7.6.15"
-    "@storybook/node-logger" "7.6.15"
-    "@storybook/preview-api" "7.6.15"
-    "@storybook/telemetry" "7.6.15"
-    "@storybook/types" "7.6.15"
+    "@storybook/manager" "7.6.14"
+    "@storybook/node-logger" "7.6.14"
+    "@storybook/preview-api" "7.6.14"
+    "@storybook/telemetry" "7.6.14"
+    "@storybook/types" "7.6.14"
     "@types/detect-port" "^1.3.0"
     "@types/node" "^18.0.0"
     "@types/pretty-hrtime" "^1.0.0"
@@ -5990,21 +5758,6 @@
     recast "^0.23.1"
     ts-dedent "^2.0.0"
 
-"@storybook/csf-tools@7.6.15":
-  version "7.6.15"
-  resolved "https://registry.yarnpkg.com/@storybook/csf-tools/-/csf-tools-7.6.15.tgz#aee2a6ec77f708246d3567310e1ffe79cfefe59e"
-  integrity sha512-8iKgg2cmbFTpVhRRJOqouhPcEh0c8ywabG4S8ICZvnJooSXUI9mD9p3tYCS7MYuSiHj0epa1Kkn9DtXJRo9o6g==
-  dependencies:
-    "@babel/generator" "^7.23.0"
-    "@babel/parser" "^7.23.0"
-    "@babel/traverse" "^7.23.2"
-    "@babel/types" "^7.23.0"
-    "@storybook/csf" "^0.1.2"
-    "@storybook/types" "7.6.15"
-    fs-extra "^11.1.0"
-    recast "^0.23.1"
-    ts-dedent "^2.0.0"
-
 "@storybook/csf@^0.0.1":
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/@storybook/csf/-/csf-0.0.1.tgz#95901507dc02f0bc6f9ac8ee1983e2fc5bb98ce6"
@@ -6062,10 +5815,10 @@
     telejson "^7.2.0"
     ts-dedent "^2.0.0"
 
-"@storybook/manager@7.6.15":
-  version "7.6.15"
-  resolved "https://registry.yarnpkg.com/@storybook/manager/-/manager-7.6.15.tgz#2894be039b93b3dfdb75fc568f9def06e19d0b79"
-  integrity sha512-GGV2ElV5AOIApy/FSDzoSlLUbyd2VhQVD3TdNGRxNauYRjEO8ulXHw2tNbT6ludtpYpDTAILzI6zT/iag8hmPQ==
+"@storybook/manager@7.6.14":
+  version "7.6.14"
+  resolved "https://registry.yarnpkg.com/@storybook/manager/-/manager-7.6.14.tgz#589933b68766f79235a73788a7dfa2042f9a3576"
+  integrity sha512-lgowunC/pm2y6d+3j7UJ/CkHpWC0o+nZ9b7mDbkJ6PmezW5Hpy83kbeCxbwRGosYoPQ0izBzVB5ZqGgKrNNDjA==
 
 "@storybook/mdx2-csf@^1.0.0":
   version "1.1.0"
@@ -6076,11 +5829,6 @@
   version "7.6.14"
   resolved "https://registry.yarnpkg.com/@storybook/node-logger/-/node-logger-7.6.14.tgz#3ab4094a68e606733363fd1692590673b1d83fa2"
   integrity sha512-prKUMGxGzeX3epdlin1UU6M1//CoAJM1GrffrFeNntnPr3h6GMTgxNzl85flUhWd4ky/wjC/36dGOI8QRYVtoA==
-
-"@storybook/node-logger@7.6.15":
-  version "7.6.15"
-  resolved "https://registry.yarnpkg.com/@storybook/node-logger/-/node-logger-7.6.15.tgz#df14693e10ca82c9580bba68363d062215f74655"
-  integrity sha512-C+sCvRjR+5uVU3VTrfyv7/RlPBxesAjIucUAK0keGyIZ7sFQYCPdkm4m/C4s+TcubgAzVvuoUHlRrSppdA7WzQ==
 
 "@storybook/postinstall@7.6.14":
   version "7.6.14"
@@ -6121,26 +5869,6 @@
     "@storybook/csf" "^0.1.2"
     "@storybook/global" "^5.0.0"
     "@storybook/types" "7.6.14"
-    "@types/qs" "^6.9.5"
-    dequal "^2.0.2"
-    lodash "^4.17.21"
-    memoizerific "^1.11.3"
-    qs "^6.10.0"
-    synchronous-promise "^2.0.15"
-    ts-dedent "^2.0.0"
-    util-deprecate "^1.0.2"
-
-"@storybook/preview-api@7.6.15":
-  version "7.6.15"
-  resolved "https://registry.yarnpkg.com/@storybook/preview-api/-/preview-api-7.6.15.tgz#d0b099b324eeeeaef714a01f81dd8b1d5b8f31f7"
-  integrity sha512-2KN9vlizF6sFlYsJEGnFqcQaJXs4TTdawC1VazVdtaMSHANDxxDu8F1cP+u7lpPH3DkNZUmTGQDBYfYY9xR0eQ==
-  dependencies:
-    "@storybook/channels" "7.6.15"
-    "@storybook/client-logger" "7.6.15"
-    "@storybook/core-events" "7.6.15"
-    "@storybook/csf" "^0.1.2"
-    "@storybook/global" "^5.0.0"
-    "@storybook/types" "7.6.15"
     "@types/qs" "^6.9.5"
     dequal "^2.0.2"
     lodash "^4.17.21"
@@ -6219,14 +5947,14 @@
     memoizerific "^1.11.3"
     qs "^6.10.0"
 
-"@storybook/telemetry@7.6.15":
-  version "7.6.15"
-  resolved "https://registry.yarnpkg.com/@storybook/telemetry/-/telemetry-7.6.15.tgz#648e40b108b835c6c25c61a28e92e3fb6d87e561"
-  integrity sha512-klhKXLUS3OXozGEtMbbhKZLDfm+m3nNk2jvGwD6kkBenzFUzb0P2m8awxU7h1pBcKZKH/27U9t3KVzNFzWoWPw==
+"@storybook/telemetry@7.6.14":
+  version "7.6.14"
+  resolved "https://registry.yarnpkg.com/@storybook/telemetry/-/telemetry-7.6.14.tgz#a12a97c6bff49444433ebae8891321b12090d6d1"
+  integrity sha512-F+a9Q4dHCpuBLQmB05DOLosU8p1Otj3Vd+/5EF9QUFSn4C64z1gmMc3jzF3iUgktY53HdoUqR871w3GoOJ7g9A==
   dependencies:
-    "@storybook/client-logger" "7.6.15"
-    "@storybook/core-common" "7.6.15"
-    "@storybook/csf-tools" "7.6.15"
+    "@storybook/client-logger" "7.6.14"
+    "@storybook/core-common" "7.6.14"
+    "@storybook/csf-tools" "7.6.14"
     chalk "^4.1.0"
     detect-package-manager "^2.0.1"
     fetch-retry "^5.0.2"
@@ -6249,16 +5977,6 @@
   integrity sha512-sJ3qn45M2XLXlOi+wkhXK5xsXbSVzi8YGrusux//DttI3s8wCP3BQSnEgZkBiEktloxPferINHT1er8/9UK7Xw==
   dependencies:
     "@storybook/channels" "7.6.14"
-    "@types/babel__core" "^7.0.0"
-    "@types/express" "^4.7.0"
-    file-system-cache "2.3.0"
-
-"@storybook/types@7.6.15":
-  version "7.6.15"
-  resolved "https://registry.yarnpkg.com/@storybook/types/-/types-7.6.15.tgz#80411ea62bb56a0bc28ce5ece6f577957f3d049f"
-  integrity sha512-tLH0lK6SXECSfMpKin9bge+7XiHZII17n6jc9ZI1TfSBZJyq3M6VzWh2r1C2lC97FlkcKXjIwM3n8h1xNjnI+A==
-  dependencies:
-    "@storybook/channels" "7.6.15"
     "@types/babel__core" "^7.0.0"
     "@types/express" "^4.7.0"
     file-system-cache "2.3.0"
@@ -6534,12 +6252,7 @@
     "@swc/core-win32-ia32-msvc" "1.4.1"
     "@swc/core-win32-x64-msvc" "1.4.1"
 
-"@swc/counter@^0.1.1":
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/@swc/counter/-/counter-0.1.2.tgz#bf06d0770e47c6f1102270b744e17b934586985e"
-  integrity sha512-9F4ys4C74eSTEUNndnER3VJ15oru2NumfQxS8geE+f3eB5xvfxpWyqE5XlVnxb/R14uoXi6SLbBwwiDSkv+XEw==
-
-"@swc/counter@^0.1.2", "@swc/counter@^0.1.3":
+"@swc/counter@^0.1.1", "@swc/counter@^0.1.2", "@swc/counter@^0.1.3":
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/@swc/counter/-/counter-0.1.3.tgz#cc7463bd02949611c6329596fccd2b0ec782b0e9"
   integrity sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==
@@ -6915,7 +6628,7 @@
     "@types/estree" "*"
     "@types/json-schema" "*"
 
-"@types/estree@*", "@types/estree@^1.0.0":
+"@types/estree@*", "@types/estree@^1.0.0", "@types/estree@^1.0.5":
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.5.tgz#a6ce3e556e00fd9895dd872dd172ad0d4bd687f4"
   integrity sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==
@@ -6931,9 +6644,9 @@
   integrity sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==
 
 "@types/express-serve-static-core@*", "@types/express-serve-static-core@^4.17.33":
-  version "4.17.41"
-  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.41.tgz#5077defa630c2e8d28aa9ffc2c01c157c305bef6"
-  integrity sha512-OaJ7XLaelTgrvlZD8/aa0vvvxZdUmlCn6MtWeB7TkiKW70BQLc9XEPpDLPdbo52ZhXUCrznlWdCHWxJWtdyajA==
+  version "4.17.43"
+  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.43.tgz#10d8444be560cb789c4735aea5eac6e5af45df54"
+  integrity sha512-oaYtiBirUOPQGSWNGPWnzyAFJ0BP3cwvN4oWZQY+zUBwpVIGsKUkpBpSztp74drYcjavs7SKFZ4DX1V2QeN8rg==
   dependencies:
     "@types/node" "*"
     "@types/qs" "*"
@@ -6978,16 +6691,16 @@
     "@types/node" "*"
 
 "@types/hast@^2.0.0":
-  version "2.3.9"
-  resolved "https://registry.yarnpkg.com/@types/hast/-/hast-2.3.9.tgz#a9a1b5bbce46e8a1312e977364bacabc8e93d2cf"
-  integrity sha512-pTHyNlaMD/oKJmS+ZZUyFUcsZeBZpC0lmGquw98CqRVNgAdJZJeD7GoeLiT6Xbx5rU9VCjSt0RwEvDgzh4obFw==
+  version "2.3.10"
+  resolved "https://registry.yarnpkg.com/@types/hast/-/hast-2.3.10.tgz#5c9d9e0b304bbb8879b857225c5ebab2d81d7643"
+  integrity sha512-McWspRw8xx8J9HurkVBfYj0xKoE25tOFlHGdx4MJ5xORQrMGZNqJhVQWaIbm6Oyla5kYOXtDiopzKRJzEOkwJw==
   dependencies:
     "@types/unist" "^2"
 
 "@types/hast@^3.0.0":
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/@types/hast/-/hast-3.0.3.tgz#7f75e6b43bc3f90316046a287d9ad3888309f7e1"
-  integrity sha512-2fYGlaDy/qyLlhidX42wAH0KBi2TCjKMH8CHmBXgRlJ3Y+OXTiqsPQ6IWarZKwF1JoUcAJdPogv1d4b0COTpmQ==
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/@types/hast/-/hast-3.0.4.tgz#1d6b39993b82cea6ad783945b0508c25903e15aa"
+  integrity sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==
   dependencies:
     "@types/unist" "*"
 
@@ -7048,9 +6761,9 @@
     "@types/istanbul-lib-report" "*"
 
 "@types/jest@*":
-  version "29.5.11"
-  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-29.5.11.tgz#0c13aa0da7d0929f078ab080ae5d4ced80fa2f2c"
-  integrity sha512-S2mHmYIVe13vrm6q4kN6fLYYAka15ALQki/vgDC3mIukEOx8WJlv0kQPM+d4w8Gp6u0uSdKND04IlTXBv0rwnQ==
+  version "29.5.12"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-29.5.12.tgz#7f7dc6eb4cf246d2474ed78744b05d06ce025544"
+  integrity sha512-eDC8bTvT/QhYdxJAulQikueigY5AsdBRH2yDKW3yveW7svY3+DzN84/2NUgkw10RTiJbWqZrTtoGVdYlvFJdLw==
   dependencies:
     expect "^29.0.0"
     pretty-format "^29.0.0"
@@ -7129,9 +6842,9 @@
     "@types/unist" "*"
 
 "@types/mdx@^2.0.0":
-  version "2.0.10"
-  resolved "https://registry.yarnpkg.com/@types/mdx/-/mdx-2.0.10.tgz#0d7b57fb1d83e27656156e4ee0dfba96532930e4"
-  integrity sha512-Rllzc5KHk0Al5/WANwgSPl1/CwjqCy+AZrGd78zuK+jO9aDM6ffblZ+zIjgPNAaEBmlO0RYDvLNh7wD0zKVgEg==
+  version "2.0.11"
+  resolved "https://registry.yarnpkg.com/@types/mdx/-/mdx-2.0.11.tgz#21f4c166ed0e0a3a733869ba04cd8daea9834b8e"
+  integrity sha512-HM5bwOaIQJIQbAYfax35HCKxx7a3KrK3nBtIqJgSOitivTD1y3oW9P3rxY9RkXYPUk7y/AjAohfHKmFpGE79zw==
 
 "@types/mime-types@^2.1.0":
   version "2.1.4"
@@ -7184,23 +6897,16 @@
     "@types/node" "*"
 
 "@types/node@*", "@types/node@^20.0.0", "@types/node@^20.6.5":
-  version "20.11.5"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.11.5.tgz#be10c622ca7fcaa3cf226cf80166abc31389d86e"
-  integrity sha512-g557vgQjUUfN76MZAN/dt1z3dzcUsimuysco0KeluHgrPdJXkP/XdAURgyO2W9fZWHRtRBiVKzKn8vyOAwlG+w==
+  version "20.11.17"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.11.17.tgz#cdd642d0e62ef3a861f88ddbc2b61e32578a9292"
+  integrity sha512-QmgQZGWu1Yw9TDyAP9ZzpFJKynYNeOvwMJmaxABfieQoVoiVOS6MN1WSpqpRcbeA5+RW82kraAVxCCJg+780Qw==
   dependencies:
     undici-types "~5.26.4"
 
-"@types/node@^18.0.0":
+"@types/node@^18.0.0", "@types/node@^18.17.5":
   version "18.19.15"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.19.15.tgz#313a9d75435669a57fc28dc8694e7f4c4319f419"
   integrity sha512-AMZ2UWx+woHNfM11PyAEQmfSxi05jm9OlkxczuHeEqmvwPkYj6MWv44gbzDPefYOLysTOFyI3ziiy2ONmUZfpA==
-  dependencies:
-    undici-types "~5.26.4"
-
-"@types/node@^18.17.5":
-  version "18.19.8"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.19.8.tgz#c1e42b165e5a526caf1f010747e0522cb2c9c36a"
-  integrity sha512-g1pZtPhsvGVTwmeVoexWZLTQaOvXwoSq//pTL0DHeNzUDrFnir4fgETdhjhIxjVnN+hKOuh98+E1eMLnUXstFg==
   dependencies:
     undici-types "~5.26.4"
 
@@ -7270,9 +6976,9 @@
     "@types/react" "*"
 
 "@types/react-dom@>=16.9.0":
-  version "18.2.18"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.2.18.tgz#16946e6cd43971256d874bc3d0a72074bb8571dd"
-  integrity sha512-TJxDm6OfAX2KJWJdMEVTwWke5Sc/E/RlnPGvGfS0W7+6ocy2xhDVQVh/KvC2Uf7kACs+gDytdusDSdWfWkaNzw==
+  version "18.2.19"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.2.19.tgz#b84b7c30c635a6c26c6a6dfbb599b2da9788be58"
+  integrity sha512-aZvQL6uUbIJpjZk4U8JZGbau9KDeAwMfmhyWorxgBkqDIEf6ROjRozcmPIicqsUwPUjbkDfHKgGee1Lq65APcA==
   dependencies:
     "@types/react" "*"
 
@@ -7343,9 +7049,9 @@
   integrity sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==
 
 "@types/semver@^7.3.12", "@types/semver@^7.3.4", "@types/semver@^7.5.0":
-  version "7.5.6"
-  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.5.6.tgz#c65b2bfce1bec346582c07724e3f8c1017a20339"
-  integrity sha512-dn1l8LaMea/IjDoHNd9J52uBbInB796CDffS6VdIxvqYCPSG0V0DzHp76GpaWnlhg88uYyPbXCDIowa86ybd5A==
+  version "7.5.7"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.5.7.tgz#326f5fdda70d13580777bcaa1bc6fa772a5aef0e"
+  integrity sha512-/wdoPq1QqkSj9/QOeKkFquEuPzQbHTWAMPH/PaUMB+JuR31lXhlWXRZ52IpfDYVlDOUBvX09uBrPwxGT1hjNBg==
 
 "@types/send@*":
   version "0.17.4"
@@ -9080,13 +8786,13 @@ arr-union@^3.1.0:
   resolved "https://registry.yarnpkg.com/arr-union/-/arr-union-3.1.0.tgz#e39b09aea9def866a8f206e288af63919bae39c4"
   integrity sha512-sKpyeERZ02v1FeCZT8lrfJq5u6goHCtpTAzPwJYe7c8SPFOboNjNg1vz2L4VTn9T4PQxEx13TbXLmYUcS6Ug7Q==
 
-array-buffer-byte-length@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/array-buffer-byte-length/-/array-buffer-byte-length-1.0.0.tgz#fabe8bc193fea865f317fe7807085ee0dee5aead"
-  integrity sha512-LPuwb2P+NrQw3XhxGc36+XSvuBPopovXYTR9Ew++Du9Yb/bx5AzBfrIsBoj0EZUifjQU+sHL21sseZ3jerWO/A==
+array-buffer-byte-length@^1.0.0, array-buffer-byte-length@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/array-buffer-byte-length/-/array-buffer-byte-length-1.0.1.tgz#1e5583ec16763540a27ae52eed99ff899223568f"
+  integrity sha512-ahC5W1xgou+KTXix4sAO8Ki12Q+jf4i0+tmk3sC+zgcynshkHxzpXdImBehiUYKKKDwvfFiJl1tZt6ewscS1Mg==
   dependencies:
-    call-bind "^1.0.2"
-    is-array-buffer "^3.0.1"
+    call-bind "^1.0.5"
+    is-array-buffer "^3.0.4"
 
 array-differ@^3.0.0:
   version "3.0.0"
@@ -9151,16 +8857,27 @@ array-unique@^0.3.2:
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.3.2.tgz#a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428"
   integrity sha512-SleRWjh9JUud2wH1hPs9rZBZ33H6T9HOiL0uwGnGx9FpE6wKGyfWugmbkEOIs6qWrZhg0LWeLziLrEwQJhs5mQ==
 
-array.prototype.findlastindex@^1.2.3:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.3.tgz#b37598438f97b579166940814e2c0493a4f50207"
-  integrity sha512-LzLoiOMAxvy+Gd3BAq3B7VeIgPdo+Q8hthvKtXybMvRV0jrXfJM/t8mw7nNlpEcVlVUnCnM2KSX4XU5HmpodOA==
+array.prototype.filter@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/array.prototype.filter/-/array.prototype.filter-1.0.3.tgz#423771edeb417ff5914111fff4277ea0624c0d0e"
+  integrity sha512-VizNcj/RGJiUyQBgzwxzE5oHdeuXY5hSbbmKMlphj1cy1Vl7Pn2asCGbSrru6hSQjmCzqTBPVWAF/whmEOVHbw==
   dependencies:
     call-bind "^1.0.2"
     define-properties "^1.2.0"
     es-abstract "^1.22.1"
-    es-shim-unscopables "^1.0.0"
-    get-intrinsic "^1.2.1"
+    es-array-method-boxes-properly "^1.0.0"
+    is-string "^1.0.7"
+
+array.prototype.findlastindex@^1.2.3:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.4.tgz#d1c50f0b3a9da191981ff8942a0aedd82794404f"
+  integrity sha512-hzvSHUshSpCflDR1QMUBLHGHP1VIEBegT4pix9H/Z92Xw3ySoy6c2qh7lJWTJnRJ8JCZ9bJNCgTyYaJGcJu6xQ==
+  dependencies:
+    call-bind "^1.0.5"
+    define-properties "^1.2.1"
+    es-abstract "^1.22.3"
+    es-errors "^1.3.0"
+    es-shim-unscopables "^1.0.2"
 
 array.prototype.flat@^1.3.1, array.prototype.flat@^1.3.2:
   version "1.3.2"
@@ -9205,27 +8922,28 @@ array.prototype.reduce@^1.0.6:
     is-string "^1.0.7"
 
 array.prototype.tosorted@^1.1.1:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/array.prototype.tosorted/-/array.prototype.tosorted-1.1.2.tgz#620eff7442503d66c799d95503f82b475745cefd"
-  integrity sha512-HuQCHOlk1Weat5jzStICBCd83NxiIMwqDg/dHEsoefabn/hJRj5pVdWcPUSpRrwhwxZOsQassMpgN/xRYFBMIg==
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/array.prototype.tosorted/-/array.prototype.tosorted-1.1.3.tgz#c8c89348337e51b8a3c48a9227f9ce93ceedcba8"
+  integrity sha512-/DdH4TiTmOKzyQbp/eadcCVexiCb36xJg7HshYOYJnNZFDj33GEv0P7GxsynpShhq4OLYJzbGcBDkLsDt7MnNg==
   dependencies:
-    call-bind "^1.0.2"
-    define-properties "^1.2.0"
-    es-abstract "^1.22.1"
-    es-shim-unscopables "^1.0.0"
-    get-intrinsic "^1.2.1"
+    call-bind "^1.0.5"
+    define-properties "^1.2.1"
+    es-abstract "^1.22.3"
+    es-errors "^1.1.0"
+    es-shim-unscopables "^1.0.2"
 
 arraybuffer.prototype.slice@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.2.tgz#98bd561953e3e74bb34938e77647179dfe6e9f12"
-  integrity sha512-yMBKppFur/fbHu9/6USUe03bZ4knMYiwFBcyiaXB8Go0qNehwX6inYPzK9U0NeQvGxKthcmHcaR8P5MStSRBAw==
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.3.tgz#097972f4255e41bc3425e37dc3f6421cf9aefde6"
+  integrity sha512-bMxMKAjg13EBSVscxTaYA4mRc5t1UAXa2kXiGTNfZ079HIWXEkKmkgFrh/nJqamaLSrXO5H4WFFkPEaLJWbs3A==
   dependencies:
-    array-buffer-byte-length "^1.0.0"
-    call-bind "^1.0.2"
-    define-properties "^1.2.0"
-    es-abstract "^1.22.1"
-    get-intrinsic "^1.2.1"
-    is-array-buffer "^3.0.2"
+    array-buffer-byte-length "^1.0.1"
+    call-bind "^1.0.5"
+    define-properties "^1.2.1"
+    es-abstract "^1.22.3"
+    es-errors "^1.2.1"
+    get-intrinsic "^1.2.3"
+    is-array-buffer "^3.0.4"
     is-shared-array-buffer "^1.0.2"
 
 arrify@^1.0.1:
@@ -9408,10 +9126,10 @@ autoprefixer@^9.6.1:
     postcss "^7.0.32"
     postcss-value-parser "^4.1.0"
 
-available-typed-arrays@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz#92f95616501069d07d10edb2fc37d3e1c65123b7"
-  integrity sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==
+available-typed-arrays@^1.0.5, available-typed-arrays@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.6.tgz#ac812d8ce5a6b976d738e1c45f08d0b00bc7d725"
+  integrity sha512-j1QzY8iPNPG4o4xmO3ptzpRxTciqD3MgEHtifP/YnJpIo58Xu+ne4BejlbkuaLfXn/nz6HFiw29bLpj2PNMdGg==
 
 aws-sign2@~0.7.0:
   version "0.7.0"
@@ -9450,9 +9168,9 @@ axios@^0.26.0:
     follow-redirects "^1.14.8"
 
 axios@^1.0.0, axios@^1.4.0, axios@^1.6.0, axios@^1.6.1, axios@^1.6.2:
-  version "1.6.5"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.6.5.tgz#2c090da14aeeab3770ad30c3a1461bc970fb0cd8"
-  integrity sha512-Ii012v05KEVuUoFWmMW/UQv9aRIc3ZwkWDcM+h5Il8izZCtRVpDUfwpoFf7eOtajT3QiGR4yDUx7lPqHJULgbg==
+  version "1.6.7"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.6.7.tgz#7b48c2e27c96f9c68a2f8f31e2ab19f59b06b0a7"
+  integrity sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==
   dependencies:
     follow-redirects "^1.15.4"
     form-data "^4.0.0"
@@ -9635,7 +9353,7 @@ babel-plugin-named-asset-import@^0.3.7, babel-plugin-named-asset-import@^0.3.8:
   resolved "https://registry.yarnpkg.com/babel-plugin-named-asset-import/-/babel-plugin-named-asset-import-0.3.8.tgz#6b7fa43c59229685368683c28bc9734f24524cc2"
   integrity sha512-WXiAc++qo7XcJ1ZnTYGtLxmBCVbddAml3CEXgWaBzNzLNoxtQ8AiGEFDMOhot9XjTCQbvP5E77Fj9Gk924f00Q==
 
-babel-plugin-polyfill-corejs2@^0.4.7, babel-plugin-polyfill-corejs2@^0.4.8:
+babel-plugin-polyfill-corejs2@^0.4.8:
   version "0.4.8"
   resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.8.tgz#dbcc3c8ca758a290d47c3c6a490d59429b0d2269"
   integrity sha512-OtIuQfafSzpo/LhnJaykc0R/MMnuLSSVjVYy9mHArIZ9qTCSZ6TpWCuEKZYVoN//t8HqBNScHrOtCrIK5IaGLg==
@@ -9643,14 +9361,6 @@ babel-plugin-polyfill-corejs2@^0.4.7, babel-plugin-polyfill-corejs2@^0.4.8:
     "@babel/compat-data" "^7.22.6"
     "@babel/helper-define-polyfill-provider" "^0.5.0"
     semver "^6.3.1"
-
-babel-plugin-polyfill-corejs3@^0.8.7:
-  version "0.8.7"
-  resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.8.7.tgz#941855aa7fdaac06ed24c730a93450d2b2b76d04"
-  integrity sha512-KyDvZYxAzkC0Aj2dAPyDzi2Ym15e5JKZSK+maI7NAwSqofvuFglbSsxE7wUOvTg9oFVnHMzVzBKcqEb4PJgtOA==
-  dependencies:
-    "@babel/helper-define-polyfill-provider" "^0.4.4"
-    core-js-compat "^3.33.1"
 
 babel-plugin-polyfill-corejs3@^0.9.0:
   version "0.9.0"
@@ -9660,7 +9370,7 @@ babel-plugin-polyfill-corejs3@^0.9.0:
     "@babel/helper-define-polyfill-provider" "^0.5.0"
     core-js-compat "^3.34.0"
 
-babel-plugin-polyfill-regenerator@^0.5.4, babel-plugin-polyfill-regenerator@^0.5.5:
+babel-plugin-polyfill-regenerator@^0.5.5:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.5.5.tgz#8b0c8fc6434239e5d7b8a9d1f832bb2b0310f06a"
   integrity sha512-OJGYZlhLqBh2DDHeqAxWB1XIvr49CxiJ2gIt61/PU55CQK4Z58OzMqjDe1zwQdQk+rBYsRc+1rJmdajM3gimHg==
@@ -10150,17 +9860,7 @@ browserslist@4.14.2:
     escalade "^3.0.2"
     node-releases "^1.1.61"
 
-browserslist@^4.0.0, browserslist@^4.12.0, browserslist@^4.14.5, browserslist@^4.18.1, browserslist@^4.21.4, browserslist@^4.22.2, browserslist@^4.6.2, browserslist@^4.6.4, browserslist@^4.9.1:
-  version "4.22.2"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.22.2.tgz#704c4943072bd81ea18997f3bd2180e89c77874b"
-  integrity sha512-0UgcrvQmBDvZHFGdYUehrCNIazki7/lUP3kkoi/r3YB2amZbFM9J43ZRkJTXBUZK4gmx56+Sqk9+Vs9mwZx9+A==
-  dependencies:
-    caniuse-lite "^1.0.30001565"
-    electron-to-chromium "^1.4.601"
-    node-releases "^2.0.14"
-    update-browserslist-db "^1.0.13"
-
-browserslist@^4.22.3:
+browserslist@^4.0.0, browserslist@^4.12.0, browserslist@^4.14.5, browserslist@^4.18.1, browserslist@^4.21.10, browserslist@^4.21.4, browserslist@^4.22.2, browserslist@^4.6.2, browserslist@^4.6.4, browserslist@^4.9.1:
   version "4.22.3"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.22.3.tgz#299d11b7e947a6b843981392721169e27d60c5a6"
   integrity sha512-UAp55yfwNv0klWNapjs/ktHoguxuQNGnOzxYmfnXIS+8AsRDZkSDxg7R1AX3GKzn078SBI5dzwzj/Yx0Or0e3A==
@@ -10394,14 +10094,16 @@ cachedir@^2.3.0:
   resolved "https://registry.yarnpkg.com/cachedir/-/cachedir-2.4.0.tgz#7fef9cf7367233d7c88068fe6e34ed0d355a610d"
   integrity sha512-9EtFOZR8g22CL7BWjJ9BUx1+A/djkofnyW3aOXZORNW2kxoUpx2h+uN2cOqwPmFhnpVmxg+KW2OjOSgChTEvsQ==
 
-call-bind@^1.0.0, call-bind@^1.0.2, call-bind@^1.0.4, call-bind@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.5.tgz#6fa2b7845ce0ea49bf4d8b9ef64727a2c2e2e513"
-  integrity sha512-C3nQxfFZxFRVoJoGKKI8y3MOEo129NQ+FgQ08iye+Mk4zNZZGdjfs06bVTr+DBSlA66Q2VEcMki/cUCP4SercQ==
+call-bind@^1.0.0, call-bind@^1.0.2, call-bind@^1.0.5, call-bind@^1.0.6:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.7.tgz#06016599c40c56498c18769d2730be242b6fa3b9"
+  integrity sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==
   dependencies:
+    es-define-property "^1.0.0"
+    es-errors "^1.3.0"
     function-bind "^1.1.2"
-    get-intrinsic "^1.2.1"
-    set-function-length "^1.1.1"
+    get-intrinsic "^1.2.4"
+    set-function-length "^1.2.1"
 
 caller-callsite@^2.0.0:
   version "2.0.0"
@@ -10495,12 +10197,7 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001125, caniuse-lite@^1.0.30001565, caniuse-lite@^1.0.30001578:
-  version "1.0.30001579"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001579.tgz#45c065216110f46d6274311a4b3fcf6278e0852a"
-  integrity sha512-u5AUVkixruKHJjw/pj9wISlcMpgFWzSrczLZbrqBSxukQixmg0SJ5sZTpvaFvxU0HoQKd4yoyAogyrAz9pzJnA==
-
-caniuse-lite@^1.0.30001580:
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001125, caniuse-lite@^1.0.30001578, caniuse-lite@^1.0.30001580:
   version "1.0.30001587"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001587.tgz#a0bce920155fa56a1885a69c74e1163fc34b4881"
   integrity sha512-HMFNotUmLXn71BQxg8cijvqxnIAofforZOwGsxyXJ0qugTdspUF4sPSJ2vhgprHCB996tIDzEq1ubumPDV8ULA==
@@ -10694,9 +10391,9 @@ chokidar@^2.1.8:
     fsevents "^1.2.7"
 
 chokidar@^3.0.0, chokidar@^3.4.1, chokidar@^3.4.2, chokidar@^3.5.3:
-  version "3.5.3"
-  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.3.tgz#1cf37c8707b932bd1af1ae22c0432e2acd1903bd"
-  integrity sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.6.0.tgz#197c6cc669ef2a8dc5e7b4d97ee4e092c3eb0d5b"
+  integrity sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==
   dependencies:
     anymatch "~3.1.2"
     braces "~3.0.2"
@@ -11381,9 +11078,9 @@ contentful-cli@1.3.29:
     zlib "^1.0.5"
 
 contentful-export@^7.8.16:
-  version "7.19.113"
-  resolved "https://registry.yarnpkg.com/contentful-export/-/contentful-export-7.19.113.tgz#1af253aa28bed8ce5ef2daebff1ccdd5ae30abb1"
-  integrity sha512-X0HVOkMZoZYc+7Oh2MVJGlRMqDcyn0Bg3rZpBmDnnm3sdW6z9UoEBX/HRitbBc1JRb2b9Q9k++svPed45p4mRw==
+  version "7.19.121"
+  resolved "https://registry.yarnpkg.com/contentful-export/-/contentful-export-7.19.121.tgz#6f3438d8df2b9444b6ac5194cd8a087c02c389ee"
+  integrity sha512-a+qO1r7xALMGDxvQM2g48lOmukPepbarpr6NOC3Q0nd66dBuS1jdhxFmlzw3NA/s10+GFVYpQaQBuVHRUa00Lg==
   dependencies:
     bfj "^8.0.0"
     bluebird "^3.3.3"
@@ -11434,9 +11131,9 @@ contentful-management@^10.0.0:
     type-fest "^4.0.0"
 
 "contentful-management@^10.0.0 || ^11.0.0", "contentful-management@^10.14.0 || ^11.0.0", contentful-management@^11.0.1:
-  version "11.12.1"
-  resolved "https://registry.yarnpkg.com/contentful-management/-/contentful-management-11.12.1.tgz#34eb0e9f2e5da8e16165152c57c36388c28de940"
-  integrity sha512-1xxBoz31DAuGCEZN9/e7MKrrxitFXxD067xYNtBJ3lvwhhsdb9mVJ+QKNHR5Ys+ZfYOlLq6dDnRBf15KeUXggA==
+  version "11.15.0"
+  resolved "https://registry.yarnpkg.com/contentful-management/-/contentful-management-11.15.0.tgz#403024816e211484819d1e5f441a98e0879f1f12"
+  integrity sha512-u5it8laHTRJY+WQVHOSBGhzcb1ucgHg9MU12EMf+w088jcONdZcgyNq75cQWdmaQv8tl3/T8YrDNuCTLSz4H1g==
   dependencies:
     "@contentful/rich-text-types" "^16.3.0"
     "@types/json-patch" "0.0.30"
@@ -11541,9 +11238,9 @@ contentful-sdk-core@^8.1.0:
     qs "^6.11.2"
 
 contentful@^10.6.9:
-  version "10.6.16"
-  resolved "https://registry.yarnpkg.com/contentful/-/contentful-10.6.16.tgz#c238bf54bbed7a4300e2781ca48ced6a0d7ba4bc"
-  integrity sha512-3PF4VQAWOhy7CiGYm4KtQn9AN81p77BgSCDQNndFfWdggs6/b2wMWXkmN1UGSJI7OKBRpbiy12mNrr7SrvuVIA==
+  version "10.6.21"
+  resolved "https://registry.yarnpkg.com/contentful/-/contentful-10.6.21.tgz#7e2a8cae91f5f06297df27053538e937490035a7"
+  integrity sha512-ez3zNJ1A2dJTuoNxSkFhwjkhrQ/jYYTvc8jFeFIMwZuYMHjYwL+mFo1372pSASeJ6QAIf2srKOmukzCGiHtcSg==
   dependencies:
     "@contentful/rich-text-types" "^16.0.2"
     axios "^1.6.0"
@@ -11722,21 +11419,7 @@ copy-to-clipboard@^3.3.1:
   dependencies:
     toggle-selection "^1.0.6"
 
-core-js-compat@^3.31.0, core-js-compat@^3.33.1:
-  version "3.35.0"
-  resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.35.0.tgz#c149a3d1ab51e743bc1da61e39cb51f461a41873"
-  integrity sha512-5blwFAddknKeNgsjBzilkdQ0+YK8L1PfqPYq40NOYMYFSS38qj+hpTcLLWwpIwA2A5bje/x5jmVn2tzUMg9IVw==
-  dependencies:
-    browserslist "^4.22.2"
-
-core-js-compat@^3.34.0:
-  version "3.36.0"
-  resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.36.0.tgz#087679119bc2fdbdefad0d45d8e5d307d45ba190"
-  integrity sha512-iV9Pd/PsgjNWBXeq8XRtWVSgz2tKAfhfvBs7qxYty+RlRd+OCksaWmOnc4JKrTc1cToXL1N0s3l/vwlxPtdElw==
-  dependencies:
-    browserslist "^4.22.3"
-
-core-js-compat@^3.6.2:
+core-js-compat@^3.31.0, core-js-compat@^3.34.0, core-js-compat@^3.6.2:
   version "3.35.1"
   resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.35.1.tgz#215247d7edb9e830efa4218ff719beb2803555e2"
   integrity sha512-sftHa5qUJY3rs9Zht1WEnmkvXputCyDBczPnr7QDgL8n3qrF3CMXY4VPSYtOLLiOUJcah2WNXREd48iOl6mQIw==
@@ -11744,9 +11427,9 @@ core-js-compat@^3.6.2:
     browserslist "^4.22.2"
 
 core-js-pure@^3.23.3, core-js-pure@^3.30.2:
-  version "3.35.0"
-  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.35.0.tgz#4660033304a050215ae82e476bd2513a419fbb34"
-  integrity sha512-f+eRYmkou59uh7BPcyJ8MC76DiGhspj1KMxVIcF24tzP8NA9HVa1uC7BTW2tgx7E1QVCzDzsgp7kArrzhlz8Ew==
+  version "3.35.1"
+  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.35.1.tgz#f33ad7fdf9dddae260339a30e5f8363f5c49a3bc"
+  integrity sha512-zcIdi/CL3MWbBJYo5YCeVAAx+Sy9yJE9I3/u9LkFABwbeaPhTMRWraM8mYFp9jW5Z50hOy7FVzCc8dCrpZqtIQ==
 
 core-js@^2.4.0:
   version "2.6.12"
@@ -11754,9 +11437,9 @@ core-js@^2.4.0:
   integrity sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==
 
 core-js@^3.19.2, core-js@^3.6.5:
-  version "3.35.0"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.35.0.tgz#58e651688484f83c34196ca13f099574ee53d6b4"
-  integrity sha512-ntakECeqg81KqMueeGJ79Q5ZgQNR+6eaE8sxGCx62zMbAIj65q+uYvatToew3m6eAGdU4gNZwpZ34NMe4GYswg==
+  version "3.35.1"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.35.1.tgz#9c28f8b7ccee482796f8590cc8d15739eaaf980c"
+  integrity sha512-IgdsbxNyMskrTFxa9lWHyMwAJU5gXOPP+1yO+K59d50VLVAIDAbs7gIv705KzALModfK3ZrSZTPNpC0PQgIZuw==
 
 core-util-is@1.0.2:
   version "1.0.2"
@@ -12016,15 +11699,15 @@ css-loader@4.3.0:
     semver "^7.3.2"
 
 css-loader@^6.5.1, css-loader@^6.7.1:
-  version "6.9.0"
-  resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-6.9.0.tgz#0cc2f14df94ed97c526c5ae42b6b13916d1d8d0e"
-  integrity sha512-3I5Nu4ytWlHvOP6zItjiHlefBNtrH+oehq8tnQa2kO305qpVyx9XNIT1CXIj5bgCJs7qICBCkgCYxQLKPANoLA==
+  version "6.10.0"
+  resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-6.10.0.tgz#7c172b270ec7b833951b52c348861206b184a4b7"
+  integrity sha512-LTSA/jWbwdMlk+rhmElbDR2vbtQoTBPr7fkJE+mxrHj+7ru0hUmHafDRzWIjIHTwpitWVaqY2/UWGRca3yUgRw==
   dependencies:
     icss-utils "^5.1.0"
-    postcss "^8.4.31"
+    postcss "^8.4.33"
     postcss-modules-extract-imports "^3.0.0"
-    postcss-modules-local-by-default "^4.0.3"
-    postcss-modules-scope "^3.1.0"
+    postcss-modules-local-by-default "^4.0.4"
+    postcss-modules-scope "^3.1.1"
     postcss-modules-values "^4.0.0"
     postcss-value-parser "^4.2.0"
     semver "^7.5.4"
@@ -12321,9 +12004,9 @@ cypress-plugin-tab@1.0.5:
     ally.js "^1.4.1"
 
 cypress@*:
-  version "13.6.3"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-13.6.3.tgz#54f03ca07ee56b2bc18211e7bd32abd2533982ba"
-  integrity sha512-d/pZvgwjAyZsoyJ3FOsJT5lDsqnxQ/clMqnNc++rkHjbkkiF2h9s0JsZSyyH4QXhVFW3zPFg82jD25roFLOdZA==
+  version "13.6.4"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-13.6.4.tgz#42c88d3ee0342f1681abfacabf9c1f082676bc53"
+  integrity sha512-pYJjCfDYB+hoOoZuhysbbYhEmNW7DEDsqn+ToCLwuVowxUXppIWRr7qk4TVRIU471ksfzyZcH+mkoF0CQUKnpw==
   dependencies:
     "@cypress/request" "^3.0.0"
     "@cypress/xvfb" "^1.2.4"
@@ -12735,14 +12418,15 @@ defer-to-connect@^2.0.0:
   resolved "https://registry.yarnpkg.com/defer-to-connect/-/defer-to-connect-2.0.1.tgz#8016bdb4143e4632b77a3449c6236277de520587"
   integrity sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==
 
-define-data-property@^1.0.1, define-data-property@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/define-data-property/-/define-data-property-1.1.1.tgz#c35f7cd0ab09883480d12ac5cb213715587800b3"
-  integrity sha512-E7uGkTzkk1d0ByLeSc6ZsFS79Axg+m1P/VsgYsxHgiuc3tFSj+MjMIwe90FC4lOAZzNBdY7kkO2P2wKdsQ1vgQ==
+define-data-property@^1.0.1, define-data-property@^1.1.2:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/define-data-property/-/define-data-property-1.1.3.tgz#281845e04737d709c2de99e278546189b65d3055"
+  integrity sha512-h3GBouC+RPtNX2N0hHVLo2ZwPYurq8mLmXpOLTsw71gr7lHt5VaI4vVkDUNOfiWmm48JEXe3VM7PmLX45AMmmg==
   dependencies:
-    get-intrinsic "^1.2.1"
+    es-errors "^1.3.0"
+    get-intrinsic "^1.2.4"
     gopd "^1.0.1"
-    has-property-descriptors "^1.0.0"
+    has-property-descriptors "^1.0.1"
 
 define-lazy-prop@^2.0.0:
   version "2.0.0"
@@ -12950,9 +12634,9 @@ diff@4.0.2:
   integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
 
 diff@^5.0.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/diff/-/diff-5.1.0.tgz#bc52d298c5ea8df9194800224445ed43ffc87e40"
-  integrity sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-5.2.0.tgz#26ded047cd1179b78b9537d5ef725503ce1ae531"
+  integrity sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==
 
 diffie-hellman@^5.0.0:
   version "5.0.3"
@@ -13173,9 +12857,9 @@ dotenv@^10.0.0, dotenv@~10.0.0:
   integrity sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==
 
 dotenv@^16.0.0:
-  version "16.3.1"
-  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.3.1.tgz#369034de7d7e5b120972693352a3bf112172cc3e"
-  integrity sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==
+  version "16.4.3"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.4.3.tgz#481235ec516c4e47d2612a478482ee36607f70c1"
+  integrity sha512-II98GFrje5psQTSve0E7bnwMFybNLqT8Vu8JIFWRjsE3khyNUm/loZupuy5DVzG2IXf/ysxvrixYOQnM6mjD3A==
 
 downshift@^6.1.12:
   version "6.1.12"
@@ -13258,15 +12942,10 @@ ejs@^3.1.6, ejs@^3.1.7, ejs@^3.1.8:
   dependencies:
     jake "^10.8.5"
 
-electron-to-chromium@^1.3.564, electron-to-chromium@^1.4.601:
-  version "1.4.637"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.637.tgz#ed8775cf5e0c380c3e8452e9818a0e4b7a671ac4"
-  integrity sha512-G7j3UCOukFtxVO1vWrPQUoDk3kL70mtvjc/DC/k2o7lE0wAdq+Vwp1ipagOow+BH0uVztFysLWbkM/RTIrbK3w==
-
-electron-to-chromium@^1.4.648:
-  version "1.4.668"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.668.tgz#5cfed14f3240cdc70a359a49790cb295b1f097f1"
-  integrity sha512-ZOBocMYCehr9W31+GpMclR+KBaDZOoAEabLdhpZ8oU1JFDwIaFY0UDbpXVEUFc0BIP2O2Qn3rkfCjQmMR4T/bQ==
+electron-to-chromium@^1.3.564, electron-to-chromium@^1.4.648:
+  version "1.4.667"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.667.tgz#2767d998548e5eeeaf8bdaffd67b56796bfbed3d"
+  integrity sha512-66L3pLlWhTNVUhnmSA5+qDM3fwnXsM6KAqE36e2w4KN0g6pkEtlT5bs41FQtQwVwKnfhNBXiWRLPs30HSxd7Kw==
 
 elegant-spinner@^1.0.1:
   version "1.0.1"
@@ -13430,9 +13109,9 @@ env-paths@^2.2.0:
   integrity sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==
 
 envinfo@^7.7.3, envinfo@^7.7.4:
-  version "7.11.0"
-  resolved "https://registry.yarnpkg.com/envinfo/-/envinfo-7.11.0.tgz#c3793f44284a55ff8c82faf1ffd91bc6478ea01f"
-  integrity sha512-G9/6xF1FPbIw0TtalAMaVPpiq2aDEuKLXM314jPVAO9r2fo2a4BLqMNkmRS7O/xPPZ+COAhGIz3ETvHEV3eUcg==
+  version "7.11.1"
+  resolved "https://registry.yarnpkg.com/envinfo/-/envinfo-7.11.1.tgz#2ffef77591057081b0129a8fd8cf6118da1b94e1"
+  integrity sha512-8PiZgZNIB4q/Lw4AhOvAfB/ityHAd2bli3lESSWmWSzSsl5dKpy5N1d1Rfkd2teq/g9xN90lc6o98DOjMeYHpg==
 
 err-code@^2.0.2:
   version "2.0.3"
@@ -13460,7 +13139,7 @@ error-stack-parser@^2.0.6:
   dependencies:
     stackframe "^1.3.4"
 
-es-abstract@^1.17.0-next.1, es-abstract@^1.17.2, es-abstract@^1.22.1:
+es-abstract@^1.17.0-next.1, es-abstract@^1.17.2, es-abstract@^1.22.1, es-abstract@^1.22.3:
   version "1.22.3"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.22.3.tgz#48e79f5573198de6dee3589195727f4f74bc4f32"
   integrity sha512-eiiY8HQeYfYH2Con2berK+To6GrK2RxbPawDkGq4UiCQQfZHb6wX9qQqkbpPqaxQFcl8d9QzZqo0tGE0VcrdwA==
@@ -13510,6 +13189,18 @@ es-array-method-boxes-properly@^1.0.0:
   resolved "https://registry.yarnpkg.com/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz#873f3e84418de4ee19c5be752990b2e44718d09e"
   integrity sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA==
 
+es-define-property@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/es-define-property/-/es-define-property-1.0.0.tgz#c7faefbdff8b2696cf5f46921edfb77cc4ba3845"
+  integrity sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==
+  dependencies:
+    get-intrinsic "^1.2.4"
+
+es-errors@^1.0.0, es-errors@^1.1.0, es-errors@^1.2.1, es-errors@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/es-errors/-/es-errors-1.3.0.tgz#05f75a25dab98e4fb1dcd5e1472c0546d5057c8f"
+  integrity sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==
+
 es-get-iterator@^1.0.2, es-get-iterator@^1.1.1, es-get-iterator@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/es-get-iterator/-/es-get-iterator-1.1.3.tgz#3ef87523c5d464d41084b2c3c9c214f1199763d6"
@@ -13526,31 +13217,32 @@ es-get-iterator@^1.0.2, es-get-iterator@^1.1.1, es-get-iterator@^1.1.3:
     stop-iteration-iterator "^1.0.0"
 
 es-iterator-helpers@^1.0.12, es-iterator-helpers@^1.0.15:
-  version "1.0.15"
-  resolved "https://registry.yarnpkg.com/es-iterator-helpers/-/es-iterator-helpers-1.0.15.tgz#bd81d275ac766431d19305923707c3efd9f1ae40"
-  integrity sha512-GhoY8uYqd6iwUl2kgjTm4CZAf6oo5mHK7BPqx3rKgx893YSsy0LGHV6gfqqQvZt/8xM8xeOnfXBCfqclMKkJ5g==
+  version "1.0.16"
+  resolved "https://registry.yarnpkg.com/es-iterator-helpers/-/es-iterator-helpers-1.0.16.tgz#495756d38dd5f9cc8e3091e913ee790d353e6f28"
+  integrity sha512-CREG2A9Vq7bpDRnldhFcMKuKArvkZtsH6Y0DHOHVg49qhf+LD8uEdUM3OkOAICv0EziGtDEnQtqY2/mfBILpFw==
   dependencies:
     asynciterator.prototype "^1.0.0"
-    call-bind "^1.0.2"
+    call-bind "^1.0.6"
     define-properties "^1.2.1"
-    es-abstract "^1.22.1"
-    es-set-tostringtag "^2.0.1"
-    function-bind "^1.1.1"
-    get-intrinsic "^1.2.1"
+    es-abstract "^1.22.3"
+    es-errors "^1.3.0"
+    es-set-tostringtag "^2.0.2"
+    function-bind "^1.1.2"
+    get-intrinsic "^1.2.4"
     globalthis "^1.0.3"
-    has-property-descriptors "^1.0.0"
+    has-property-descriptors "^1.0.1"
     has-proto "^1.0.1"
     has-symbols "^1.0.3"
-    internal-slot "^1.0.5"
+    internal-slot "^1.0.7"
     iterator.prototype "^1.1.2"
-    safe-array-concat "^1.0.1"
+    safe-array-concat "^1.1.0"
 
 es-module-lexer@^1.2.1, es-module-lexer@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-1.4.1.tgz#41ea21b43908fe6a287ffcbe4300f790555331f5"
   integrity sha512-cXLGjP0c4T3flZJKQSuziYoq7MlT+rnvfZjfp7h+I7K9BNX54kP9nyWvdbwjQ4u1iWbOL4u96fgeZLToQlZC7w==
 
-es-set-tostringtag@^2.0.1:
+es-set-tostringtag@^2.0.1, es-set-tostringtag@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/es-set-tostringtag/-/es-set-tostringtag-2.0.2.tgz#11f7cc9f63376930a5f20be4915834f4bc74f9c9"
   integrity sha512-BuDyupZt65P9D2D2vA/zqcI3G5xRsklm5N3xCwuiy+/vKy8i0ifdsQP1sLgO4tZDSCaQUSnmC48khknGMV3D2Q==
@@ -13559,7 +13251,7 @@ es-set-tostringtag@^2.0.1:
     has-tostringtag "^1.0.0"
     hasown "^2.0.0"
 
-es-shim-unscopables@^1.0.0:
+es-shim-unscopables@^1.0.0, es-shim-unscopables@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/es-shim-unscopables/-/es-shim-unscopables-1.0.2.tgz#1f6942e71ecc7835ed1c8a83006d8771a63a3763"
   integrity sha512-J3yBRXCzDu4ULnQwxyToo/OjdMx6akgVC7K6few0a7F/0wLtmKKN7I73AH5T2836UuXRqN7Qg+IIUw/+YJksRw==
@@ -13642,9 +13334,9 @@ esbuild@^0.18.0:
     "@esbuild/win32-x64" "0.18.20"
 
 escalade@^3.0.2, escalade@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40"
-  integrity sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.2.tgz#54076e9ab29ea5bf3d8f1ed62acffbb88272df27"
+  integrity sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==
 
 escape-html@~1.0.3:
   version "1.0.3"
@@ -14574,9 +14266,9 @@ fast-url-parser@1.1.3:
     punycode "^1.3.2"
 
 fastq@^1.6.0:
-  version "1.16.0"
-  resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.16.0.tgz#83b9a9375692db77a822df081edb6a9cf6839320"
-  integrity sha512-ifCoaXsDrsdkWTtiNJX5uzHDsrck5TzfKKDcuFFTIrrc/BS076qgEIfoIy1VeZqViznfKiysPYTh/QeHtnIsYA==
+  version "1.17.1"
+  resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.17.1.tgz#2a523f07a4e7b1e81a42b91b8bf2254107753b47"
+  integrity sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==
   dependencies:
     reusify "^1.0.4"
 
@@ -14877,9 +14569,9 @@ flatten@^1.0.2:
   integrity sha512-dVsPA/UwQ8+2uoFe5GHtiBMu48dWLTdsuEd7CKGlZlD78r1TTWBvDuFaFGKCo/ZfEr95Uk56vZoX86OsHkUeIg==
 
 flow-parser@0.*:
-  version "0.226.0"
-  resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.226.0.tgz#d552ab6762342e0e2b112fc937dd70b59e5e5d05"
-  integrity sha512-YlH+Y/P/5s0S7Vg14RwXlJMF/JsGfkG7gcKB/zljyoqaPNX9YVsGzx+g6MLTbhZaWbPhs4347aTpmSb9GgiPtw==
+  version "0.228.0"
+  resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.228.0.tgz#0b801507c8cf44257338596b49bd0904caea2026"
+  integrity sha512-xPWkzCO07AnS8X+fQFpWm+tJ+C7aeaiVzJ+rSepbkCXUvUJ6l6squEl63axoMcixyH4wLjmypOzq/+zTD0O93w==
 
 flush-write-stream@^1.0.0:
   version "1.1.1"
@@ -14889,10 +14581,10 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
 
-focus-lock@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/focus-lock/-/focus-lock-1.0.0.tgz#2c50d8ce59d3d6608cda2672be9e65812459206c"
-  integrity sha512-a8Ge6cdKh9za/GZR/qtigTAk7SrGore56EFcoMshClsh7FLk1zwszc/ltuMfKhx56qeuyL/jWQ4J4axou0iJ9w==
+focus-lock@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/focus-lock/-/focus-lock-1.1.0.tgz#74fe85dc1a15360cc1a694de8e686c691e0dd5ed"
+  integrity sha512-7j9OR+mxVmGcfxpCU7qKT09R32TX4jlic2/iWT5pm58SYWB1lbREpb7hEkrXxx9MzkenDBOAGatBEcMbJ143UQ==
   dependencies:
     tslib "^2.0.3"
 
@@ -15220,11 +14912,12 @@ get-caller-file@^2.0.1, get-caller-file@^2.0.5:
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
-get-intrinsic@^1.0.1, get-intrinsic@^1.0.2, get-intrinsic@^1.1.1, get-intrinsic@^1.1.3, get-intrinsic@^1.2.0, get-intrinsic@^1.2.1, get-intrinsic@^1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.2.2.tgz#281b7622971123e1ef4b3c90fd7539306da93f3b"
-  integrity sha512-0gSo4ml/0j98Y3lngkFEot/zhiCeWsbYIlZ+uZOVgzLyLaUw7wxUL+nCTP0XJvJg1AXulJRI3UJi8GsbDuxdGA==
+get-intrinsic@^1.0.1, get-intrinsic@^1.1.1, get-intrinsic@^1.1.3, get-intrinsic@^1.2.1, get-intrinsic@^1.2.2, get-intrinsic@^1.2.3, get-intrinsic@^1.2.4:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.2.4.tgz#e385f5a4b5227d449c3eabbad05494ef0abbeadd"
+  integrity sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==
   dependencies:
+    es-errors "^1.3.0"
     function-bind "^1.1.2"
     has-proto "^1.0.1"
     has-symbols "^1.0.3"
@@ -15305,12 +14998,13 @@ get-stream@^8.0.1:
   integrity sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==
 
 get-symbol-description@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/get-symbol-description/-/get-symbol-description-1.0.0.tgz#7fdb81c900101fbd564dd5f1a30af5aadc1e58d6"
-  integrity sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/get-symbol-description/-/get-symbol-description-1.0.2.tgz#533744d5aa20aca4e079c8e5daf7fd44202821f5"
+  integrity sha512-g0QYk1dZBxGwk+Ngc+ltRH2IBp2f7zBkBMBJZCDerh6EhlhSR6+9irMCuT/09zD6qkarHUSn529sK/yL4S27mg==
   dependencies:
-    call-bind "^1.0.2"
-    get-intrinsic "^1.1.1"
+    call-bind "^1.0.5"
+    es-errors "^1.3.0"
+    get-intrinsic "^1.2.4"
 
 get-value@^2.0.3, get-value@^2.0.6:
   version "2.0.6"
@@ -15736,11 +15430,11 @@ has-flag@^4.0.0:
   integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
 
 has-property-descriptors@^1.0.0, has-property-descriptors@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/has-property-descriptors/-/has-property-descriptors-1.0.1.tgz#52ba30b6c5ec87fd89fa574bc1c39125c6f65340"
-  integrity sha512-VsX8eaIewvas0xnvinAe9bw4WfIeODpGYikiWYLH+dma0Jw6KHYqWiWfhQlgOVK8D6PvjubK5Uc4P0iIhIcNVg==
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz#963ed7d071dc7bf5f084c5bfbe0d1b6222586854"
+  integrity sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==
   dependencies:
-    get-intrinsic "^1.2.2"
+    es-define-property "^1.0.0"
 
 has-proto@^1.0.1:
   version "1.0.1"
@@ -15752,12 +15446,12 @@ has-symbols@^1.0.0, has-symbols@^1.0.1, has-symbols@^1.0.2, has-symbols@^1.0.3:
   resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.3.tgz#bb7b2c4349251dce87b125f7bdf874aa7c8b39f8"
   integrity sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==
 
-has-tostringtag@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/has-tostringtag/-/has-tostringtag-1.0.0.tgz#7e133818a7d394734f941e73c3d3f9291e658b25"
-  integrity sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==
+has-tostringtag@^1.0.0, has-tostringtag@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/has-tostringtag/-/has-tostringtag-1.0.2.tgz#2cdc42d40bef2e5b4eeab7c01a73c54ce7ab5abc"
+  integrity sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==
   dependencies:
-    has-symbols "^1.0.2"
+    has-symbols "^1.0.3"
 
 has-unicode@2.0.1, has-unicode@^2.0.1:
   version "2.0.1"
@@ -15818,9 +15512,9 @@ hash.js@^1.0.0, hash.js@^1.0.3:
     minimalistic-assert "^1.0.1"
 
 hasown@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.0.tgz#f4c513d454a57b7c7e1650778de226b11700546c"
-  integrity sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.1.tgz#26f48f039de2c0f8d3356c223fb8d50253519faa"
+  integrity sha512-1/th4MHjnwncwXsIW6QMzlvYL9kG5e/CpVvLRZe4XPa8TOUNbCELqmvhDmnkNsAjwaG4+I8gJJL0JBvTTLO9qA==
   dependencies:
     function-bind "^1.1.2"
 
@@ -16214,9 +15908,9 @@ https-proxy-agent@^5.0.0, https-proxy-agent@^5.0.1:
     debug "4"
 
 https-proxy-agent@^7.0.2:
-  version "7.0.2"
-  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-7.0.2.tgz#e2645b846b90e96c6e6f347fb5b2e41f1590b09b"
-  integrity sha512-NmLNjm6ucYwtcUmL7JQC1ZQ57LmHP4lT15FQ8D61nak1rO6DH+fz5qNK2Ap5UN4ZapYICE3/0KodcLYSPsPbaA==
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-7.0.3.tgz#93f115f0f106a746faf364d1301b2e561cdf70de"
+  integrity sha512-kCnwztfX0KZJSLOBrcL0emLeFako55NWMovvyPP2AjsghNk9RB1yjSI+jVumPHYZsNXegNoqupSW9IY3afSH8w==
   dependencies:
     agent-base "^7.0.2"
     debug "4"
@@ -16316,9 +16010,9 @@ ignore@^4.0.6:
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
 
 ignore@^5.0.0, ignore@^5.0.4, ignore@^5.0.5, ignore@^5.1.4, ignore@^5.1.8, ignore@^5.2.0, ignore@^5.2.4:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.3.0.tgz#67418ae40d34d6999c95ff56016759c718c82f78"
-  integrity sha512-g7dmpshy+gD7mh88OC9NwSGTKoc3kyLAZQRU1mt53Aw/vnvfXnbC+F/7F7QoYVKbV+KNvJx8wArewKy1vXMtlg==
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.3.1.tgz#5073e554cd42c5b33b394375f538b8593e34d4ef"
+  integrity sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==
 
 immer@8.0.1:
   version "8.0.1"
@@ -16612,12 +16306,12 @@ internal-ip@^4.3.0:
     default-gateway "^4.2.0"
     ipaddr.js "^1.9.0"
 
-internal-slot@^1.0.4, internal-slot@^1.0.5:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/internal-slot/-/internal-slot-1.0.6.tgz#37e756098c4911c5e912b8edbf71ed3aa116f930"
-  integrity sha512-Xj6dv+PsbtwyPpEflsejS+oIZxmMlV44zAhG479uYu89MsjcYOhCFnNyKrkJrihbsiasQyY0afoCl/9BLR65bg==
+internal-slot@^1.0.4, internal-slot@^1.0.5, internal-slot@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/internal-slot/-/internal-slot-1.0.7.tgz#c06dcca3ed874249881007b0a5523b172a190802"
+  integrity sha512-NGnrKwXzSms2qUUih/ILZ5JBqNTSa1+ZmP6flaIp6KmSElgE9qdndzS3cqjrDovwFdmwsGsLdeFgB6suw+1e9g==
   dependencies:
-    get-intrinsic "^1.2.2"
+    es-errors "^1.3.0"
     hasown "^2.0.0"
     side-channel "^1.0.4"
 
@@ -16632,6 +16326,14 @@ invariant@^2.2.2, invariant@^2.2.4:
   integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
   dependencies:
     loose-envify "^1.0.0"
+
+ip-address@^9.0.5:
+  version "9.0.5"
+  resolved "https://registry.yarnpkg.com/ip-address/-/ip-address-9.0.5.tgz#117a960819b08780c3bd1f14ef3c1cc1d3f3ea5a"
+  integrity sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==
+  dependencies:
+    jsbn "1.1.0"
+    sprintf-js "^1.1.3"
 
 ip-regex@^2.1.0:
   version "2.1.0"
@@ -16688,14 +16390,13 @@ is-arguments@^1.0.4, is-arguments@^1.1.1:
     call-bind "^1.0.2"
     has-tostringtag "^1.0.0"
 
-is-array-buffer@^3.0.1, is-array-buffer@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/is-array-buffer/-/is-array-buffer-3.0.2.tgz#f2653ced8412081638ecb0ebbd0c41c6e0aecbbe"
-  integrity sha512-y+FyyR/w8vfIRq4eQcM1EYgSTnmHXPqaF+IgzgraytCFq5Xh8lllDVmAZolPJiZttZLeFSINPYMaEJ7/vWUa1w==
+is-array-buffer@^3.0.2, is-array-buffer@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/is-array-buffer/-/is-array-buffer-3.0.4.tgz#7a1f92b3d61edd2bc65d24f130530ea93d7fae98"
+  integrity sha512-wcjaerHw0ydZwfhiKbXJWLDY8A7yV7KhjQOpb83hGgGfId/aQa4TOvwyzn2PuswW2gPCYEL/nEAiSVpdOj1lXw==
   dependencies:
     call-bind "^1.0.2"
-    get-intrinsic "^1.2.0"
-    is-typed-array "^1.1.10"
+    get-intrinsic "^1.2.1"
 
 is-arrayish@^0.2.1:
   version "0.2.1"
@@ -17180,12 +16881,12 @@ is-text-path@^2.0.0:
   dependencies:
     text-extensions "^2.0.0"
 
-is-typed-array@^1.1.10, is-typed-array@^1.1.12, is-typed-array@^1.1.3, is-typed-array@^1.1.9:
-  version "1.1.12"
-  resolved "https://registry.yarnpkg.com/is-typed-array/-/is-typed-array-1.1.12.tgz#d0bab5686ef4a76f7a73097b95470ab199c57d4a"
-  integrity sha512-Z14TF2JNG8Lss5/HMqt0//T9JeHXttXy5pH/DBU4vi98ozO2btxzq9MwYDZYnKwU8nRsz/+GVFVRDq3DkVuSPg==
+is-typed-array@^1.1.10, is-typed-array@^1.1.12, is-typed-array@^1.1.13, is-typed-array@^1.1.3, is-typed-array@^1.1.9:
+  version "1.1.13"
+  resolved "https://registry.yarnpkg.com/is-typed-array/-/is-typed-array-1.1.13.tgz#d6c5ca56df62334959322d7d7dd1cca50debe229"
+  integrity sha512-uZ25/bUAlUY5fR4OKT4rZQEBrzQWYV9ZJYGGsUmEJ6thodVJ1HX64ePQ6Z0qPWP+m+Uq6e9UugrE38jeYsDSMw==
   dependencies:
-    which-typed-array "^1.1.11"
+    which-typed-array "^1.1.14"
 
 is-typedarray@^1.0.0, is-typedarray@~1.0.0:
   version "1.0.0"
@@ -18722,13 +18423,13 @@ joi@^13.4.0:
     topo "3.x.x"
 
 joi@^17.11.0:
-  version "17.12.0"
-  resolved "https://registry.yarnpkg.com/joi/-/joi-17.12.0.tgz#a3fb5715f198beb0471cd551dd26792089c308d5"
-  integrity sha512-HSLsmSmXz+PV9PYoi3p7cgIbj06WnEBNT28n+bbBNcPZXZFqCzzvGqpTBPujx/Z0nh1+KNQPDrNgdmQ8dq0qYw==
+  version "17.12.1"
+  resolved "https://registry.yarnpkg.com/joi/-/joi-17.12.1.tgz#3347ecf4cd3301962d42191c021b165eef1f395b"
+  integrity sha512-vtxmq+Lsc5SlfqotnfVjlViWfOL9nt/avKNbKYizwf6gsCfq9NYY/ceYRMFD8XDdrjJ9abJyScWmhmIiy+XRtQ==
   dependencies:
     "@hapi/hoek" "^9.3.0"
     "@hapi/topo" "^5.1.0"
-    "@sideway/address" "^4.1.4"
+    "@sideway/address" "^4.1.5"
     "@sideway/formula" "^3.0.1"
     "@sideway/pinpoint" "^2.0.0"
 
@@ -18774,6 +18475,11 @@ js-yaml@^3.10.0, js-yaml@^3.13.1:
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
+
+jsbn@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-1.1.0.tgz#b01307cb29b618a1ed26ec79e911f803c4da0040"
+  integrity sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==
 
 jsbn@~0.1.0:
   version "0.1.1"
@@ -18948,10 +18654,15 @@ json5@^2.0.0, json5@^2.1.2, json5@^2.2.0, json5@^2.2.2, json5@^2.2.3:
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
 
-jsonc-parser@3.2.0, jsonc-parser@^3.2.0:
+jsonc-parser@3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/jsonc-parser/-/jsonc-parser-3.2.0.tgz#31ff3f4c2b9793f89c67212627c51c6394f88e76"
   integrity sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==
+
+jsonc-parser@^3.2.0:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/jsonc-parser/-/jsonc-parser-3.2.1.tgz#031904571ccf929d7670ee8c547545081cb37f1a"
+  integrity sha512-AilxAyFOAcK5wA1+LeaySVBrHsGQvUFCDWXKpZjzaL0PqW+xfBOttn8GNtWKFWqneyMZj41MWF9Kl6iPWLwgOA==
 
 jsonfile@^4.0.0:
   version "4.0.0"
@@ -19453,9 +19164,9 @@ load-json-file@^4.0.0:
     strip-bom "^3.0.0"
 
 load-plugin@^6.0.0:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/load-plugin/-/load-plugin-6.0.1.tgz#ca30b33b40ec0e11c2f6b07d34cbcc78a70300dd"
-  integrity sha512-YZyxJaWfN4F1xfPCyKFNIOL26vlFukmJY7wegxsriav4y2/0ZiICota6uFvyy52GjUj+tsPSjGLX+2m7kiU0+g==
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/load-plugin/-/load-plugin-6.0.2.tgz#a3ec9e04fb6009cf97f226e4695bc0f7037a9280"
+  integrity sha512-3KRkTvCOsyNrx4zvBl/+ZMqPdVyp26TIf6xkmfEGuGwCfNQ/HzhktwbJCxd1KJpzPbK42t/WVOL3cX+TDaMRuQ==
   dependencies:
     "@npmcli/config" "^8.0.0"
     import-meta-resolve "^4.0.0"
@@ -19726,9 +19437,9 @@ log-update@^4.0.0:
     wrap-ansi "^6.2.0"
 
 loglevel@^1.6.8:
-  version "1.8.1"
-  resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.8.1.tgz#5c621f83d5b48c54ae93b6156353f555963377b4"
-  integrity sha512-tCRIJM51SHjAayKwC+QAg8hT8vg6z7GSgLJKGvzuPb1Wc+hLzqtuVLxp6/HzSPOozuK+8ErAhy7U/sVzw8Dgfg==
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.9.1.tgz#d63976ac9bcd03c7c873116d41c2a85bafff1be7"
+  integrity sha512-hP3I3kCrDIMuRwAwHltphhDM1r8i55H33GgqjXbrisuJhF4kRhW1dNuxsRklp4bXl8DSdLaNLuiL4A/LWRfxvg==
 
 longest-streak@^3.0.0:
   version "3.1.0"
@@ -19795,9 +19506,9 @@ lru-cache@^7.4.4, lru-cache@^7.5.1, lru-cache@^7.7.1:
   integrity sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==
 
 "lru-cache@^9.1.1 || ^10.0.0":
-  version "10.1.0"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.1.0.tgz#2098d41c2dc56500e6c88584aa656c84de7d0484"
-  integrity sha512-/1clY/ui8CzjKFyjdvwPWJUYKiFVXG2I2cY0ssG7h4+hwk+XOIX7ZSG9Q7TW8TW3Kp3BUSqgFWBLgL4PJ+Blag==
+  version "10.2.0"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.2.0.tgz#0bd445ca57363465900f4d1f9bd8db343a4d95c3"
+  integrity sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==
 
 lz-string@^1.4.4, lz-string@^1.5.0:
   version "1.5.0"
@@ -19940,9 +19651,9 @@ markdown-table@^3.0.0:
   integrity sha512-Z1NL3Tb1M9wH4XESsCDEksWoKTdlUafKc4pt0GRwjUyXaCFZ+dc3g2erqB6zm3szA2IUSi7VnPI+o/9jnxh9hw==
 
 markdown-to-jsx@^7.1.1, markdown-to-jsx@^7.1.8:
-  version "7.4.0"
-  resolved "https://registry.yarnpkg.com/markdown-to-jsx/-/markdown-to-jsx-7.4.0.tgz#4606c5c549a6f6cb87604c35f5ee4f42959ffb6b"
-  integrity sha512-zilc+MIkVVXPyTb4iIUTIz9yyqfcWjszGXnwF9K/aiBWcHXFcmdEMTkG01/oQhwSCH7SY1BnG6+ev5BzWmbPrg==
+  version "7.4.1"
+  resolved "https://registry.yarnpkg.com/markdown-to-jsx/-/markdown-to-jsx-7.4.1.tgz#1ed6a60f8f9cd944bec39d9923fbbc8d3d60dcb9"
+  integrity sha512-GbrbkTnHp9u6+HqbPRFJbObi369AgJNXi/sGqq5HRsoZW063xR1XDCaConqq+whfEIAlzB1YPnOgsPc7B7bc/A==
 
 marked@^0.8.0:
   version "0.8.2"
@@ -20097,9 +19808,9 @@ mdast-util-phrasing@^3.0.0:
     unist-util-is "^5.0.0"
 
 mdast-util-phrasing@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/mdast-util-phrasing/-/mdast-util-phrasing-4.0.0.tgz#468cbbb277375523de807248b8ad969feb02a5c7"
-  integrity sha512-xadSsJayQIucJ9n053dfQwVu1kuXg7jCTdYsMK8rqzKZh52nLfSH/k0sAxE0u+pj/zKZX+o5wB+ML5mRayOxFA==
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz#7cc0a8dec30eaf04b7b1a9661a92adb3382aa6e3"
+  integrity sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==
   dependencies:
     "@types/mdast" "^4.0.0"
     unist-util-is "^6.0.0"
@@ -20515,9 +20226,9 @@ micromark-util-character@^1.0.0:
     micromark-util-types "^1.0.0"
 
 micromark-util-character@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/micromark-util-character/-/micromark-util-character-2.0.1.tgz#52b824c2e2633b6fb33399d2ec78ee2a90d6b298"
-  integrity sha512-3wgnrmEAJ4T+mGXAUfMvMAbxU9RDG43XmGce4j6CwPtVxB3vfwXSZ6KhFwDzZ3mZHhmPimMAXg71veiBGzeAZw==
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/micromark-util-character/-/micromark-util-character-2.1.0.tgz#31320ace16b4644316f6bf057531689c71e2aee1"
+  integrity sha512-KvOVV+X1yLBfs9dCBSopq/+G1PcgT3lAK07mC4BzXi5E7ahzMAF8oIupDDJ6mievI6F+lAATkbQQlQixJfT3aQ==
   dependencies:
     micromark-util-symbol "^2.0.0"
     micromark-util-types "^2.0.0"
@@ -20866,11 +20577,12 @@ mini-css-extract-plugin@0.11.3:
     webpack-sources "^1.1.0"
 
 mini-css-extract-plugin@^2.4.5:
-  version "2.7.7"
-  resolved "https://registry.yarnpkg.com/mini-css-extract-plugin/-/mini-css-extract-plugin-2.7.7.tgz#4acf02f362c641c38fb913bfcb7ca2fc4a7cf339"
-  integrity sha512-+0n11YGyRavUR3IlaOzJ0/4Il1avMvJ1VJfhWfCn24ITQXhRr1gghbhhrda6tgtNcpZaWKdSuwKq20Jb7fnlyw==
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/mini-css-extract-plugin/-/mini-css-extract-plugin-2.8.0.tgz#1aeae2a90a954b6426c9e8311eab36b450f553a0"
+  integrity sha512-CxmUYPFcTgET1zImteG/LZOy/4T5rTojesQXkSNBiquhydn78tfbCE9sjIjnJ/UcjNjOC1bphTCCW5rrS7cXAg==
   dependencies:
     schema-utils "^4.0.0"
+    tapable "^2.2.1"
 
 minimalistic-assert@^1.0.0, minimalistic-assert@^1.0.1:
   version "1.0.1"
@@ -21312,9 +21024,9 @@ node-dir@^0.1.17:
     minimatch "^3.0.2"
 
 node-fetch-native@^1.6.1:
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/node-fetch-native/-/node-fetch-native-1.6.1.tgz#f95c74917d3cebc794cdae0cd2a9c7594aad0cb4"
-  integrity sha512-bW9T/uJDPAJB2YNYEpWzE54U5O3MQidXsOyTfnbKYtTtFexRvGzb1waphBN4ZwP6EcIvYYEOwW0b72BpAqydTw==
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/node-fetch-native/-/node-fetch-native-1.6.2.tgz#f439000d972eb0c8a741b65dcda412322955e1c6"
+  integrity sha512-69mtXOFZ6hSkYiXAVB5SqaRvrbITC/NPyqv7yuu/qw0nmgPyYbIMYYNIDhNtwPrzk0ptrimrLz/hhjvm4w5Z+w==
 
 node-fetch@2.6.7:
   version "2.6.7"
@@ -21781,13 +21493,13 @@ nx@15.9.7, "nx@>=15.5.2 < 16":
     "@nrwl/nx-win32-x64-msvc" "15.9.7"
 
 nypm@^0.3.3:
-  version "0.3.4"
-  resolved "https://registry.yarnpkg.com/nypm/-/nypm-0.3.4.tgz#48ec8fc19fbf20fb747728716ceac3a4bd0456a3"
-  integrity sha512-1JLkp/zHBrkS3pZ692IqOaIKSYHmQXgqfELk6YTOfVBnwealAmPA1q2kKK7PHJAHSMBozerThEFZXP3G6o7Ukg==
+  version "0.3.6"
+  resolved "https://registry.yarnpkg.com/nypm/-/nypm-0.3.6.tgz#940b558e6e56c2ed5dc43adf6dcf2c16577a80ff"
+  integrity sha512-2CATJh3pd6CyNfU5VZM7qSwFu0ieyabkEdnogE30Obn1czrmOYiZ8DOZLe1yBdLKWoyD3Mcy2maUs+0MR3yVjQ==
   dependencies:
     citty "^0.1.5"
     execa "^8.0.1"
-    pathe "^1.1.1"
+    pathe "^1.1.2"
     ufo "^1.3.2"
 
 object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
@@ -21809,7 +21521,7 @@ object-hash@^3.0.0:
   resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-3.0.0.tgz#73f97f753e7baffc0e2cc9d6e079079744ac82e9"
   integrity sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==
 
-object-inspect@^1.13.1, object-inspect@^1.9.0:
+object-inspect@^1.13.1:
   version "1.13.1"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.13.1.tgz#b96c6109324ccfef6b12216a956ca4dc2ff94bc2"
   integrity sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==
@@ -21884,14 +21596,15 @@ object.getownpropertydescriptors@^2.0.3, object.getownpropertydescriptors@^2.1.0
     safe-array-concat "^1.0.0"
 
 object.groupby@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/object.groupby/-/object.groupby-1.0.1.tgz#d41d9f3c8d6c778d9cbac86b4ee9f5af103152ee"
-  integrity sha512-HqaQtqLnp/8Bn4GL16cj+CUYbnpe1bh0TtEaWvybszDG4tgxCJuRpV8VGuvNaI1fAnI4lUJzDG55MXcOH4JZcQ==
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/object.groupby/-/object.groupby-1.0.2.tgz#494800ff5bab78fd0eff2835ec859066e00192ec"
+  integrity sha512-bzBq58S+x+uo0VjurFT0UktpKHOZmv4/xePiOA1nbB9pMqpGK7rUPNgf+1YC+7mE+0HzhTMqNUuCqvKhj6FnBw==
   dependencies:
-    call-bind "^1.0.2"
-    define-properties "^1.2.0"
-    es-abstract "^1.22.1"
-    get-intrinsic "^1.2.1"
+    array.prototype.filter "^1.0.3"
+    call-bind "^1.0.5"
+    define-properties "^1.2.1"
+    es-abstract "^1.22.3"
+    es-errors "^1.0.0"
 
 object.hasown@^1.1.2:
   version "1.1.3"
@@ -22575,7 +22288,7 @@ path@^0.12.7:
     process "^0.11.1"
     util "^0.10.3"
 
-pathe@^1.1.1:
+pathe@^1.1.1, pathe@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/pathe/-/pathe-1.1.2.tgz#6c4cb47a945692e48a1ddd6e4094d170516437ec"
   integrity sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==
@@ -22739,9 +22452,9 @@ pnp-webpack-plugin@1.6.4:
     ts-pnp "^1.1.6"
 
 polished@^4.2.2:
-  version "4.2.2"
-  resolved "https://registry.yarnpkg.com/polished/-/polished-4.2.2.tgz#2529bb7c3198945373c52e34618c8fe7b1aa84d1"
-  integrity sha512-Sz2Lkdxz6F2Pgnpi9U5Ng/WdWAUZxmHrNPoVlm3aAemxoy2Qy7LGjQg4uf8qKelDAUW94F4np3iH2YPf2qefcQ==
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/polished/-/polished-4.3.1.tgz#5a00ae32715609f83d89f6f31d0f0261c6170548"
+  integrity sha512-OBatVyC/N7SCW/FaDHrSd+vn0o5cS855TOmYi4OkdWUMSJCET/xip//ch8xGUvtr3i44X9LVyWwQlRMTN3pwSA==
   dependencies:
     "@babel/runtime" "^7.17.8"
 
@@ -23365,7 +23078,7 @@ postcss-modules-local-by-default@^3.0.3:
     postcss-selector-parser "^6.0.2"
     postcss-value-parser "^4.1.0"
 
-postcss-modules-local-by-default@^4.0.3:
+postcss-modules-local-by-default@^4.0.4:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/postcss-modules-local-by-default/-/postcss-modules-local-by-default-4.0.4.tgz#7cbed92abd312b94aaea85b68226d3dec39a14e6"
   integrity sha512-L4QzMnOdVwRm1Qb8m4x8jsZzKAaPAgrUF1r/hjDR2Xj7R+8Zsf97jAlSQzWtKx5YNiNGN8QxmPFIc/sh+RQl+Q==
@@ -23382,10 +23095,10 @@ postcss-modules-scope@^2.2.0:
     postcss "^7.0.6"
     postcss-selector-parser "^6.0.0"
 
-postcss-modules-scope@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/postcss-modules-scope/-/postcss-modules-scope-3.1.0.tgz#fbfddfda93a31f310f1d152c2bb4d3f3c5592ee0"
-  integrity sha512-SaIbK8XW+MZbd0xHPf7kdfA/3eOt7vxJ72IRecn3EzuZVLr1r0orzf0MX/pN8m+NMDoo6X/SQd8oeKqGZd8PXg==
+postcss-modules-scope@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/postcss-modules-scope/-/postcss-modules-scope-3.1.1.tgz#32cfab55e84887c079a19bbb215e721d683ef134"
+  integrity sha512-uZgqzdTleelWjzJY+Fhti6F3C9iF1JR/dODLs/JDefozYcKTBCdD8BIl6nNPbTbcLnGrk56hzwZC2DaGNvYjzA==
   dependencies:
     postcss-selector-parser "^6.0.4"
 
@@ -23938,10 +23651,10 @@ postcss@^7, postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.14, postcss@^7.0.17, po
     picocolors "^0.2.1"
     source-map "^0.6.1"
 
-postcss@^8.1.0, postcss@^8.3.5, postcss@^8.4.23, postcss@^8.4.31, postcss@^8.4.4:
-  version "8.4.33"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.33.tgz#1378e859c9f69bf6f638b990a0212f43e2aaa742"
-  integrity sha512-Kkpbhhdjw2qQs2O2DGX+8m5OVqEcbB9HRBvuYM9pgrjEFUg30A9LmXNlTAUj4S9kgtGyrMbTzVjH7E+s5Re2yg==
+postcss@^8.1.0, postcss@^8.3.5, postcss@^8.4.23, postcss@^8.4.33, postcss@^8.4.4:
+  version "8.4.35"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.35.tgz#60997775689ce09011edf083a549cea44aabe2f7"
+  integrity sha512-u5U8qYpBCpN13BsiEB0CbR1Hhh4Gc0zLFuedrHJKMctHCHAGrMdG0PRM/KErzAL3CU6/eckEtmHNB3x6e3c0vA==
   dependencies:
     nanoid "^3.3.7"
     picocolors "^1.0.0"
@@ -24169,9 +23882,9 @@ prop-types@^15.0.0, prop-types@^15.5.7, prop-types@^15.6.1, prop-types@^15.6.2, 
     react-is "^16.13.1"
 
 property-information@^6.0.0:
-  version "6.4.0"
-  resolved "https://registry.yarnpkg.com/property-information/-/property-information-6.4.0.tgz#6bc4c618b0c2d68b3bb8b552cbb97f8e300a0f82"
-  integrity sha512-9t5qARVofg2xQqKtytzt+lZ4d1Qvj8t5B8fEwXK6qOfgRLgH/b13QlgEyDh033NOS31nXeFbYv7CLUDG1CeifQ==
+  version "6.4.1"
+  resolved "https://registry.yarnpkg.com/property-information/-/property-information-6.4.1.tgz#de8b79a7415fd2107dfbe65758bb2cc9dfcf60ac"
+  integrity sha512-OHYtXfu5aI2sS2LWFSN5rgJjrQ4pCy8i1jubJLe2QvMF8JJ++HXTUIVWFLfXJoaOfvYYjk2SN8J2wFUWIGXT4w==
 
 propose@0.0.5:
   version "0.0.5"
@@ -24625,21 +24338,21 @@ react-fast-compare@^3.0.1:
   integrity sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==
 
 react-focus-lock@^2.9.1:
-  version "2.9.6"
-  resolved "https://registry.yarnpkg.com/react-focus-lock/-/react-focus-lock-2.9.6.tgz#cad168a150fdd72d5ab2419ba8e62780788011b1"
-  integrity sha512-B7gYnCjHNrNYwY2juS71dHbf0+UpXXojt02svxybj8N5bxceAkzPChKEncHuratjUHkIFNCn06k2qj1DRlzTug==
+  version "2.9.8"
+  resolved "https://registry.yarnpkg.com/react-focus-lock/-/react-focus-lock-2.9.8.tgz#32e9343d5ed9baa9e619adcac82e8756e8d00ae4"
+  integrity sha512-nLrUCTF8/BWGaWV00wvmIOPe56HTLWtqjqwWebHE80jB0fCMsm/Cl2zbp8ulbCoe5BOU7bWSCg5YhkYhDxykWw==
   dependencies:
     "@babel/runtime" "^7.0.0"
-    focus-lock "^1.0.0"
+    focus-lock "^1.0.1"
     prop-types "^15.6.2"
     react-clientside-effect "^1.2.6"
     use-callback-ref "^1.3.0"
     use-sidecar "^1.1.2"
 
 react-hotkeys-hook@^4.4.1:
-  version "4.4.4"
-  resolved "https://registry.yarnpkg.com/react-hotkeys-hook/-/react-hotkeys-hook-4.4.4.tgz#5f055f39113218fe5e23f8723db68ccf99d155ab"
-  integrity sha512-wzZmqb/Obr0ds9Myc1sIFPJ52GA/Eeg/vXBWV0HA1LvHlVAW5Va3KB0q6EZNlNSHQWscWZ2K8+6w0GYSie2o7A==
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/react-hotkeys-hook/-/react-hotkeys-hook-4.5.0.tgz#807b389b15256daf6a813a1ec09e6698064fe97f"
+  integrity sha512-Samb85GSgAWFQNvVt3PS90LPPGSf9mkH/r4au81ZP1yOIFayLC3QAvqTgGtJ8YEDMXtPmaVBs6NgipHO6h4Mug==
 
 react-intersection-observer@9.4.0:
   version "9.4.0"
@@ -25151,14 +24864,15 @@ redeyed@~2.1.0:
     esprima "~4.0.0"
 
 reflect.getprototypeof@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/reflect.getprototypeof/-/reflect.getprototypeof-1.0.4.tgz#aaccbf41aca3821b87bb71d9dcbc7ad0ba50a3f3"
-  integrity sha512-ECkTw8TmJwW60lOTR+ZkODISW6RQ8+2CL3COqtiJKLd6MmB45hN51HprHFziKLGkAuTGQhBb91V8cy+KHlaCjw==
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/reflect.getprototypeof/-/reflect.getprototypeof-1.0.5.tgz#e0bd28b597518f16edaf9c0e292c631eb13e0674"
+  integrity sha512-62wgfC8dJWrmxv44CA36pLDnP6KKl3Vhxb7PL+8+qrrFMMoJij4vgiMP8zV4O8+CBMXY1mHxI5fITGHXFHVmQQ==
   dependencies:
-    call-bind "^1.0.2"
-    define-properties "^1.2.0"
-    es-abstract "^1.22.1"
-    get-intrinsic "^1.2.1"
+    call-bind "^1.0.5"
+    define-properties "^1.2.1"
+    es-abstract "^1.22.3"
+    es-errors "^1.0.0"
+    get-intrinsic "^1.2.3"
     globalthis "^1.0.3"
     which-builtin-type "^1.1.3"
 
@@ -25215,13 +24929,14 @@ regex-parser@^2.2.11:
   integrity sha512-TVILVSz2jY5D47F4mA4MppkBrafEaiUWJO/TcZHEIuI13AqoZMkK1WMA4Om1YkYbTx+9Ki1/tSUXbceyr9saRg==
 
 regexp.prototype.flags@^1.3.0, regexp.prototype.flags@^1.5.0, regexp.prototype.flags@^1.5.1:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.5.1.tgz#90ce989138db209f81492edd734183ce99f9677e"
-  integrity sha512-sy6TXMN+hnP/wMy+ISxg3krXx7BAtWVO4UouuCN/ziM9UEne0euamVNafDfvC83bRNr95y0V5iijeDQFUNpvrg==
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.5.2.tgz#138f644a3350f981a858c44f6bb1a61ff59be334"
+  integrity sha512-NcDiDkTLuPR+++OCKB0nWafEmhg/Da8aUPLPMQbK+bxKKCm1/S5he+AqYa4PlMCVBalb4/yxIRub6qkEx5yJbw==
   dependencies:
-    call-bind "^1.0.2"
-    define-properties "^1.2.0"
-    set-function-name "^2.0.0"
+    call-bind "^1.0.6"
+    define-properties "^1.2.1"
+    es-errors "^1.3.0"
+    set-function-name "^2.0.1"
 
 regexpp@^3.1.0:
   version "3.2.0"
@@ -25852,9 +25567,9 @@ rework@1.0.1:
     css "^2.0.0"
 
 rfdc@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/rfdc/-/rfdc-1.3.0.tgz#d0b7c441ab2720d05dc4cf26e01c89631d9da08b"
-  integrity sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/rfdc/-/rfdc-1.3.1.tgz#2b6d4df52dffe8bb346992a10ea9451f24373a8f"
+  integrity sha512-r5a3l5HzYlIC68TpmYKlxWjmOP6wiPJ1vWv2HeLhNsRZMrCkxeqxiHlQ21oXmQ4F3SiryXBHhAD7JZqvOJjFmg==
 
 rgb-regex@^1.0.1:
   version "1.0.1"
@@ -26014,7 +25729,7 @@ sade@^1.7.3:
   dependencies:
     mri "^1.1.0"
 
-safe-array-concat@^1.0.0, safe-array-concat@^1.0.1:
+safe-array-concat@^1.0.0, safe-array-concat@^1.0.1, safe-array-concat@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/safe-array-concat/-/safe-array-concat-1.1.0.tgz#8d0cae9cb806d6d1c06e08ab13d847293ebe0692"
   integrity sha512-ZdQ0Jeb9Ofti4hbt5lX3T2JcAamT9hfzYU1MNB+z/jaEbB6wfFfPIR/zEORmZqobkCCJhSjodobH6WHNmJ97dg==
@@ -26035,12 +25750,12 @@ safe-buffer@5.2.1, safe-buffer@>=5.1.0, safe-buffer@^5.0.1, safe-buffer@^5.1.0, 
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
 
 safe-regex-test@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/safe-regex-test/-/safe-regex-test-1.0.2.tgz#3ba32bdb3ea35f940ee87e5087c60ee786c3f6c5"
-  integrity sha512-83S9w6eFq12BBIJYvjMux6/dkirb8+4zJRA9cxNBVb7Wq5fJBW+Xze48WqR8pxua7bDuAaaAxtVVd4Idjp1dBQ==
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/safe-regex-test/-/safe-regex-test-1.0.3.tgz#a5b4c0f06e0ab50ea2c395c14d8371232924c377"
+  integrity sha512-CdASjNJPvRa7roO6Ra/gLYBTzYzzPyyBXxIMdGW3USQLyjWEls2RgW5UBTXaQVp+OrpeCK3bLem8smtmheoRuw==
   dependencies:
-    call-bind "^1.0.5"
-    get-intrinsic "^1.2.2"
+    call-bind "^1.0.6"
+    es-errors "^1.3.0"
     is-regex "^1.1.4"
 
 safe-regex@^1.1.0:
@@ -26241,10 +25956,17 @@ semver@7.3.8:
   dependencies:
     lru-cache "^6.0.0"
 
-semver@7.5.4, semver@^7.0.0, semver@^7.1.1, semver@^7.2.1, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5, semver@^7.3.7, semver@^7.3.8, semver@^7.5.3, semver@^7.5.4:
+semver@7.5.4:
   version "7.5.4"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.4.tgz#483986ec4ed38e1c6c48c34894a9182dbff68a6e"
   integrity sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==
+  dependencies:
+    lru-cache "^6.0.0"
+
+semver@7.6.0, semver@^7.0.0, semver@^7.1.1, semver@^7.2.1, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5, semver@^7.3.7, semver@^7.3.8, semver@^7.5.3, semver@^7.5.4:
+  version "7.6.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.6.0.tgz#1a46a4db4bffcccd97b743b5005c8325f23d4e2d"
+  integrity sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==
   dependencies:
     lru-cache "^6.0.0"
 
@@ -26355,14 +26077,15 @@ set-blocking@^2.0.0:
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==
 
-set-function-length@^1.1.1:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/set-function-length/-/set-function-length-1.2.0.tgz#2f81dc6c16c7059bda5ab7c82c11f03a515ed8e1"
-  integrity sha512-4DBHDoyHlM1IRPGYcoxexgh67y4ueR53FKV1yyxwFMY7aCqcN/38M1+SwZ/qJQ8iLv7+ck385ot4CcisOAPT9w==
+set-function-length@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/set-function-length/-/set-function-length-1.2.1.tgz#47cc5945f2c771e2cf261c6737cf9684a2a5e425"
+  integrity sha512-j4t6ccc+VsKwYHso+kElc5neZpjtq9EnRICFZtWyBsLojhmeF/ZBd/elqm22WJh/BziDe/SBiOeAt0m2mfLD0g==
   dependencies:
-    define-data-property "^1.1.1"
+    define-data-property "^1.1.2"
+    es-errors "^1.3.0"
     function-bind "^1.1.2"
-    get-intrinsic "^1.2.2"
+    get-intrinsic "^1.2.3"
     gopd "^1.0.1"
     has-property-descriptors "^1.0.1"
 
@@ -26469,13 +26192,14 @@ shellwords@^0.1.1:
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
 
 side-channel@^1.0.3, side-channel@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.0.4.tgz#efce5c8fdc104ee751b25c58d4290011fa5ea2cf"
-  integrity sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.0.5.tgz#9a84546599b48909fb6af1211708d23b1946221b"
+  integrity sha512-QcgiIWV4WV7qWExbN5llt6frQB/lBven9pqliLXfGPB+K9ZYXxDozp0wLkHS24kWCm+6YXH/f0HhnObZnZOBnQ==
   dependencies:
-    call-bind "^1.0.0"
-    get-intrinsic "^1.0.2"
-    object-inspect "^1.9.0"
+    call-bind "^1.0.6"
+    es-errors "^1.3.0"
+    get-intrinsic "^1.2.4"
+    object-inspect "^1.13.1"
 
 signal-exit@3.0.7, signal-exit@^3.0.0, signal-exit@^3.0.2, signal-exit@^3.0.3, signal-exit@^3.0.7:
   version "3.0.7"
@@ -26688,11 +26412,11 @@ socks-proxy-agent@^7.0.0:
     socks "^2.6.2"
 
 socks@^2.6.2:
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/socks/-/socks-2.7.1.tgz#d8e651247178fde79c0663043e07240196857d55"
-  integrity sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==
+  version "2.7.3"
+  resolved "https://registry.yarnpkg.com/socks/-/socks-2.7.3.tgz#7d8a75d7ce845c0a96f710917174dba0d543a785"
+  integrity sha512-vfuYK48HXCTFD03G/1/zkIls3Ebr2YNa4qU9gHDZdblHLiqhJrJGkY3+0Nx0JpN9qBhJbVObc1CNciT1bIZJxw==
   dependencies:
-    ip "^2.0.0"
+    ip-address "^9.0.5"
     smart-buffer "^4.2.0"
 
 sort-keys-length@^1.0.0:
@@ -26835,9 +26559,9 @@ spdx-correct@^3.0.0:
     spdx-license-ids "^3.0.0"
 
 spdx-exceptions@^2.1.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz#3f28ce1a77a00372683eade4a433183527a2163d"
-  integrity sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/spdx-exceptions/-/spdx-exceptions-2.4.0.tgz#c07a4ede25b16e4f78e6707bbd84b15a45c19c1b"
+  integrity sha512-hcjppoJ68fhxA/cjbN4T8N6uCUejN8yFw69ttpqtBeCbF3u13n7mb31NB9jKwGTTWWnt9IbRA/mf1FprYS8wfw==
 
 spdx-expression-parse@^3.0.0:
   version "3.0.1"
@@ -26848,9 +26572,9 @@ spdx-expression-parse@^3.0.0:
     spdx-license-ids "^3.0.0"
 
 spdx-license-ids@^3.0.0:
-  version "3.0.16"
-  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.16.tgz#a14f64e0954f6e25cc6587bd4f392522db0d998f"
-  integrity sha512-eWN+LnM3GR6gPu35WxNgbGl8rmY1AEmoMDvL/QD6zYmPWgywxWqJWNdLGT+ke8dKNWrcYgYjPpG5gbTfghP8rw==
+  version "3.0.17"
+  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.17.tgz#887da8aa73218e51a1d917502d79863161a93f9c"
+  integrity sha512-sh8PWc/ftMqAAdFiBu6Fy6JUOYjqDJBJvIhpfDMyHrr0Rbp5liZqd4TjtQ/RgfLjKFZb+LMx5hpml5qOWy0qvg==
 
 spdy-transport@^3.0.0:
   version "3.0.0"
@@ -26912,6 +26636,11 @@ split@^1.0.0:
   integrity sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==
   dependencies:
     through "2"
+
+sprintf-js@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.1.3.tgz#4914b903a2f8b685d17fdf78a70e917e872e444a"
+  integrity sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==
 
 sprintf-js@~1.0.2:
   version "1.0.3"
@@ -27044,11 +26773,11 @@ storybook-addon-swc@1.2.0:
     swc-loader "^0.1.15"
 
 storybook@^7.6.14:
-  version "7.6.15"
-  resolved "https://registry.yarnpkg.com/storybook/-/storybook-7.6.15.tgz#a53247cb5f719b78a1e8a6780696580c1f26fe80"
-  integrity sha512-Ybezq9JRk5CBhzjgzZ/oT7mnU45UwhyVSGKW+PUKZGGUG9VH2hCrTEES9f/zEF82kj/5COVPyqR/5vlXuuS39A==
+  version "7.6.14"
+  resolved "https://registry.yarnpkg.com/storybook/-/storybook-7.6.14.tgz#4af87bec32098e1115b417de0a149a242c3bab01"
+  integrity sha512-4WMb/Dyzl4QzAd1X1b13cJXwynI7fGbT3qGy+X169hsXn6u73tlRcuPXrTsEO9a+rNBxZiBEBJf5poYxCH2j5Q==
   dependencies:
-    "@storybook/cli" "7.6.15"
+    "@storybook/cli" "7.6.14"
 
 stream-browserify@^2.0.1:
   version "2.0.2"
@@ -27782,7 +27511,7 @@ terser-webpack-plugin@^1.4.3:
     webpack-sources "^1.4.0"
     worker-farm "^1.7.0"
 
-terser-webpack-plugin@^5.2.5, terser-webpack-plugin@^5.3.1, terser-webpack-plugin@^5.3.7:
+terser-webpack-plugin@^5.2.5, terser-webpack-plugin@^5.3.1, terser-webpack-plugin@^5.3.10, terser-webpack-plugin@^5.3.7:
   version "5.3.10"
   resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-5.3.10.tgz#904f4c9193c6fd2a03f693a2150c62a92f40d199"
   integrity sha512-BKFPWlPDndPs+NGGCr1U59t0XScL5317Y0UReNrHaw9/FwhPENlq6bfgs+4yPfyP51vqC1bQ4rp1EfXW5ZSH9w==
@@ -28122,9 +27851,9 @@ trough@^1.0.0:
   integrity sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==
 
 trough@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/trough/-/trough-2.1.0.tgz#0f7b511a4fde65a46f18477ab38849b22c554876"
-  integrity sha512-AqTiAOLcj85xS7vQ8QkAV41hPDIJ71XJB4RCUrzo/1GM2CQwhkJGaf9Hgr7BOugMRpgGUrqRg/DrBDl4H40+8g==
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/trough/-/trough-2.2.0.tgz#94a60bd6bd375c152c1df911a4b11d5b0256f50f"
+  integrity sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==
 
 truncate@^3.0.0:
   version "3.0.0"
@@ -28137,9 +27866,9 @@ tryer@^1.0.1:
   integrity sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA==
 
 ts-api-utils@^1.0.1:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/ts-api-utils/-/ts-api-utils-1.0.3.tgz#f12c1c781d04427313dbac808f453f050e54a331"
-  integrity sha512-wNMeqtMz5NtwpT/UZGY5alT+VoKdSsOOP/kqHFcUW1P/VRhH2wJ48+DN2WwUliNbQ976ETwDL0Ifd2VVvgonvg==
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/ts-api-utils/-/ts-api-utils-1.2.1.tgz#f716c7e027494629485b21c0df6180f4d08f5e8b"
+  integrity sha512-RIYA36cJn2WiH9Hy77hdF9r7oEwxAtB/TS9/S4Qd90Ap4z5FSiin5zEiTL44OII1Y3IIlEvxwxFUVgrHSZ/UpA==
 
 ts-dedent@^2.0.0, ts-dedent@^2.2.0:
   version "2.2.0"
@@ -28356,9 +28085,9 @@ type-fest@^3.8.0:
   integrity sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==
 
 type-fest@^4.0.0:
-  version "4.9.0"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-4.9.0.tgz#d29c8efe5b1e703feeb29cef23d887b2f479844d"
-  integrity sha512-KS/6lh/ynPGiHD/LnAobrEFq3Ad4pBzOlJ1wAnJx9N4EYoqFhMfLIBjUT2UEx4wg5ZE+cC1ob6DCSpppVo+rtg==
+  version "4.10.2"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-4.10.2.tgz#3abdb144d93c5750432aac0d73d3e85fcab45738"
+  integrity sha512-anpAG63wSpdEbLwOqH8L84urkL6PiVIov3EMmgIhhThevh9aiMQov+6Btx0wldNcvm4wV+e2/Rt1QdDwKHFbHw==
 
 type-is@~1.6.18:
   version "1.6.18"
@@ -28379,13 +28108,13 @@ type@^2.7.2:
   integrity sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw==
 
 typed-array-buffer@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/typed-array-buffer/-/typed-array-buffer-1.0.0.tgz#18de3e7ed7974b0a729d3feecb94338d1472cd60"
-  integrity sha512-Y8KTSIglk9OZEr8zywiIHG/kmQ7KWyjseXs1CbSo8vC42w7hg2HgYTxSWwP0+is7bWDc1H+Fo026CpHFwm8tkw==
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/typed-array-buffer/-/typed-array-buffer-1.0.1.tgz#0608ffe6bca71bf15a45bff0ca2604107a1325f5"
+  integrity sha512-RSqu1UEuSlrBhHTWC8O9FnPjOduNs4M7rJ4pRKoEjtx1zUNOPN2sSXHLDX+Y2WPbHIxbvg4JFo2DNAEfPIKWoQ==
   dependencies:
-    call-bind "^1.0.2"
-    get-intrinsic "^1.2.1"
-    is-typed-array "^1.1.10"
+    call-bind "^1.0.6"
+    es-errors "^1.3.0"
+    is-typed-array "^1.1.13"
 
 typed-array-byte-length@^1.0.0:
   version "1.0.0"
@@ -28452,9 +28181,9 @@ ucfirst@^1.0.0:
   integrity sha512-xbB/CQ0GdkxqH4IElZqenn/dL/tnyx7DCDASWJPE92ePbFM21kKemXI2LBeYtEvblf1Ol98hyJJS43Wu5JMQSQ==
 
 ufo@^1.3.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/ufo/-/ufo-1.3.2.tgz#c7d719d0628a1c80c006d2240e0d169f6e3c0496"
-  integrity sha512-o+ORpgGwaYQXgqGDwd+hkS4PuZ3QnmqMMxRuajK/a38L6fTpcE5GPIfrf+L/KemFzfUpeUQc1rRS1iDBozvnFA==
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/ufo/-/ufo-1.4.0.tgz#39845b31be81b4f319ab1d99fd20c56cac528d32"
+  integrity sha512-Hhy+BhRBleFjpJ2vchUNN40qgkh0366FWJGqVLYBHev0vpHTrXSA0ryT+74UiW6KWsldNurQMKGqCm1M2zBciQ==
 
 uglify-js@^3.1.4:
   version "3.17.4"
@@ -29524,9 +29253,9 @@ webpack-dev-server@^4.6.0:
     ws "^8.13.0"
 
 webpack-hot-middleware@^2.25.1:
-  version "2.26.0"
-  resolved "https://registry.yarnpkg.com/webpack-hot-middleware/-/webpack-hot-middleware-2.26.0.tgz#0a103c9b2836c1f27d7f74bbe0e96c99c82d0265"
-  integrity sha512-okzjec5sAEy4t+7rzdT8eRyxsk0FDSmBPN2KwX4Qd+6+oQCfe5Ve07+u7cJvofgB+B4w5/4dO4Pz0jhhHyyPLQ==
+  version "2.26.1"
+  resolved "https://registry.yarnpkg.com/webpack-hot-middleware/-/webpack-hot-middleware-2.26.1.tgz#87214f1e3f9f3acab9271fef9e6ed7b637d719c0"
+  integrity sha512-khZGfAeJx6I8K9zKohEWWYN6KDlVw2DHownoe+6Vtwj1LP9WFgegXnVMSkZ/dBEBtXFwrkkydsaPFlB7f8wU2A==
   dependencies:
     ansi-html-community "0.0.8"
     html-entities "^2.1.0"
@@ -29619,18 +29348,18 @@ webpack@4.44.2:
     webpack-sources "^1.4.1"
 
 webpack@5, webpack@^5.64.4:
-  version "5.89.0"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.89.0.tgz#56b8bf9a34356e93a6625770006490bf3a7f32dc"
-  integrity sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==
+  version "5.90.1"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.90.1.tgz#62ab0c097d7cbe83d32523dbfbb645cdb7c3c01c"
+  integrity sha512-SstPdlAC5IvgFnhiRok8hqJo/+ArAbNv7rhU4fnWGHNVfN59HSQFaxZDSAL3IFG2YmqxuRs+IU33milSxbPlog==
   dependencies:
     "@types/eslint-scope" "^3.7.3"
-    "@types/estree" "^1.0.0"
+    "@types/estree" "^1.0.5"
     "@webassemblyjs/ast" "^1.11.5"
     "@webassemblyjs/wasm-edit" "^1.11.5"
     "@webassemblyjs/wasm-parser" "^1.11.5"
     acorn "^8.7.1"
     acorn-import-assertions "^1.9.0"
-    browserslist "^4.14.5"
+    browserslist "^4.21.10"
     chrome-trace-event "^1.0.2"
     enhanced-resolve "^5.15.0"
     es-module-lexer "^1.2.1"
@@ -29644,7 +29373,7 @@ webpack@5, webpack@^5.64.4:
     neo-async "^2.6.2"
     schema-utils "^3.2.0"
     tapable "^2.1.1"
-    terser-webpack-plugin "^5.3.7"
+    terser-webpack-plugin "^5.3.10"
     watchpack "^2.4.0"
     webpack-sources "^3.2.3"
 
@@ -29799,16 +29528,16 @@ which-module@^2.0.0:
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.1.tgz#776b1fe35d90aebe99e8ac15eb24093389a4a409"
   integrity sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==
 
-which-typed-array@^1.1.11, which-typed-array@^1.1.13, which-typed-array@^1.1.2, which-typed-array@^1.1.9:
-  version "1.1.13"
-  resolved "https://registry.yarnpkg.com/which-typed-array/-/which-typed-array-1.1.13.tgz#870cd5be06ddb616f504e7b039c4c24898184d36"
-  integrity sha512-P5Nra0qjSncduVPEAr7xhoF5guty49ArDTwzJ/yNuPIbZppyRxFQsRCWrocxIY+CnMVG+qfbU2FmDKyvSGClow==
+which-typed-array@^1.1.13, which-typed-array@^1.1.14, which-typed-array@^1.1.2, which-typed-array@^1.1.9:
+  version "1.1.14"
+  resolved "https://registry.yarnpkg.com/which-typed-array/-/which-typed-array-1.1.14.tgz#1f78a111aee1e131ca66164d8bdc3ab062c95a06"
+  integrity sha512-VnXFiIW8yNn9kIHN88xvZ4yOWchftKDsRJ8fEPacX/wl1lOvBrhsJ/OeJCXq7B0AaijRuqgzSKalJoPk+D8MPg==
   dependencies:
-    available-typed-arrays "^1.0.5"
-    call-bind "^1.0.4"
+    available-typed-arrays "^1.0.6"
+    call-bind "^1.0.5"
     for-each "^0.3.3"
     gopd "^1.0.1"
-    has-tostringtag "^1.0.0"
+    has-tostringtag "^1.0.1"
 
 which@2.0.2, which@^2.0.1, which@^2.0.2:
   version "2.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1912,7 +1912,7 @@
 
 "@contentful/f36-badge@^4.60.0":
   version "4.60.0"
-  resolved "https://registry.yarnpkg.com/@contentful/f36-autocomplete/-/f36-autocomplete-4.60.0.tgz#dbfad7478a48ded4db52609818678755ac7e0c07"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-badge/-/f36-badge-4.60.0.tgz#dbfad7478a48ded4db52609818678755ac7e0c07"
   integrity sha512-tUceZPFS8/ynENGUKcw1tVSisIW3xrhH7S9QB5JRSSaL1ccOLT3AVZQjIxm5MmHUw2l1EhSZngpEPFZyHvWEdQ==
   dependencies:
     "@contentful/f36-core" "^4.60.0"
@@ -2188,7 +2188,7 @@
 
 "@contentful/f36-datepicker@^4.60.0":
   version "4.60.0"
-  resolved "hhttps://registry.yarnpkg.com/@contentful/f36-datepicker/-/f36-datepicker-4.60.0.tgz#3e673b96a5b1220c699adc5f950fd6616603f17f"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-datepicker/-/f36-datepicker-4.60.0.tgz#3e673b96a5b1220c699adc5f950fd6616603f17f"
   integrity sha512-mnXYlPRy0nMaS3REoV86nSc/iJ1QuX43gz5msFxqz4ZHazjYYgXa0fk48Qd5WNpUC1jXbW2H0rGX84o2Aa5BFA==
   dependencies:
     "@contentful/f36-button" "^4.60.0"
@@ -2713,7 +2713,7 @@
 
 "@contentful/f36-typography@^4.60.0":
   version "4.60.0"
-  resolved "https://registry.yarnpkg.com/@contentful/f36-typography/-/f36-typography-4.60.0#0f2c507d9341fb6aaf4fa68876f643c5021b589b"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-typography/-/f36-typography-4.60.0.tgz#0f2c507d9341fb6aaf4fa68876f643c5021b589b"
   integrity sha512-iEg1VT0wH3nUKZs8jSCxKnQPWVgrqckRuG3UpLzk4FKfyDHopimFMCLqy+XswWpA+aDRueMC4Il+TVVTO5N7qQ==
   dependencies:
     "@contentful/f36-core" "^4.60.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8,9 +8,9 @@
   integrity sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==
 
 "@adobe/css-tools@^4.0.1":
-  version "4.3.3"
-  resolved "https://registry.yarnpkg.com/@adobe/css-tools/-/css-tools-4.3.3.tgz#90749bde8b89cd41764224f5aac29cd4138f75ff"
-  integrity sha512-rE0Pygv0sEZ4vBWHlAgJLGDU7Pm8xoO6p3wsEceb7GYAjScrOHpEo8KK/eVkAcnSM+slAEtXjA2JpdjLp4fJQQ==
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/@adobe/css-tools/-/css-tools-4.3.2.tgz#a6abc715fb6884851fca9dad37fc34739a04fd11"
+  integrity sha512-DA5a1C0gD/pLOvhv33YMrbf2FK3oUzwNl9oOJqE4XVjuEtt6XIakRcsd7eLiOSPkp1kTRQGICTA8cKra/vFbjw==
 
 "@alloc/quick-lru@^5.2.0":
   version "5.2.0"
@@ -55,7 +55,7 @@
   dependencies:
     "@babel/highlight" "^7.10.4"
 
-"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.16.0", "@babel/code-frame@^7.16.7", "@babel/code-frame@^7.21.4", "@babel/code-frame@^7.23.5", "@babel/code-frame@^7.5.5", "@babel/code-frame@^7.8.3":
+"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.16.0", "@babel/code-frame@^7.16.7", "@babel/code-frame@^7.21.4", "@babel/code-frame@^7.22.13", "@babel/code-frame@^7.23.5", "@babel/code-frame@^7.5.5", "@babel/code-frame@^7.8.3":
   version "7.23.5"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.23.5.tgz#9009b69a8c602293476ad598ff53e4562e15c244"
   integrity sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==
@@ -134,7 +134,28 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
-"@babel/core@^7.1.0", "@babel/core@^7.11.1", "@babel/core@^7.11.6", "@babel/core@^7.12.3", "@babel/core@^7.16.0", "@babel/core@^7.18.9", "@babel/core@^7.23.0", "@babel/core@^7.23.2", "@babel/core@^7.5.5", "@babel/core@^7.7.2", "@babel/core@^7.7.4", "@babel/core@^7.7.5", "@babel/core@^7.8.0", "@babel/core@^7.8.4":
+"@babel/core@^7.1.0", "@babel/core@^7.11.1", "@babel/core@^7.11.6", "@babel/core@^7.12.3", "@babel/core@^7.16.0", "@babel/core@^7.5.5", "@babel/core@^7.7.2", "@babel/core@^7.7.4", "@babel/core@^7.7.5", "@babel/core@^7.8.0", "@babel/core@^7.8.4":
+  version "7.23.7"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.23.7.tgz#4d8016e06a14b5f92530a13ed0561730b5c6483f"
+  integrity sha512-+UpDgowcmqe36d4NwqvKsyPMlOLNGMsfMmQ5WGCu+siCe3t3dfe9njrzGfdN4qq+bcNUt0+Vw6haRxBOycs4dw==
+  dependencies:
+    "@ampproject/remapping" "^2.2.0"
+    "@babel/code-frame" "^7.23.5"
+    "@babel/generator" "^7.23.6"
+    "@babel/helper-compilation-targets" "^7.23.6"
+    "@babel/helper-module-transforms" "^7.23.3"
+    "@babel/helpers" "^7.23.7"
+    "@babel/parser" "^7.23.6"
+    "@babel/template" "^7.22.15"
+    "@babel/traverse" "^7.23.7"
+    "@babel/types" "^7.23.6"
+    convert-source-map "^2.0.0"
+    debug "^4.1.0"
+    gensync "^1.0.0-beta.2"
+    json5 "^2.2.3"
+    semver "^6.3.1"
+
+"@babel/core@^7.18.9", "@babel/core@^7.23.0", "@babel/core@^7.23.2":
   version "7.23.9"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.23.9.tgz#b028820718000f267870822fec434820e9b1e4d1"
   integrity sha512-5q0175NOjddqpvvzU+kDiSOAk4PfdO6FvwCWoQ6RO7rTzEe8vlo+4HVfcnAREhD4npMs0e9uZypjTwzZPCf/cw==
@@ -155,19 +176,10 @@
     json5 "^2.2.3"
     semver "^6.3.1"
 
-"@babel/eslint-parser@7.23.3":
+"@babel/eslint-parser@7.23.3", "@babel/eslint-parser@^7.16.3":
   version "7.23.3"
   resolved "https://registry.yarnpkg.com/@babel/eslint-parser/-/eslint-parser-7.23.3.tgz#7bf0db1c53b54da0c8a12627373554a0828479ca"
   integrity sha512-9bTuNlyx7oSstodm1cR1bECj4fkiknsDa1YniISkJemMY3DGhJNYBECbe6QD/q54mp2J8VO66jW3/7uP//iFCw==
-  dependencies:
-    "@nicolo-ribaudo/eslint-scope-5-internals" "5.1.1-v1"
-    eslint-visitor-keys "^2.1.0"
-    semver "^6.3.1"
-
-"@babel/eslint-parser@^7.16.3":
-  version "7.23.10"
-  resolved "https://registry.yarnpkg.com/@babel/eslint-parser/-/eslint-parser-7.23.10.tgz#2d4164842d6db798873b40e0c4238827084667a2"
-  integrity sha512-3wSYDPZVnhseRnxRJH6ZVTNknBz76AEnyC+AYYhasjP3Yy23qz0ERR7Fcd2SHmYuSFJ2kY9gaaDd3vyqU09eSw==
   dependencies:
     "@nicolo-ribaudo/eslint-scope-5-internals" "5.1.1-v1"
     eslint-visitor-keys "^2.1.0"
@@ -209,9 +221,9 @@
     semver "^6.3.1"
 
 "@babel/helper-create-class-features-plugin@^7.22.15", "@babel/helper-create-class-features-plugin@^7.23.6", "@babel/helper-create-class-features-plugin@^7.8.3":
-  version "7.23.10"
-  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.23.10.tgz#25d55fafbaea31fd0e723820bb6cc3df72edf7ea"
-  integrity sha512-2XpP2XhkXzgxecPNEEK8Vz8Asj9aRxt08oKOqtiZoqV2UGZ5T+EkyP9sXQ9nwMxBIG34a7jmasVqoMop7VdPUw==
+  version "7.23.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.23.7.tgz#b2e6826e0e20d337143655198b79d58fdc9bd43d"
+  integrity sha512-xCoqR/8+BoNnXOY7RVSgv6X+o7pmT5q1d+gGcRlXYkI+9B31glE4jeejhKVpA04O1AtzOt7OSQ6VYKP5FcRl9g==
   dependencies:
     "@babel/helper-annotate-as-pure" "^7.22.5"
     "@babel/helper-environment-visitor" "^7.22.20"
@@ -231,6 +243,17 @@
     "@babel/helper-annotate-as-pure" "^7.22.5"
     regexpu-core "^5.3.1"
     semver "^6.3.1"
+
+"@babel/helper-define-polyfill-provider@^0.4.4":
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.4.4.tgz#64df615451cb30e94b59a9696022cffac9a10088"
+  integrity sha512-QcJMILQCu2jm5TFPGA3lCpJJTeEP+mqeXooG/NZbg/h5FTFi6V0+99ahlRsW8/kRLyb24LZVCCiclDedhLKcBA==
+  dependencies:
+    "@babel/helper-compilation-targets" "^7.22.6"
+    "@babel/helper-plugin-utils" "^7.22.5"
+    debug "^4.1.1"
+    lodash.debounce "^4.0.8"
+    resolve "^1.14.2"
 
 "@babel/helper-define-polyfill-provider@^0.5.0":
   version "0.5.0"
@@ -363,7 +386,16 @@
     "@babel/template" "^7.22.15"
     "@babel/types" "^7.22.19"
 
-"@babel/helpers@^7.12.1", "@babel/helpers@^7.23.9", "@babel/helpers@^7.9.0", "@babel/helpers@^7.9.6":
+"@babel/helpers@^7.12.1", "@babel/helpers@^7.23.7", "@babel/helpers@^7.9.0", "@babel/helpers@^7.9.6":
+  version "7.23.8"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.23.8.tgz#fc6b2d65b16847fd50adddbd4232c76378959e34"
+  integrity sha512-KDqYz4PiOWvDFrdHLPhKtCThtIcKVy6avWD2oG4GEvyQ+XDZwHD4YQd+H2vNMnq2rkdxsDkU82T+Vk8U/WXHRQ==
+  dependencies:
+    "@babel/template" "^7.22.15"
+    "@babel/traverse" "^7.23.7"
+    "@babel/types" "^7.23.6"
+
+"@babel/helpers@^7.23.9":
   version "7.23.9"
   resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.23.9.tgz#c3e20bbe7f7a7e10cb9b178384b4affdf5995c7d"
   integrity sha512-87ICKgU5t5SzOT7sBMfCOZQ2rHjRU+Pcb9BoILMYz600W6DkVRLFBPwQ18gwUVvggqXivaUakpnxWQGbpywbBQ==
@@ -381,7 +413,12 @@
     chalk "^2.4.2"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.1.0", "@babel/parser@^7.12.3", "@babel/parser@^7.14.7", "@babel/parser@^7.20.7", "@babel/parser@^7.23.0", "@babel/parser@^7.23.9", "@babel/parser@^7.7.0", "@babel/parser@^7.9.0", "@babel/parser@^7.9.6":
+"@babel/parser@^7.1.0", "@babel/parser@^7.12.3", "@babel/parser@^7.14.7", "@babel/parser@^7.20.7", "@babel/parser@^7.22.15", "@babel/parser@^7.23.6", "@babel/parser@^7.7.0", "@babel/parser@^7.9.0", "@babel/parser@^7.9.6":
+  version "7.23.6"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.23.6.tgz#ba1c9e512bda72a47e285ae42aff9d2a635a9e3b"
+  integrity sha512-Z2uID7YJ7oNvAI20O9X0bblw7Qqs8Q2hFy0R9tAfnfLkp5MW0UH9eUvnDSnFwKZ0AvgS1ucqR4KzvVHgnke1VQ==
+
+"@babel/parser@^7.23.0", "@babel/parser@^7.23.9":
   version "7.23.9"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.23.9.tgz#7b903b6149b0f8fa7ad564af646c4c38a77fc44b"
   integrity sha512-9tcKgqKbs3xGJ+NtKF2ndOBBLVwPjl1SHxPQkd36r3Dlirw3xWUeGaTbqr7uGZcTaxkVNwc+03SVP7aCdWrTlA==
@@ -710,6 +747,16 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.22.5"
 
+"@babel/plugin-transform-async-generator-functions@^7.23.7":
+  version "7.23.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.23.7.tgz#3aa0b4f2fa3788b5226ef9346cf6d16ec61f99cd"
+  integrity sha512-PdxEpL71bJp1byMG0va5gwQcXHxuEYC/BgI/e88mGTtohbZN28O5Yit0Plkkm/dBzCF/BxmbNcses1RH1T+urA==
+  dependencies:
+    "@babel/helper-environment-visitor" "^7.22.20"
+    "@babel/helper-plugin-utils" "^7.22.5"
+    "@babel/helper-remap-async-to-generator" "^7.22.20"
+    "@babel/plugin-syntax-async-generators" "^7.8.4"
+
 "@babel/plugin-transform-async-generator-functions@^7.23.9":
   version "7.23.9"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.23.9.tgz#9adaeb66fc9634a586c5df139c6240d41ed801ce"
@@ -908,7 +955,17 @@
     "@babel/helper-plugin-utils" "^7.22.5"
     "@babel/helper-simple-access" "^7.22.5"
 
-"@babel/plugin-transform-modules-systemjs@^7.23.9", "@babel/plugin-transform-modules-systemjs@^7.9.0":
+"@babel/plugin-transform-modules-systemjs@^7.23.3", "@babel/plugin-transform-modules-systemjs@^7.9.0":
+  version "7.23.3"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.23.3.tgz#fa7e62248931cb15b9404f8052581c302dd9de81"
+  integrity sha512-ZxyKGTkF9xT9YJuKQRo19ewf3pXpopuYQd8cDXqNzc3mUNbOME0RKMoZxviQk74hwzfQsEe66dE92MaZbdHKNQ==
+  dependencies:
+    "@babel/helper-hoist-variables" "^7.22.5"
+    "@babel/helper-module-transforms" "^7.23.3"
+    "@babel/helper-plugin-utils" "^7.22.5"
+    "@babel/helper-validator-identifier" "^7.22.20"
+
+"@babel/plugin-transform-modules-systemjs@^7.23.9":
   version "7.23.9"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.23.9.tgz#105d3ed46e4a21d257f83a2f9e2ee4203ceda6be"
   integrity sha512-KDlPRM6sLo4o1FkiSlXoAa8edLXFsKKIda779fbLrvmeuc3itnjCtaO6RrtoaANsIJANj+Vk1zqbZIMhkCAHVw==
@@ -1198,7 +1255,7 @@
     "@babel/helper-create-regexp-features-plugin" "^7.22.15"
     "@babel/helper-plugin-utils" "^7.22.5"
 
-"@babel/preset-env@7.23.9", "@babel/preset-env@^7.11.0", "@babel/preset-env@^7.12.1", "@babel/preset-env@^7.23.2", "@babel/preset-env@^7.8.4":
+"@babel/preset-env@7.23.9", "@babel/preset-env@^7.23.2":
   version "7.23.9"
   resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.23.9.tgz#beace3b7994560ed6bf78e4ae2073dff45387669"
   integrity sha512-3kBGTNBBk9DQiPoXYS0g0BYlwTQYUTifqgKTjxUwEUkduRT2QOa0FPGBJ+NROQhGyYO5BuTJwGvBnqKDykac6A==
@@ -1350,6 +1407,92 @@
     levenary "^1.1.1"
     semver "^5.5.0"
 
+"@babel/preset-env@^7.11.0", "@babel/preset-env@^7.12.1", "@babel/preset-env@^7.8.4":
+  version "7.23.8"
+  resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.23.8.tgz#7d6f8171ea7c221ecd28059e65ad37c20e441e3e"
+  integrity sha512-lFlpmkApLkEP6woIKprO6DO60RImpatTQKtz4sUcDjVcK8M8mQ4sZsuxaTMNOZf0sqAq/ReYW1ZBHnOQwKpLWA==
+  dependencies:
+    "@babel/compat-data" "^7.23.5"
+    "@babel/helper-compilation-targets" "^7.23.6"
+    "@babel/helper-plugin-utils" "^7.22.5"
+    "@babel/helper-validator-option" "^7.23.5"
+    "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression" "^7.23.3"
+    "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining" "^7.23.3"
+    "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly" "^7.23.7"
+    "@babel/plugin-proposal-private-property-in-object" "7.21.0-placeholder-for-preset-env.2"
+    "@babel/plugin-syntax-async-generators" "^7.8.4"
+    "@babel/plugin-syntax-class-properties" "^7.12.13"
+    "@babel/plugin-syntax-class-static-block" "^7.14.5"
+    "@babel/plugin-syntax-dynamic-import" "^7.8.3"
+    "@babel/plugin-syntax-export-namespace-from" "^7.8.3"
+    "@babel/plugin-syntax-import-assertions" "^7.23.3"
+    "@babel/plugin-syntax-import-attributes" "^7.23.3"
+    "@babel/plugin-syntax-import-meta" "^7.10.4"
+    "@babel/plugin-syntax-json-strings" "^7.8.3"
+    "@babel/plugin-syntax-logical-assignment-operators" "^7.10.4"
+    "@babel/plugin-syntax-nullish-coalescing-operator" "^7.8.3"
+    "@babel/plugin-syntax-numeric-separator" "^7.10.4"
+    "@babel/plugin-syntax-object-rest-spread" "^7.8.3"
+    "@babel/plugin-syntax-optional-catch-binding" "^7.8.3"
+    "@babel/plugin-syntax-optional-chaining" "^7.8.3"
+    "@babel/plugin-syntax-private-property-in-object" "^7.14.5"
+    "@babel/plugin-syntax-top-level-await" "^7.14.5"
+    "@babel/plugin-syntax-unicode-sets-regex" "^7.18.6"
+    "@babel/plugin-transform-arrow-functions" "^7.23.3"
+    "@babel/plugin-transform-async-generator-functions" "^7.23.7"
+    "@babel/plugin-transform-async-to-generator" "^7.23.3"
+    "@babel/plugin-transform-block-scoped-functions" "^7.23.3"
+    "@babel/plugin-transform-block-scoping" "^7.23.4"
+    "@babel/plugin-transform-class-properties" "^7.23.3"
+    "@babel/plugin-transform-class-static-block" "^7.23.4"
+    "@babel/plugin-transform-classes" "^7.23.8"
+    "@babel/plugin-transform-computed-properties" "^7.23.3"
+    "@babel/plugin-transform-destructuring" "^7.23.3"
+    "@babel/plugin-transform-dotall-regex" "^7.23.3"
+    "@babel/plugin-transform-duplicate-keys" "^7.23.3"
+    "@babel/plugin-transform-dynamic-import" "^7.23.4"
+    "@babel/plugin-transform-exponentiation-operator" "^7.23.3"
+    "@babel/plugin-transform-export-namespace-from" "^7.23.4"
+    "@babel/plugin-transform-for-of" "^7.23.6"
+    "@babel/plugin-transform-function-name" "^7.23.3"
+    "@babel/plugin-transform-json-strings" "^7.23.4"
+    "@babel/plugin-transform-literals" "^7.23.3"
+    "@babel/plugin-transform-logical-assignment-operators" "^7.23.4"
+    "@babel/plugin-transform-member-expression-literals" "^7.23.3"
+    "@babel/plugin-transform-modules-amd" "^7.23.3"
+    "@babel/plugin-transform-modules-commonjs" "^7.23.3"
+    "@babel/plugin-transform-modules-systemjs" "^7.23.3"
+    "@babel/plugin-transform-modules-umd" "^7.23.3"
+    "@babel/plugin-transform-named-capturing-groups-regex" "^7.22.5"
+    "@babel/plugin-transform-new-target" "^7.23.3"
+    "@babel/plugin-transform-nullish-coalescing-operator" "^7.23.4"
+    "@babel/plugin-transform-numeric-separator" "^7.23.4"
+    "@babel/plugin-transform-object-rest-spread" "^7.23.4"
+    "@babel/plugin-transform-object-super" "^7.23.3"
+    "@babel/plugin-transform-optional-catch-binding" "^7.23.4"
+    "@babel/plugin-transform-optional-chaining" "^7.23.4"
+    "@babel/plugin-transform-parameters" "^7.23.3"
+    "@babel/plugin-transform-private-methods" "^7.23.3"
+    "@babel/plugin-transform-private-property-in-object" "^7.23.4"
+    "@babel/plugin-transform-property-literals" "^7.23.3"
+    "@babel/plugin-transform-regenerator" "^7.23.3"
+    "@babel/plugin-transform-reserved-words" "^7.23.3"
+    "@babel/plugin-transform-shorthand-properties" "^7.23.3"
+    "@babel/plugin-transform-spread" "^7.23.3"
+    "@babel/plugin-transform-sticky-regex" "^7.23.3"
+    "@babel/plugin-transform-template-literals" "^7.23.3"
+    "@babel/plugin-transform-typeof-symbol" "^7.23.3"
+    "@babel/plugin-transform-unicode-escapes" "^7.23.3"
+    "@babel/plugin-transform-unicode-property-regex" "^7.23.3"
+    "@babel/plugin-transform-unicode-regex" "^7.23.3"
+    "@babel/plugin-transform-unicode-sets-regex" "^7.23.3"
+    "@babel/preset-modules" "0.1.6-no-external-plugins"
+    babel-plugin-polyfill-corejs2 "^0.4.7"
+    babel-plugin-polyfill-corejs3 "^0.8.7"
+    babel-plugin-polyfill-regenerator "^0.5.4"
+    core-js-compat "^3.31.0"
+    semver "^6.3.1"
+
 "@babel/preset-flow@^7.22.15":
   version "7.23.3"
   resolved "https://registry.yarnpkg.com/@babel/preset-flow/-/preset-flow-7.23.3.tgz#8084e08b9ccec287bd077ab288b286fab96ffab1"
@@ -1451,9 +1594,9 @@
   integrity sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA==
 
 "@babel/runtime-corejs3@^7.10.2":
-  version "7.23.9"
-  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.23.9.tgz#1b43062a13ecb60158aecdd81bc3fab4108b7cbc"
-  integrity sha512-oeOFTrYWdWXCvXGB5orvMTJ6gCZ9I6FBjR+M38iKNXCsPxr4xT0RTdg5uz1H7QP8pp74IzPtwritEr+JscqHXQ==
+  version "7.23.8"
+  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.23.8.tgz#b8aa3d47570bdd08fed77fdfd69542118af0df26"
+  integrity sha512-2ZzmcDugdm0/YQKFVYsXiwUN7USPX8PM7cytpb4PFl87fM+qYPSvTZX//8tyeJB1j0YDmafBJEbl5f8NfLyuKw==
   dependencies:
     core-js-pure "^3.30.2"
     regenerator-runtime "^0.14.0"
@@ -1466,13 +1609,22 @@
     regenerator-runtime "^0.13.4"
 
 "@babel/runtime@^7.0.0", "@babel/runtime@^7.10.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.13", "@babel/runtime@^7.12.5", "@babel/runtime@^7.13.10", "@babel/runtime@^7.14.6", "@babel/runtime@^7.14.8", "@babel/runtime@^7.17.2", "@babel/runtime@^7.17.8", "@babel/runtime@^7.18.6", "@babel/runtime@^7.2.0", "@babel/runtime@^7.21.0", "@babel/runtime@^7.23.2", "@babel/runtime@^7.3.4", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
-  version "7.23.9"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.23.9.tgz#47791a15e4603bb5f905bc0753801cf21d6345f7"
-  integrity sha512-0CX6F+BI2s9dkUqr08KFrAIZgNFj75rdBU/DjCyYLIaV/quFjkk6T+EJ2LkZHyZTbEV4L5p97mNkUsHl2wLFAw==
+  version "7.23.8"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.23.8.tgz#8ee6fe1ac47add7122902f257b8ddf55c898f650"
+  integrity sha512-Y7KbAP984rn1VGMbGqKmBLio9V7y5Je9GvU4rQPCPinCyNfUcToxIXl06d59URp/F3LwinvODxab5N/G6qggkw==
   dependencies:
     regenerator-runtime "^0.14.0"
 
-"@babel/template@^7.10.4", "@babel/template@^7.22.15", "@babel/template@^7.23.9", "@babel/template@^7.3.3", "@babel/template@^7.8.6":
+"@babel/template@^7.10.4", "@babel/template@^7.22.15", "@babel/template@^7.3.3", "@babel/template@^7.8.6":
+  version "7.22.15"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.22.15.tgz#09576efc3830f0430f4548ef971dde1350ef2f38"
+  integrity sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==
+  dependencies:
+    "@babel/code-frame" "^7.22.13"
+    "@babel/parser" "^7.22.15"
+    "@babel/types" "^7.22.15"
+
+"@babel/template@^7.23.9":
   version "7.23.9"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.23.9.tgz#f881d0487cba2828d3259dcb9ef5005a9731011a"
   integrity sha512-+xrD2BWLpvHKNmX2QbpdpsBaWnRxahMwJjO+KZk2JOElj5nSmKezyS1B4u+QbHMTX69t4ukm6hh9lsYQ7GHCKA==
@@ -1481,7 +1633,23 @@
     "@babel/parser" "^7.23.9"
     "@babel/types" "^7.23.9"
 
-"@babel/traverse@^7.1.0", "@babel/traverse@^7.12.1", "@babel/traverse@^7.18.9", "@babel/traverse@^7.23.2", "@babel/traverse@^7.23.9", "@babel/traverse@^7.7.0", "@babel/traverse@^7.7.2", "@babel/traverse@^7.9.0", "@babel/traverse@^7.9.6":
+"@babel/traverse@^7.1.0", "@babel/traverse@^7.12.1", "@babel/traverse@^7.23.7", "@babel/traverse@^7.7.0", "@babel/traverse@^7.7.2", "@babel/traverse@^7.9.0", "@babel/traverse@^7.9.6":
+  version "7.23.7"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.23.7.tgz#9a7bf285c928cb99b5ead19c3b1ce5b310c9c305"
+  integrity sha512-tY3mM8rH9jM0YHFGyfC0/xf+SB5eKUu7HPj7/k3fpi9dAlsMc5YbQvDi0Sh2QTPXqMhyaAtzAr807TIyfQrmyg==
+  dependencies:
+    "@babel/code-frame" "^7.23.5"
+    "@babel/generator" "^7.23.6"
+    "@babel/helper-environment-visitor" "^7.22.20"
+    "@babel/helper-function-name" "^7.23.0"
+    "@babel/helper-hoist-variables" "^7.22.5"
+    "@babel/helper-split-export-declaration" "^7.22.6"
+    "@babel/parser" "^7.23.6"
+    "@babel/types" "^7.23.6"
+    debug "^4.3.1"
+    globals "^11.1.0"
+
+"@babel/traverse@^7.18.9", "@babel/traverse@^7.23.2", "@babel/traverse@^7.23.9":
   version "7.23.9"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.23.9.tgz#2f9d6aead6b564669394c5ce0f9302bb65b9d950"
   integrity sha512-I/4UJ9vs90OkBtY6iiiTORVMyIhJ4kAVmsKo9KFc8UOxMeUfi2hvtIBsET5u9GizXE6/GFSuKCTNfgCswuEjRg==
@@ -1497,7 +1665,16 @@
     debug "^4.3.1"
     globals "^11.1.0"
 
-"@babel/types@^7.0.0", "@babel/types@^7.12.1", "@babel/types@^7.12.6", "@babel/types@^7.18.9", "@babel/types@^7.20.7", "@babel/types@^7.22.15", "@babel/types@^7.22.19", "@babel/types@^7.22.5", "@babel/types@^7.23.0", "@babel/types@^7.23.4", "@babel/types@^7.23.6", "@babel/types@^7.23.9", "@babel/types@^7.3.3", "@babel/types@^7.4.4", "@babel/types@^7.7.0", "@babel/types@^7.9.0", "@babel/types@^7.9.6":
+"@babel/types@^7.0.0", "@babel/types@^7.12.1", "@babel/types@^7.12.6", "@babel/types@^7.20.7", "@babel/types@^7.22.15", "@babel/types@^7.22.19", "@babel/types@^7.22.5", "@babel/types@^7.23.0", "@babel/types@^7.23.4", "@babel/types@^7.23.6", "@babel/types@^7.3.3", "@babel/types@^7.4.4", "@babel/types@^7.7.0", "@babel/types@^7.9.0", "@babel/types@^7.9.6":
+  version "7.23.6"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.23.6.tgz#be33fdb151e1f5a56877d704492c240fc71c7ccd"
+  integrity sha512-+uarb83brBzPKN38NX1MkB6vb6+mwvR6amUulqAE7ccQw1pEl+bCia9TbdG1lsnFP7lZySvUn37CHyXQdfTwzg==
+  dependencies:
+    "@babel/helper-string-parser" "^7.23.4"
+    "@babel/helper-validator-identifier" "^7.22.20"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.18.9", "@babel/types@^7.23.9":
   version "7.23.9"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.23.9.tgz#1dd7b59a9a2b5c87f8b41e52770b5ecbf492e002"
   integrity sha512-dQjSq/7HaSjRM43FFGnv5keM2HsxpmyV1PfaSVm0nzzjwwTmjOe6J4bC8e3+pTEIgHaHj+1ZlLThRJ2auc/w1Q==
@@ -1553,9 +1730,9 @@
     "@lezer/json" "^1.0.0"
 
 "@codemirror/language@^6.0.0":
-  version "6.10.1"
-  resolved "https://registry.yarnpkg.com/@codemirror/language/-/language-6.10.1.tgz#428c932a158cb75942387acfe513c1ece1090b05"
-  integrity sha512-5GrXzrhq6k+gL5fjkAwt90nYDmjlzTIJV8THnxNFtNKWotMIlzzN+CpqxqwXOECnUdOndmSeWntVrVcv5axWRQ==
+  version "6.10.0"
+  resolved "https://registry.yarnpkg.com/@codemirror/language/-/language-6.10.0.tgz#2d0e818716825ee2ed0dacd04595eaa61bae8f23"
+  integrity sha512-2vaNn9aPGCRFKWcHPFksctzJ8yS5p7YoaT+jHpc0UGKzNuAIx4qy6R5wiqbP+heEEdyaABA582mNqSHzSoYdmg==
   dependencies:
     "@codemirror/state" "^6.0.0"
     "@codemirror/view" "^6.23.0"
@@ -1565,18 +1742,18 @@
     style-mod "^4.0.0"
 
 "@codemirror/lint@^6.0.0":
-  version "6.5.0"
-  resolved "https://registry.yarnpkg.com/@codemirror/lint/-/lint-6.5.0.tgz#ea43b6e653dcc5bcd93456b55e9fe62e63f326d9"
-  integrity sha512-+5YyicIaaAZKU8K43IQi8TBy6mF6giGeWAH7N96Z5LC30Wm5JMjqxOYIE9mxwMG1NbhT2mA3l9hA4uuKUM3E5g==
+  version "6.4.2"
+  resolved "https://registry.yarnpkg.com/@codemirror/lint/-/lint-6.4.2.tgz#c13be5320bde9707efdc94e8bcd3c698abae0b92"
+  integrity sha512-wzRkluWb1ptPKdzlsrbwwjYCPLgzU6N88YBAmlZi8WFyuiEduSd05MnJYNogzyc8rPK7pj6m95ptUApc8sHKVA==
   dependencies:
     "@codemirror/state" "^6.0.0"
     "@codemirror/view" "^6.0.0"
     crelt "^1.0.5"
 
 "@codemirror/search@^6.0.0":
-  version "6.5.6"
-  resolved "https://registry.yarnpkg.com/@codemirror/search/-/search-6.5.6.tgz#8f858b9e678d675869112e475f082d1e8488db93"
-  integrity sha512-rpMgcsh7o0GuCDUXKPvww+muLA1pDJaFrpq/CCHtpQJYz8xopu4D1hPcKRoDD0YlF8gZaqTNIRa4VRBWyhyy7Q==
+  version "6.5.5"
+  resolved "https://registry.yarnpkg.com/@codemirror/search/-/search-6.5.5.tgz#cf97e201da364da2285c2a250167af25bbd2a4a2"
+  integrity sha512-PIEN3Ke1buPod2EHbJsoQwlbpkz30qGZKcnmH1eihq9+bPQx8gelauUwLYaY4vBOuBAuEhmpDLii4rj/uO0yMA==
   dependencies:
     "@codemirror/state" "^6.0.0"
     "@codemirror/view" "^6.0.0"
@@ -1598,9 +1775,9 @@
     "@lezer/highlight" "^1.0.0"
 
 "@codemirror/view@^6.0.0", "@codemirror/view@^6.17.0", "@codemirror/view@^6.23.0":
-  version "6.24.0"
-  resolved "https://registry.yarnpkg.com/@codemirror/view/-/view-6.24.0.tgz#2f780290a54cfe571b1a1468c47b483de0cf6fb2"
-  integrity sha512-zK6m5pNkdhdJl8idPP1gA4N8JKTiSsOz8U/Iw+C1ChMwyLG7+MLiNXnH/wFuAk6KeGEe33/adOiAh5jMqee03w==
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/@codemirror/view/-/view-6.23.0.tgz#8054a2043273abad7f1587d15accb0623e1960ed"
+  integrity sha512-/51px9N4uW8NpuWkyUX+iam5+PM6io2fm+QmRnzwqBy5v/pwGg9T0kILFtYeum8hjuvENtgsGNKluOfqIICmeQ==
   dependencies:
     "@codemirror/state" "^6.4.0"
     style-mod "^4.1.0"
@@ -1634,66 +1811,66 @@
   dependencies:
     conventional-changelog-conventionalcommits "^7.0.2"
 
-"@commitlint/config-validator@^18.6.1":
-  version "18.6.1"
-  resolved "https://registry.yarnpkg.com/@commitlint/config-validator/-/config-validator-18.6.1.tgz#e0d71a99c984a68586c7ae7afd3f52342022fae8"
-  integrity sha512-05uiToBVfPhepcQWE1ZQBR/Io3+tb3gEotZjnI4tTzzPk16NffN6YABgwFQCLmzZefbDcmwWqJWc2XT47q7Znw==
+"@commitlint/config-validator@^18.5.0":
+  version "18.5.0"
+  resolved "https://registry.yarnpkg.com/@commitlint/config-validator/-/config-validator-18.5.0.tgz#3ddd3f94001ebbc5a61c7190fa7a51fab289690f"
+  integrity sha512-mDAA6WQPjh9Ida8ACdInDylBQcqeUD2gBHE+dQu+B3OIHiWiSSrq4F2+wg3nDU9EzfcQSwPwYL+QbMmiW5SmLA==
   dependencies:
-    "@commitlint/types" "^18.6.1"
+    "@commitlint/types" "^18.4.4"
     ajv "^8.11.0"
 
-"@commitlint/ensure@^18.6.1":
-  version "18.6.1"
-  resolved "https://registry.yarnpkg.com/@commitlint/ensure/-/ensure-18.6.1.tgz#17141e083200ca94d8480dc23b0e8f8b1fd37b7f"
-  integrity sha512-BPm6+SspyxQ7ZTsZwXc7TRQL5kh5YWt3euKmEIBZnocMFkJevqs3fbLRb8+8I/cfbVcAo4mxRlpTPfz8zX7SnQ==
+"@commitlint/ensure@^18.4.4":
+  version "18.4.4"
+  resolved "https://registry.yarnpkg.com/@commitlint/ensure/-/ensure-18.4.4.tgz#5e142e489e32f6a22865cea05ca369a95a4b77a1"
+  integrity sha512-KjD19p6julB5WrQL+Cd8p+AePwpl1XzGAjB0jnuFMKWtji9L7ucCZUKDstGjlkBZGGzH/nvdB8K+bh5K27EVUg==
   dependencies:
-    "@commitlint/types" "^18.6.1"
+    "@commitlint/types" "^18.4.4"
     lodash.camelcase "^4.3.0"
     lodash.kebabcase "^4.1.1"
     lodash.snakecase "^4.1.1"
     lodash.startcase "^4.4.0"
     lodash.upperfirst "^4.3.1"
 
-"@commitlint/execute-rule@^18.6.1":
-  version "18.6.1"
-  resolved "https://registry.yarnpkg.com/@commitlint/execute-rule/-/execute-rule-18.6.1.tgz#18175e043fe6fb5fceea7b8530316c644f93dfe6"
-  integrity sha512-7s37a+iWyJiGUeMFF6qBlyZciUkF8odSAnHijbD36YDctLhGKoYltdvuJ/AFfRm6cBLRtRk9cCVPdsEFtt/2rg==
+"@commitlint/execute-rule@^18.4.4":
+  version "18.4.4"
+  resolved "https://registry.yarnpkg.com/@commitlint/execute-rule/-/execute-rule-18.4.4.tgz#ade986742c1944c8162a54288747e54a8c6146b5"
+  integrity sha512-a37Nd3bDQydtg9PCLLWM9ZC+GO7X5i4zJvrggJv5jBhaHsXeQ9ZWdO6ODYR+f0LxBXXNYK3geYXJrCWUCP8JEg==
 
 "@commitlint/format@^18.4.4":
-  version "18.6.1"
-  resolved "https://registry.yarnpkg.com/@commitlint/format/-/format-18.6.1.tgz#5f2b8b3ae4d8d80bd9239178e97df63e5b8d280a"
-  integrity sha512-K8mNcfU/JEFCharj2xVjxGSF+My+FbUHoqR+4GqPGrHNqXOGNio47ziiR4HQUPKtiNs05o8/WyLBoIpMVOP7wg==
+  version "18.4.4"
+  resolved "https://registry.yarnpkg.com/@commitlint/format/-/format-18.4.4.tgz#51996ba0a7eac14f7f8991cff8700e4a2fd86ba7"
+  integrity sha512-2v3V5hVlv0R3pe7p66IX5F7cjeVvGM5JqITRIbBCFvGHPJ/CG74rjTkAu0RBEiIhlk3eOaLjVGq3d5falPkLBA==
   dependencies:
-    "@commitlint/types" "^18.6.1"
+    "@commitlint/types" "^18.4.4"
     chalk "^4.1.0"
 
-"@commitlint/is-ignored@^18.6.1":
-  version "18.6.1"
-  resolved "https://registry.yarnpkg.com/@commitlint/is-ignored/-/is-ignored-18.6.1.tgz#4ee08ba91ff3defb06e0ef19259a9c6734a8d06e"
-  integrity sha512-MOfJjkEJj/wOaPBw5jFjTtfnx72RGwqYIROABudOtJKW7isVjFe9j0t8xhceA02QebtYf4P/zea4HIwnXg8rvA==
+"@commitlint/is-ignored@^18.4.4":
+  version "18.4.4"
+  resolved "https://registry.yarnpkg.com/@commitlint/is-ignored/-/is-ignored-18.4.4.tgz#3fbf2a55a960ccf037e79ad4610091a693800680"
+  integrity sha512-rXWes9owKBTjfTr6Od7YlflRg4N+ngkOH+dUZhk0qL/XQb26mHz0EgVgdixMVBac1OsohRwJaLmVHX+5F6vfmg==
   dependencies:
-    "@commitlint/types" "^18.6.1"
-    semver "7.6.0"
+    "@commitlint/types" "^18.4.4"
+    semver "7.5.4"
 
 "@commitlint/lint@^18.5.0":
-  version "18.6.1"
-  resolved "https://registry.yarnpkg.com/@commitlint/lint/-/lint-18.6.1.tgz#fe3834636c99ee14534a8eb3832831ac362e9fd8"
-  integrity sha512-8WwIFo3jAuU+h1PkYe5SfnIOzp+TtBHpFr4S8oJWhu44IWKuVx6GOPux3+9H1iHOan/rGBaiacicZkMZuluhfQ==
+  version "18.5.0"
+  resolved "https://registry.yarnpkg.com/@commitlint/lint/-/lint-18.5.0.tgz#83c7434e969d04aaa84c5129c17b3dcde33d4650"
+  integrity sha512-4VbfTGTZf/aDaOn+vednMQFu5EIKfERvv7j8La3etQCra0O2QMrZL28xugTroYekawpTkiWWvLswtpVfabIbgw==
   dependencies:
-    "@commitlint/is-ignored" "^18.6.1"
-    "@commitlint/parse" "^18.6.1"
-    "@commitlint/rules" "^18.6.1"
-    "@commitlint/types" "^18.6.1"
+    "@commitlint/is-ignored" "^18.4.4"
+    "@commitlint/parse" "^18.4.4"
+    "@commitlint/rules" "^18.4.4"
+    "@commitlint/types" "^18.4.4"
 
 "@commitlint/load@^18.5.0":
-  version "18.6.1"
-  resolved "https://registry.yarnpkg.com/@commitlint/load/-/load-18.6.1.tgz#fb79ed7ee8b5897a9b5c274c1e24eda9162df816"
-  integrity sha512-p26x8734tSXUHoAw0ERIiHyW4RaI4Bj99D8YgUlVV9SedLf8hlWAfyIFhHRIhfPngLlCe0QYOdRKYFt8gy56TA==
+  version "18.5.0"
+  resolved "https://registry.yarnpkg.com/@commitlint/load/-/load-18.5.0.tgz#b14eef9306c2500594d8a7f1e4a8d68cb2562439"
+  integrity sha512-vpyGgk7rzbFsU01NVwPNC/WetHFP0EwSYnQ1R833SJFHkEo+cWvqoVlw/VoZwBMoI6sF5/lwEdKzFDr1DHJ6+A==
   dependencies:
-    "@commitlint/config-validator" "^18.6.1"
-    "@commitlint/execute-rule" "^18.6.1"
-    "@commitlint/resolve-extends" "^18.6.1"
-    "@commitlint/types" "^18.6.1"
+    "@commitlint/config-validator" "^18.5.0"
+    "@commitlint/execute-rule" "^18.4.4"
+    "@commitlint/resolve-extends" "^18.5.0"
+    "@commitlint/types" "^18.4.4"
     chalk "^4.1.0"
     cosmiconfig "^8.3.6"
     cosmiconfig-typescript-loader "^5.0.0"
@@ -1702,69 +1879,69 @@
     lodash.uniq "^4.5.0"
     resolve-from "^5.0.0"
 
-"@commitlint/message@^18.6.1":
-  version "18.6.1"
-  resolved "https://registry.yarnpkg.com/@commitlint/message/-/message-18.6.1.tgz#107bd40923ad23d2de56c92a68b179ebfb7e314e"
-  integrity sha512-VKC10UTMLcpVjMIaHHsY1KwhuTQtdIKPkIdVEwWV+YuzKkzhlI3aNy6oo1eAN6b/D2LTtZkJe2enHmX0corYRw==
+"@commitlint/message@^18.4.4":
+  version "18.4.4"
+  resolved "https://registry.yarnpkg.com/@commitlint/message/-/message-18.4.4.tgz#811682a0d147a24e5c467acdb52071434df2b9f5"
+  integrity sha512-lHF95mMDYgAI1LBXveJUyg4eLaMXyOqJccCK3v55ZOEUsMPrDi8upqDjd/NmzWmESYihaOMBTAnxm+6oD1WoDQ==
 
-"@commitlint/parse@^18.6.1":
-  version "18.6.1"
-  resolved "https://registry.yarnpkg.com/@commitlint/parse/-/parse-18.6.1.tgz#2946b814125e907b9c4d63d3e71d0c1b54b30b62"
-  integrity sha512-eS/3GREtvVJqGZrwAGRwR9Gdno3YcZ6Xvuaa+vUF8j++wsmxrA2En3n0ccfVO2qVOLJC41ni7jSZhQiJpMPGOQ==
+"@commitlint/parse@^18.4.4":
+  version "18.4.4"
+  resolved "https://registry.yarnpkg.com/@commitlint/parse/-/parse-18.4.4.tgz#5c8f515d4dbebe9b7ccfcd1701e58446e2bec6da"
+  integrity sha512-99G7dyn/OoyNWXJni0Ki0K3aJd01pEb/Im/Id6y4X7PN+kGOahjz2z/cXYYHn7xDdooqFVdiVrVLeChfgpWZ2g==
   dependencies:
-    "@commitlint/types" "^18.6.1"
+    "@commitlint/types" "^18.4.4"
     conventional-changelog-angular "^7.0.0"
     conventional-commits-parser "^5.0.0"
 
 "@commitlint/read@^18.4.4":
-  version "18.6.1"
-  resolved "https://registry.yarnpkg.com/@commitlint/read/-/read-18.6.1.tgz#8c138311ed9749427920c369f6276be136f2aa50"
-  integrity sha512-ia6ODaQFzXrVul07ffSgbZGFajpe8xhnDeLIprLeyfz3ivQU1dIoHp7yz0QIorZ6yuf4nlzg4ZUkluDrGN/J/w==
+  version "18.4.4"
+  resolved "https://registry.yarnpkg.com/@commitlint/read/-/read-18.4.4.tgz#7f6848edd3210bf82e6aaa0cd30e72e7e669e009"
+  integrity sha512-r58JbWky4gAFPea/CZmvlqP9Ehbs+8gSEUqhIJOojKzTc3xlxFnZUDVPcEnnaqzQEEoV6C69VW7xuzdcBlu/FQ==
   dependencies:
-    "@commitlint/top-level" "^18.6.1"
-    "@commitlint/types" "^18.6.1"
+    "@commitlint/top-level" "^18.4.4"
+    "@commitlint/types" "^18.4.4"
     git-raw-commits "^2.0.11"
     minimist "^1.2.6"
 
-"@commitlint/resolve-extends@^18.6.1":
-  version "18.6.1"
-  resolved "https://registry.yarnpkg.com/@commitlint/resolve-extends/-/resolve-extends-18.6.1.tgz#f0572c682fc24dbabe2e0f42873261e0fa42c91a"
-  integrity sha512-ifRAQtHwK+Gj3Bxj/5chhc4L2LIc3s30lpsyW67yyjsETR6ctHAHRu1FSpt0KqahK5xESqoJ92v6XxoDRtjwEQ==
+"@commitlint/resolve-extends@^18.5.0":
+  version "18.5.0"
+  resolved "https://registry.yarnpkg.com/@commitlint/resolve-extends/-/resolve-extends-18.5.0.tgz#ea955fc9455f70a5389cdc9633c78132c8008ed2"
+  integrity sha512-OxCYOMnlkOEEIkwTaRiFjHyuWBq962WBZQVHfMHej8tr3d+SfjznvqZhPmW8/SuqtfmGEiJPGWUNOxgwH+O0MA==
   dependencies:
-    "@commitlint/config-validator" "^18.6.1"
-    "@commitlint/types" "^18.6.1"
+    "@commitlint/config-validator" "^18.5.0"
+    "@commitlint/types" "^18.4.4"
     import-fresh "^3.0.0"
     lodash.mergewith "^4.6.2"
     resolve-from "^5.0.0"
     resolve-global "^1.0.0"
 
-"@commitlint/rules@^18.6.1":
-  version "18.6.1"
-  resolved "https://registry.yarnpkg.com/@commitlint/rules/-/rules-18.6.1.tgz#da25aeffe6c0e1c7625e44f46089fb8860986caf"
-  integrity sha512-kguM6HxZDtz60v/zQYOe0voAtTdGybWXefA1iidjWYmyUUspO1zBPQEmJZ05/plIAqCVyNUTAiRPWIBKLCrGew==
+"@commitlint/rules@^18.4.4":
+  version "18.4.4"
+  resolved "https://registry.yarnpkg.com/@commitlint/rules/-/rules-18.4.4.tgz#859e920a4f0053ae27e4cdd65f68e7576a5ab53f"
+  integrity sha512-6Uzlsnl/GljEI+80NWjf4ThOfR8NIsbm18IfXYuCEchlwMHSxiuYG4rHSK5DNmG/+MIo8eR5VdQ0gQyt7kWzAA==
   dependencies:
-    "@commitlint/ensure" "^18.6.1"
-    "@commitlint/message" "^18.6.1"
-    "@commitlint/to-lines" "^18.6.1"
-    "@commitlint/types" "^18.6.1"
+    "@commitlint/ensure" "^18.4.4"
+    "@commitlint/message" "^18.4.4"
+    "@commitlint/to-lines" "^18.4.4"
+    "@commitlint/types" "^18.4.4"
     execa "^5.0.0"
 
-"@commitlint/to-lines@^18.6.1":
-  version "18.6.1"
-  resolved "https://registry.yarnpkg.com/@commitlint/to-lines/-/to-lines-18.6.1.tgz#d28827a4a540c98eea1aae31dafd66f80b2f1b9e"
-  integrity sha512-Gl+orGBxYSNphx1+83GYeNy5N0dQsHBQ9PJMriaLQDB51UQHCVLBT/HBdOx5VaYksivSf5Os55TLePbRLlW50Q==
+"@commitlint/to-lines@^18.4.4":
+  version "18.4.4"
+  resolved "https://registry.yarnpkg.com/@commitlint/to-lines/-/to-lines-18.4.4.tgz#546cf8d985459f3526359b6a63d7a5b421e1ed60"
+  integrity sha512-mwe2Roa59NCz/krniAdCygFabg7+fQCkIhXqBHw00XQ8Y7lw4poZLLxeGI3p3bLpcEOXdqIDrEGLwHmG5lBdwQ==
 
-"@commitlint/top-level@^18.6.1":
-  version "18.6.1"
-  resolved "https://registry.yarnpkg.com/@commitlint/top-level/-/top-level-18.6.1.tgz#429fcb985e3beaba9b17e05c0ae61926c647baf0"
-  integrity sha512-HyiHQZUTf0+r0goTCDs/bbVv/LiiQ7AVtz6KIar+8ZrseB9+YJAIo8HQ2IC2QT1y3N1lbW6OqVEsTHjbT6hGSw==
+"@commitlint/top-level@^18.4.4":
+  version "18.4.4"
+  resolved "https://registry.yarnpkg.com/@commitlint/top-level/-/top-level-18.4.4.tgz#df69ffa49fdc4541d1f05e814352d575fb0f3b0d"
+  integrity sha512-PBwW1drgeavl9CadB7IPRUk6rkUP/O8jEkxjlC+ofuh3pw0bzJdAT+Kw7M1Yc9KtTb9xTaqUB8uvRtaybHa/tQ==
   dependencies:
     find-up "^5.0.0"
 
-"@commitlint/types@^18.4.4", "@commitlint/types@^18.6.1":
-  version "18.6.1"
-  resolved "https://registry.yarnpkg.com/@commitlint/types/-/types-18.6.1.tgz#7eb3ab2d799d9166fbb98b96b0744581e59a4ad4"
-  integrity sha512-gwRLBLra/Dozj2OywopeuHj2ac26gjGkz2cZ+86cTJOdtWfiRRr4+e77ZDAGc6MDWxaWheI+mAV5TLWWRwqrFg==
+"@commitlint/types@^18.4.4":
+  version "18.4.4"
+  resolved "https://registry.yarnpkg.com/@commitlint/types/-/types-18.4.4.tgz#dae9e0ce6a6728a36b8982ff301af0170bbe0d38"
+  integrity sha512-/FykLtodD8gKs3+VNkAUwofu4LBHankclj+I8fB2jTRvG6PV7k/OUt4P+VbM7ip853qS4F0g7Z6hLNa6JeMcAQ==
   dependencies:
     chalk "^4.1.0"
 
@@ -1812,100 +1989,191 @@
   integrity sha512-e2OQlbOHMPZCI6BMA3OkTgOszPs2dhkbm+EXlllhBqmIvCOzLuA5iOGfoCEddkCqM8VHI+Zhdumq8XnFtSF+Jw==
 
 "@contentful/contentful-slatejs-adapter@^15.13.1", "@contentful/contentful-slatejs-adapter@^15.16.5":
-  version "15.16.12"
-  resolved "https://registry.yarnpkg.com/@contentful/contentful-slatejs-adapter/-/contentful-slatejs-adapter-15.16.12.tgz#aa65e092a15877d9ca9b8adcaa0d577e176f05be"
-  integrity sha512-rB554D3CaJjZ80Z/rCtr5un7XNUL4UPYJzfm1e+dHzWl71p7gor+uOkmzZuQHq0xG+zF5dTqwdr9Sqh2OveSQA==
+  version "15.16.8"
+  resolved "https://registry.yarnpkg.com/@contentful/contentful-slatejs-adapter/-/contentful-slatejs-adapter-15.16.8.tgz#1df8401551f658afae6639a380219e350dd654b9"
+  integrity sha512-5Ix5uEOl7XB3FiikEcV2Y1qkJXAKfSGPTNAQLBd624URJKZh+Q+PkWVqrdATUMO2LD1YekaTeBlJNdFK2PhriQ==
   dependencies:
-    "@contentful/rich-text-types" "^16.3.4"
+    "@contentful/rich-text-types" "^16.3.0"
 
-"@contentful/f36-accordion@^4.57.0", "@contentful/f36-accordion@^4.59.3":
-  version "4.59.3"
-  resolved "https://registry.yarnpkg.com/@contentful/f36-accordion/-/f36-accordion-4.59.3.tgz#de0a39ff318e8c1f531b6fe3aacf03058b37126f"
-  integrity sha512-yiNSuWlCHMzpyP3Lks5A80LFVoCdssjYHgam/9UuLSHldx0sg84/O63Ito+tlcQDR+m0JwS+xlr7QjpqRBXkSQ==
+"@contentful/f36-accordion@^4.57.0", "@contentful/f36-accordion@^4.58.4":
+  version "4.58.4"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-accordion/-/f36-accordion-4.58.4.tgz#76e2845f3db8af5976d0b53e7e8bcc34b60707c7"
+  integrity sha512-yXDi12ZF5YLcdlMLxyhRptuYUYAmAICQv3Zxgq6Jx8lBZfwSjyNQvuZsqy+vCQ1P3gHaCnzM56M9PB6Op2hLXQ==
   dependencies:
-    "@contentful/f36-collapse" "^4.59.3"
-    "@contentful/f36-core" "^4.59.3"
+    "@contentful/f36-collapse" "^4.58.4"
+    "@contentful/f36-core" "^4.58.4"
     "@contentful/f36-icons" "^4.27.0"
     "@contentful/f36-tokens" "^4.0.4"
-    "@contentful/f36-typography" "^4.59.3"
+    "@contentful/f36-typography" "^4.58.4"
     emotion "^10.0.17"
 
-"@contentful/f36-asset@^4.57.0", "@contentful/f36-asset@^4.59.3":
-  version "4.59.3"
-  resolved "https://registry.yarnpkg.com/@contentful/f36-asset/-/f36-asset-4.59.3.tgz#5d234eb7cc48e2078f840975fe21f032ee8fdd83"
-  integrity sha512-G07cPOtvO3vZVrawS2sqRtnJFTukXtYenjHwheXMHwOJWUwvQFtKgiIUriLVSoiDlQtEc1r1Po8jXwnQTTQBBw==
+"@contentful/f36-accordion@^4.60.0":
+  version "4.60.0"
+  resolved "https://npm.pkg.github.com/download/@contentful/f36-accordion/4.60.0/868e0fea89425a99720f56371bf175ac364c28ed#868e0fea89425a99720f56371bf175ac364c28ed"
+  integrity sha512-oAX1LIUwFcmFIJRvgbjYEwiZDT7XwGRZ37bwBMkoTRrMgrXTGSEdNxLnjpSUco6pxAIt393vyycbxcNEBTUKDA==
   dependencies:
-    "@contentful/f36-core" "^4.59.3"
-    "@contentful/f36-icon" "^4.59.3"
+    "@contentful/f36-collapse" "^4.60.0"
+    "@contentful/f36-core" "^4.60.0"
     "@contentful/f36-icons" "^4.27.0"
     "@contentful/f36-tokens" "^4.0.4"
-    "@contentful/f36-typography" "^4.59.3"
+    "@contentful/f36-typography" "^4.60.0"
     emotion "^10.0.17"
 
-"@contentful/f36-autocomplete@^4.57.0", "@contentful/f36-autocomplete@^4.59.3":
-  version "4.59.3"
-  resolved "https://registry.yarnpkg.com/@contentful/f36-autocomplete/-/f36-autocomplete-4.59.3.tgz#a6d6253e69f01407a61fff6e40d0b53bd303099e"
-  integrity sha512-erDzdAgyBcxA5uXqLEWiTiDU15zolGZn1MjTIML4IlAYARo3W/4y7wqJ/BehCfs7stA1qWzQ8wOvefjIsHuT/Q==
+"@contentful/f36-asset@^4.57.0", "@contentful/f36-asset@^4.58.4":
+  version "4.58.4"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-asset/-/f36-asset-4.58.4.tgz#69401cf3e6bf3e6e4a1c752f9934dbd68ff1e331"
+  integrity sha512-+QE+xORpWR2+J/muMUC6bZScOiMqI0jwNqNAdItErzzsrzRkknS+ZE1UCuoM8VrWC/NBmmiX41hqwP/3qaoj2A==
   dependencies:
-    "@contentful/f36-button" "^4.59.3"
-    "@contentful/f36-core" "^4.59.3"
-    "@contentful/f36-forms" "^4.59.3"
+    "@contentful/f36-core" "^4.58.4"
+    "@contentful/f36-icon" "^4.58.4"
     "@contentful/f36-icons" "^4.27.0"
-    "@contentful/f36-popover" "^4.59.3"
-    "@contentful/f36-skeleton" "^4.59.3"
     "@contentful/f36-tokens" "^4.0.4"
-    "@contentful/f36-typography" "^4.59.3"
+    "@contentful/f36-typography" "^4.58.4"
+    emotion "^10.0.17"
+
+"@contentful/f36-asset@^4.60.0":
+  version "4.60.0"
+  resolved "https://npm.pkg.github.com/download/@contentful/f36-asset/4.60.0/455104d3b885e488ab91bd47c81c967ba7204f4f#455104d3b885e488ab91bd47c81c967ba7204f4f"
+  integrity sha512-93oH0l5whXCIWnK50WBzmnzEFTMzddgVdoLySbZj+fJcfD4dX7GGSNg5JOi9uJwIlZjCLLWlwS4G7QuwFLiX0Q==
+  dependencies:
+    "@contentful/f36-core" "^4.60.0"
+    "@contentful/f36-icon" "^4.60.0"
+    "@contentful/f36-icons" "^4.27.0"
+    "@contentful/f36-tokens" "^4.0.4"
+    "@contentful/f36-typography" "^4.60.0"
+    emotion "^10.0.17"
+
+"@contentful/f36-autocomplete@^4.57.0", "@contentful/f36-autocomplete@^4.58.4":
+  version "4.58.4"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-autocomplete/-/f36-autocomplete-4.58.4.tgz#53494832d38f2b6a6d588f644b5a73337b56a5cd"
+  integrity sha512-dfK6iaAFWDewlYAfpx8mUzmE8MOQrKCe7IILCf35Le29dRY7M162oJCQmvFnwVBLYuZW3OaTRHIH8UbWMDjKbQ==
+  dependencies:
+    "@contentful/f36-button" "^4.58.4"
+    "@contentful/f36-core" "^4.58.4"
+    "@contentful/f36-forms" "^4.58.4"
+    "@contentful/f36-icons" "^4.27.0"
+    "@contentful/f36-popover" "^4.58.4"
+    "@contentful/f36-skeleton" "^4.58.4"
+    "@contentful/f36-tokens" "^4.0.4"
+    "@contentful/f36-typography" "^4.58.4"
     "@contentful/f36-utils" "^4.24.3"
     downshift "^6.1.12"
     emotion "^10.0.17"
 
-"@contentful/f36-badge@^4.57.0", "@contentful/f36-badge@^4.59.3":
-  version "4.59.3"
-  resolved "https://registry.yarnpkg.com/@contentful/f36-badge/-/f36-badge-4.59.3.tgz#fa894131e0ab0522e86f443bae636e9a01ddb1a5"
-  integrity sha512-dED7wqVX6VhgG089cfTk5kOZhRWbu3g1cqjo5+GXMRs9W+AMsYmtyjRbKWEeWQzSPiXR67pfp+fccOvOXZEMUw==
+"@contentful/f36-autocomplete@^4.60.0":
+  version "4.60.0"
+  resolved "https://npm.pkg.github.com/download/@contentful/f36-autocomplete/4.60.0/ca98fc707b6a2050dbc2bd15ed5d6d2cf716408c#ca98fc707b6a2050dbc2bd15ed5d6d2cf716408c"
+  integrity sha512-sFf0mQuss52RcBoHo2NBfceVrMqgvv1TJUPqfImXBIFZiIeI5xRl+R0Rgt6Qc8nH9WG4lg6oYzQgrZOxEnbkzA==
   dependencies:
-    "@contentful/f36-core" "^4.59.3"
+    "@contentful/f36-button" "^4.60.0"
+    "@contentful/f36-core" "^4.60.0"
+    "@contentful/f36-forms" "^4.60.0"
+    "@contentful/f36-icons" "^4.27.0"
+    "@contentful/f36-popover" "^4.60.0"
+    "@contentful/f36-skeleton" "^4.60.0"
+    "@contentful/f36-tokens" "^4.0.4"
+    "@contentful/f36-typography" "^4.60.0"
+    "@contentful/f36-utils" "^4.24.3"
+    downshift "^6.1.12"
+    emotion "^10.0.17"
+
+"@contentful/f36-badge@^4.57.0", "@contentful/f36-badge@^4.58.4":
+  version "4.58.4"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-badge/-/f36-badge-4.58.4.tgz#9d3e02504ec6fce9e619ce38514f1b3d348c6f75"
+  integrity sha512-kkb5Bswrir412l49NKbx59QF1Gq45vWmOInph3sAEEesYjxt2orCD/Zi5KK3SDqIFvs7vFXhBvdm02CzRgyyow==
+  dependencies:
+    "@contentful/f36-core" "^4.58.4"
     "@contentful/f36-icons" "^4.27.0"
     "@contentful/f36-tokens" "^4.0.4"
     emotion "^10.0.17"
 
-"@contentful/f36-button@^4.57.0", "@contentful/f36-button@^4.59.3":
-  version "4.59.3"
-  resolved "https://registry.yarnpkg.com/@contentful/f36-button/-/f36-button-4.59.3.tgz#2e093ef1fbec01d75f507808c8588aca1d01530e"
-  integrity sha512-dQfdC6JQNpt8hq6O6FuCT/vrk7y1glpCIaey28HhflNGgdsq2MIA4nPm8hgrJc63VJNBZKXtx3N7mCvKqOxPjg==
+"@contentful/f36-badge@^4.60.0":
+  version "4.60.0"
+  resolved "https://npm.pkg.github.com/download/@contentful/f36-badge/4.60.0/dbfad7478a48ded4db52609818678755ac7e0c07#dbfad7478a48ded4db52609818678755ac7e0c07"
+  integrity sha512-tUceZPFS8/ynENGUKcw1tVSisIW3xrhH7S9QB5JRSSaL1ccOLT3AVZQjIxm5MmHUw2l1EhSZngpEPFZyHvWEdQ==
   dependencies:
-    "@contentful/f36-core" "^4.59.3"
-    "@contentful/f36-spinner" "^4.59.3"
+    "@contentful/f36-core" "^4.60.0"
+    "@contentful/f36-icons" "^4.27.0"
+    "@contentful/f36-tokens" "^4.0.4"
+    emotion "^10.0.17"
+
+"@contentful/f36-button@^4.57.0", "@contentful/f36-button@^4.58.4":
+  version "4.58.4"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-button/-/f36-button-4.58.4.tgz#a6b32d2948b541010c2051c882c6195a04a51ef6"
+  integrity sha512-NgQNcgoQn5oG7sGQBT4srBEnbBKYJntHzp7j2zxlCnsb4t8/v0qbkwBLKCtTTdIz2CHHjxKBA/jhia4Mx27/dg==
+  dependencies:
+    "@contentful/f36-core" "^4.58.4"
+    "@contentful/f36-spinner" "^4.58.4"
     "@contentful/f36-tokens" "^4.0.4"
     "@contentful/f36-utils" "^4.24.3"
     emotion "^10.0.17"
 
-"@contentful/f36-card@^4.57.0", "@contentful/f36-card@^4.59.3":
-  version "4.59.3"
-  resolved "https://registry.yarnpkg.com/@contentful/f36-card/-/f36-card-4.59.3.tgz#7e096fe3ef6b1b0ba3e29d754c70f6e39421ba3b"
-  integrity sha512-nCaL1DfwY9aSmjJKPBz9Uix8hf4Af288pW6P07piKQcNvL9oGhFO1c1rQlWCA4j8+cvxcklgolwmhWa9y9suAw==
+"@contentful/f36-button@^4.60.0":
+  version "4.60.0"
+  resolved "https://npm.pkg.github.com/download/@contentful/f36-button/4.60.0/834e78c44b1c690d716e6b3a42a99e7a7dd20356#834e78c44b1c690d716e6b3a42a99e7a7dd20356"
+  integrity sha512-F4wAzsW8FR1bZBVdj3MI6l9/ugAJfouROaBihaCCLV+ebpqYB9Yg5urv304ZHl3vXA71n3/D39LGTasxBTuIVg==
   dependencies:
-    "@contentful/f36-asset" "^4.59.3"
-    "@contentful/f36-badge" "^4.59.3"
-    "@contentful/f36-button" "^4.59.3"
-    "@contentful/f36-core" "^4.59.3"
-    "@contentful/f36-drag-handle" "^4.59.3"
-    "@contentful/f36-icon" "^4.59.3"
-    "@contentful/f36-icons" "^4.27.0"
-    "@contentful/f36-menu" "^4.59.3"
-    "@contentful/f36-skeleton" "^4.59.3"
+    "@contentful/f36-core" "^4.60.0"
+    "@contentful/f36-spinner" "^4.60.0"
     "@contentful/f36-tokens" "^4.0.4"
-    "@contentful/f36-tooltip" "^4.59.3"
-    "@contentful/f36-typography" "^4.59.3"
+    "@contentful/f36-utils" "^4.24.3"
+    emotion "^10.0.17"
+
+"@contentful/f36-card@^4.57.0", "@contentful/f36-card@^4.58.4":
+  version "4.58.4"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-card/-/f36-card-4.58.4.tgz#b8a5294a8d17f84478fd842775acc18c41485e82"
+  integrity sha512-6vfO4LfM3Y7HEDjIP/tR8rMmmjer0FuDL5AHEodFDMcodQeJjClhE/Yh38udW0ISJrrm60yqbrUPdcohF3qd6w==
+  dependencies:
+    "@contentful/f36-asset" "^4.58.4"
+    "@contentful/f36-badge" "^4.58.4"
+    "@contentful/f36-button" "^4.58.4"
+    "@contentful/f36-core" "^4.58.4"
+    "@contentful/f36-drag-handle" "^4.58.4"
+    "@contentful/f36-icon" "^4.58.4"
+    "@contentful/f36-icons" "^4.27.0"
+    "@contentful/f36-menu" "^4.58.4"
+    "@contentful/f36-skeleton" "^4.58.4"
+    "@contentful/f36-tokens" "^4.0.4"
+    "@contentful/f36-tooltip" "^4.58.4"
+    "@contentful/f36-typography" "^4.58.4"
     emotion "^10.0.17"
     truncate "^3.0.0"
 
-"@contentful/f36-collapse@^4.57.0", "@contentful/f36-collapse@^4.59.3":
-  version "4.59.3"
-  resolved "https://registry.yarnpkg.com/@contentful/f36-collapse/-/f36-collapse-4.59.3.tgz#03ec33badcd1b4d779f7d040420f13521417e77a"
-  integrity sha512-htMO60Pm6AtgWQtdh6FqeRcwBxPm5CYJFg3m9SMQgFog4NsMK5nBm7Lm1JwiVxL1BgMPFihx6UkZP0gIJkP2WQ==
+"@contentful/f36-card@^4.60.0":
+  version "4.60.0"
+  resolved "https://npm.pkg.github.com/download/@contentful/f36-card/4.60.0/32c46e8262b0da6307d912c0751ded32b42520d7#32c46e8262b0da6307d912c0751ded32b42520d7"
+  integrity sha512-bl5BmrYipIZVSQARfKz8e6Ujgkb0pjCMfX2lM/2GslfNre3IlUJhv2/d4Cq7eatfhioMbQpk5lblV/wORvsAkw==
   dependencies:
-    "@contentful/f36-core" "^4.59.3"
+    "@contentful/f36-asset" "^4.60.0"
+    "@contentful/f36-badge" "^4.60.0"
+    "@contentful/f36-button" "^4.60.0"
+    "@contentful/f36-core" "^4.60.0"
+    "@contentful/f36-drag-handle" "^4.60.0"
+    "@contentful/f36-icon" "^4.60.0"
+    "@contentful/f36-icons" "^4.27.0"
+    "@contentful/f36-menu" "^4.60.0"
+    "@contentful/f36-skeleton" "^4.60.0"
+    "@contentful/f36-tokens" "^4.0.4"
+    "@contentful/f36-tooltip" "^4.60.0"
+    "@contentful/f36-typography" "^4.60.0"
+    emotion "^10.0.17"
+    truncate "^3.0.0"
+
+"@contentful/f36-collapse@^4.57.0", "@contentful/f36-collapse@^4.58.4":
+  version "4.58.4"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-collapse/-/f36-collapse-4.58.4.tgz#876488f019911ab7483eec95b528d433df9097b5"
+  integrity sha512-yKiVlWFyRTjRFIBOp8f0IxnpDxuhXmZbpjNfycrQV53kMNCK4wYw5JZMFWyZVMCcqxucbDnnbckMCBVdCqRkfw==
+  dependencies:
+    "@contentful/f36-core" "^4.58.4"
+    "@contentful/f36-tokens" "^4.0.4"
+    emotion "^10.0.17"
+
+"@contentful/f36-collapse@^4.60.0":
+  version "4.60.0"
+  resolved "https://npm.pkg.github.com/download/@contentful/f36-collapse/4.60.0/1c43cd75de9af6eef5b2613dee27b7628e4b6733#1c43cd75de9af6eef5b2613dee27b7628e4b6733"
+  integrity sha512-Q5Jk7irONzrfOpSFw5C+Xdh//dVU4ismnaGEVi1mk+DgMvAR8AkVrcuP5jgeAVX7zk/ZSFzzlNc+1WBWEAIFQQ==
+  dependencies:
+    "@contentful/f36-core" "^4.60.0"
     "@contentful/f36-tokens" "^4.0.4"
     emotion "^10.0.17"
 
@@ -1951,62 +2219,115 @@
     "@contentful/f36-utils" "^4.24.2"
 
 "@contentful/f36-components@^4.0.27", "@contentful/f36-components@^4.0.33", "@contentful/f36-components@^4.20.6", "@contentful/f36-components@^4.3.23", "@contentful/f36-components@^4.34.1":
-  version "4.59.3"
-  resolved "https://registry.yarnpkg.com/@contentful/f36-components/-/f36-components-4.59.3.tgz#23e1db4d6f0b0ff0bbfc3318795369e5c860e59c"
-  integrity sha512-2nR3d5Dasrr+23XWiT02hY1np6YFTVo8lJhBbz4NVNxzovIq1YCH56GaHR6HngQdeURzV9Pu83SKkJWvCrCJ7Q==
+  version "4.58.4"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-components/-/f36-components-4.58.4.tgz#390a225db8f7109090f10fa0309c90f0f49607f3"
+  integrity sha512-FkETZ4URxDWr197h3Fen4Inps75BdktODgENgyFT3Edufj6IfrdvKh20AT5EnyiS5K8kQIpbEw7ZFI+lMsbaWw==
   dependencies:
-    "@contentful/f36-accordion" "^4.59.3"
-    "@contentful/f36-asset" "^4.59.3"
-    "@contentful/f36-autocomplete" "^4.59.3"
-    "@contentful/f36-badge" "^4.59.3"
-    "@contentful/f36-button" "^4.59.3"
-    "@contentful/f36-card" "^4.59.3"
-    "@contentful/f36-collapse" "^4.59.3"
-    "@contentful/f36-copybutton" "^4.59.3"
-    "@contentful/f36-core" "^4.59.3"
-    "@contentful/f36-datepicker" "^4.59.3"
-    "@contentful/f36-datetime" "^4.59.3"
-    "@contentful/f36-drag-handle" "^4.59.3"
-    "@contentful/f36-empty-state" "^4.59.3"
-    "@contentful/f36-entity-list" "^4.59.3"
-    "@contentful/f36-forms" "^4.59.3"
-    "@contentful/f36-icon" "^4.59.3"
+    "@contentful/f36-accordion" "^4.58.4"
+    "@contentful/f36-asset" "^4.58.4"
+    "@contentful/f36-autocomplete" "^4.58.4"
+    "@contentful/f36-badge" "^4.58.4"
+    "@contentful/f36-button" "^4.58.4"
+    "@contentful/f36-card" "^4.58.4"
+    "@contentful/f36-collapse" "^4.58.4"
+    "@contentful/f36-copybutton" "^4.58.4"
+    "@contentful/f36-core" "^4.58.4"
+    "@contentful/f36-datepicker" "^4.58.4"
+    "@contentful/f36-datetime" "^4.58.4"
+    "@contentful/f36-drag-handle" "^4.58.4"
+    "@contentful/f36-empty-state" "^4.58.4"
+    "@contentful/f36-entity-list" "^4.58.4"
+    "@contentful/f36-forms" "^4.58.4"
+    "@contentful/f36-icon" "^4.58.4"
     "@contentful/f36-icons" "^4.27.0"
-    "@contentful/f36-list" "^4.59.3"
-    "@contentful/f36-menu" "^4.59.3"
-    "@contentful/f36-modal" "^4.59.3"
+    "@contentful/f36-list" "^4.58.4"
+    "@contentful/f36-menu" "^4.58.4"
+    "@contentful/f36-modal" "^4.58.4"
     "@contentful/f36-navbar" "^4.1.0"
-    "@contentful/f36-note" "^4.59.3"
-    "@contentful/f36-notification" "^4.59.3"
-    "@contentful/f36-pagination" "^4.59.3"
-    "@contentful/f36-pill" "^4.59.3"
-    "@contentful/f36-popover" "^4.59.3"
-    "@contentful/f36-skeleton" "^4.59.3"
-    "@contentful/f36-spinner" "^4.59.3"
-    "@contentful/f36-table" "^4.59.3"
-    "@contentful/f36-tabs" "^4.59.3"
-    "@contentful/f36-text-link" "^4.59.3"
+    "@contentful/f36-note" "^4.58.4"
+    "@contentful/f36-notification" "^4.58.4"
+    "@contentful/f36-pagination" "^4.58.4"
+    "@contentful/f36-pill" "^4.58.4"
+    "@contentful/f36-popover" "^4.58.4"
+    "@contentful/f36-skeleton" "^4.58.4"
+    "@contentful/f36-spinner" "^4.58.4"
+    "@contentful/f36-table" "^4.58.4"
+    "@contentful/f36-tabs" "^4.58.4"
+    "@contentful/f36-text-link" "^4.58.4"
     "@contentful/f36-tokens" "^4.0.4"
-    "@contentful/f36-tooltip" "^4.59.3"
-    "@contentful/f36-typography" "^4.59.3"
+    "@contentful/f36-tooltip" "^4.58.4"
+    "@contentful/f36-typography" "^4.58.4"
     "@contentful/f36-utils" "^4.24.3"
 
-"@contentful/f36-copybutton@^4.57.0", "@contentful/f36-copybutton@^4.59.3":
-  version "4.59.3"
-  resolved "https://registry.yarnpkg.com/@contentful/f36-copybutton/-/f36-copybutton-4.59.3.tgz#c77e35f2245a51929c76af288bda95be0742b7cf"
-  integrity sha512-JbyqCFw6KjHDQD5BdggCm4lGFi14HlIhOqvjWmvHwlt4XuEjvNy/uS8C5cPav1eB6ykdMdwp6anJDZ28bUXfBw==
+"@contentful/f36-components@^4.60.0":
+  version "4.60.0"
+  resolved "https://npm.pkg.github.com/download/@contentful/f36-components/4.60.0/4bf2ac0f40074b564d6d5ff7a3252e65871dfd17#4bf2ac0f40074b564d6d5ff7a3252e65871dfd17"
+  integrity sha512-9vDuLm0hQJPyKG+XpBle41AXRzRDcLqPl10HZ19bA+E/K1Pen9XFfkqH3qZqigF/peEyGJvzYomAmr2PCfJGRA==
   dependencies:
-    "@contentful/f36-button" "^4.59.3"
-    "@contentful/f36-core" "^4.59.3"
+    "@contentful/f36-accordion" "^4.60.0"
+    "@contentful/f36-asset" "^4.60.0"
+    "@contentful/f36-autocomplete" "^4.60.0"
+    "@contentful/f36-badge" "^4.60.0"
+    "@contentful/f36-button" "^4.60.0"
+    "@contentful/f36-card" "^4.60.0"
+    "@contentful/f36-collapse" "^4.60.0"
+    "@contentful/f36-copybutton" "^4.60.0"
+    "@contentful/f36-core" "^4.60.0"
+    "@contentful/f36-datepicker" "^4.60.0"
+    "@contentful/f36-datetime" "^4.60.0"
+    "@contentful/f36-drag-handle" "^4.60.0"
+    "@contentful/f36-empty-state" "^4.60.0"
+    "@contentful/f36-entity-list" "^4.60.0"
+    "@contentful/f36-forms" "^4.60.0"
+    "@contentful/f36-icon" "^4.60.0"
+    "@contentful/f36-icons" "^4.27.0"
+    "@contentful/f36-list" "^4.60.0"
+    "@contentful/f36-menu" "^4.60.0"
+    "@contentful/f36-modal" "^4.60.0"
+    "@contentful/f36-navbar" "^4.1.0"
+    "@contentful/f36-note" "^4.60.0"
+    "@contentful/f36-notification" "^4.60.0"
+    "@contentful/f36-pagination" "^4.60.0"
+    "@contentful/f36-pill" "^4.60.0"
+    "@contentful/f36-popover" "^4.60.0"
+    "@contentful/f36-skeleton" "^4.60.0"
+    "@contentful/f36-spinner" "^4.60.0"
+    "@contentful/f36-table" "^4.60.0"
+    "@contentful/f36-tabs" "^4.60.0"
+    "@contentful/f36-text-link" "^4.60.0"
+    "@contentful/f36-tokens" "^4.0.4"
+    "@contentful/f36-tooltip" "^4.60.0"
+    "@contentful/f36-typography" "^4.60.0"
+    "@contentful/f36-utils" "^4.24.3"
+
+"@contentful/f36-copybutton@^4.57.0", "@contentful/f36-copybutton@^4.58.4":
+  version "4.58.4"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-copybutton/-/f36-copybutton-4.58.4.tgz#ea2b55fb64b81a0b2d0e47eb83d07b5fd3b09aa0"
+  integrity sha512-92W5DiExrNjDm+6fcQGp3ENWfdy5XXgxIk7zAAiAK6zZwXZ2TpSiTICgxvI1tJrybqpcGzLTCXQpnrbDlVggFQ==
+  dependencies:
+    "@contentful/f36-button" "^4.58.4"
+    "@contentful/f36-core" "^4.58.4"
     "@contentful/f36-icons" "^4.27.0"
     "@contentful/f36-tokens" "^4.0.4"
-    "@contentful/f36-tooltip" "^4.59.3"
+    "@contentful/f36-tooltip" "^4.58.4"
     emotion "^10.0.17"
 
-"@contentful/f36-core@^4.45.0", "@contentful/f36-core@^4.48.0", "@contentful/f36-core@^4.57.0", "@contentful/f36-core@^4.59.3":
-  version "4.59.3"
-  resolved "https://registry.yarnpkg.com/@contentful/f36-core/-/f36-core-4.59.3.tgz#38b4cf441000a1d9893447cdcb77e5685cb795b3"
-  integrity sha512-KWuRPFtBd3HXO1hL6VBokSQ6SC6JsnwKB7L8ukmCKuo3CeW+C7u4jlbOkLVtlvmTHwDphD+oqDJu67zdJ2EYVw==
+"@contentful/f36-copybutton@^4.60.0":
+  version "4.60.0"
+  resolved "https://npm.pkg.github.com/download/@contentful/f36-copybutton/4.60.0/5a7e222a6790c5103d95ba60150ec065f9a9331f#5a7e222a6790c5103d95ba60150ec065f9a9331f"
+  integrity sha512-fkxC4bk4YDH/GKjC0Djg/wLCgrvvoOVP+Fcx21Vogf1jlSmnJN4Ju3yOzdDKT8vPoKLlDNWRz3CbYHmH2rdqvA==
+  dependencies:
+    "@contentful/f36-button" "^4.60.0"
+    "@contentful/f36-core" "^4.60.0"
+    "@contentful/f36-icons" "^4.27.0"
+    "@contentful/f36-tokens" "^4.0.4"
+    "@contentful/f36-tooltip" "^4.60.0"
+    emotion "^10.0.17"
+
+"@contentful/f36-core@^4.45.0", "@contentful/f36-core@^4.48.0", "@contentful/f36-core@^4.57.0", "@contentful/f36-core@^4.58.4":
+  version "4.58.4"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-core/-/f36-core-4.58.4.tgz#c6d57fc0d809869e16c31b1d00f1086ff0ac40aa"
+  integrity sha512-RUEl6TrC5fMZB50GACl75nk6GWI595wucTFXHlgWXYW6+qHcjJ+77/h+egkdNKzeXPsZGcX6tsYDOt58/RoAtA==
   dependencies:
     "@contentful/f36-tokens" "^4.0.4"
     "@emotion/core" "^10.1.1"
@@ -2014,88 +2335,184 @@
     csstype "^3.1.1"
     emotion "^10.0.17"
 
-"@contentful/f36-datepicker@^4.57.0", "@contentful/f36-datepicker@^4.59.3":
-  version "4.59.3"
-  resolved "https://registry.yarnpkg.com/@contentful/f36-datepicker/-/f36-datepicker-4.59.3.tgz#66b54cca2f2ffd4db060135abc8431702662bbe1"
-  integrity sha512-rI5N3gPgBcQEp14UIMsok42+Omu2Waw9iyggX+3BMdmLfA4pz4WovYKWQekLlUZAnvqGINatT0KJIDIN7JCMpw==
+"@contentful/f36-core@^4.60.0":
+  version "4.60.0"
+  resolved "https://npm.pkg.github.com/download/@contentful/f36-core/4.60.0/fcd13bb7c7882c924ffe1910453bed58fe704b71#fcd13bb7c7882c924ffe1910453bed58fe704b71"
+  integrity sha512-gJhZzmgjb+6jljgofnQnuaz5s2dP+tSeHzlpIzppW2KbFNvZfk408jbIZn9Ny2xw9LodXcEiFTuCewyYVQ7Dzw==
   dependencies:
-    "@contentful/f36-button" "^4.59.3"
-    "@contentful/f36-core" "^4.59.3"
-    "@contentful/f36-forms" "^4.59.3"
-    "@contentful/f36-icons" "^4.27.0"
-    "@contentful/f36-popover" "^4.59.3"
     "@contentful/f36-tokens" "^4.0.4"
-    "@contentful/f36-typography" "^4.59.3"
+    "@emotion/core" "^10.1.1"
+    "@emotion/is-prop-valid" "^1.2.0"
+    csstype "^3.1.1"
+    emotion "^10.0.17"
+
+"@contentful/f36-datepicker@^4.57.0", "@contentful/f36-datepicker@^4.58.4":
+  version "4.58.4"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-datepicker/-/f36-datepicker-4.58.4.tgz#9c99aa36a43c0df6bcb15b0656af293e78cf0cfa"
+  integrity sha512-wHDubFxjKUgn3oWeGCoD9dXMkK0lbRMRigY3jPnl98Mce1aGw0092fRM8iJflh1k2UqbLQppAVOGpucJcMc3Sg==
+  dependencies:
+    "@contentful/f36-button" "^4.58.4"
+    "@contentful/f36-core" "^4.58.4"
+    "@contentful/f36-forms" "^4.58.4"
+    "@contentful/f36-icons" "^4.27.0"
+    "@contentful/f36-popover" "^4.58.4"
+    "@contentful/f36-tokens" "^4.0.4"
+    "@contentful/f36-typography" "^4.58.4"
     date-fns "^2.28.0"
     emotion "^10.0.17"
     react-day-picker "^8.7.1"
     react-focus-lock "^2.9.1"
 
-"@contentful/f36-datetime@^4.57.0", "@contentful/f36-datetime@^4.59.3":
-  version "4.59.3"
-  resolved "https://registry.yarnpkg.com/@contentful/f36-datetime/-/f36-datetime-4.59.3.tgz#08d7dc8944c03cd4a8c317dbd178930c826e0522"
-  integrity sha512-bPThNC/j4BSlILGxTAb8k/ivAFXSh2nFUkooKQWuh3RgKQzEOqoIH4sYZOafBc96foHqp+U7J+ywkl2PdZ4gLw==
+"@contentful/f36-datepicker@^4.60.0":
+  version "4.60.0"
+  resolved "https://npm.pkg.github.com/download/@contentful/f36-datepicker/4.60.0/3e673b96a5b1220c699adc5f950fd6616603f17f#3e673b96a5b1220c699adc5f950fd6616603f17f"
+  integrity sha512-mnXYlPRy0nMaS3REoV86nSc/iJ1QuX43gz5msFxqz4ZHazjYYgXa0fk48Qd5WNpUC1jXbW2H0rGX84o2Aa5BFA==
   dependencies:
-    "@contentful/f36-core" "^4.59.3"
+    "@contentful/f36-button" "^4.60.0"
+    "@contentful/f36-core" "^4.60.0"
+    "@contentful/f36-forms" "^4.60.0"
+    "@contentful/f36-icons" "^4.27.0"
+    "@contentful/f36-popover" "^4.60.0"
+    "@contentful/f36-tokens" "^4.0.4"
+    "@contentful/f36-typography" "^4.60.0"
+    date-fns "^2.28.0"
+    emotion "^10.0.17"
+    react-day-picker "^8.7.1"
+    react-focus-lock "^2.9.1"
+
+"@contentful/f36-datetime@^4.57.0", "@contentful/f36-datetime@^4.58.4":
+  version "4.58.4"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-datetime/-/f36-datetime-4.58.4.tgz#da912725fd3a90873564acd1af9bf82fd8332791"
+  integrity sha512-Rx/OKXfs2CTPHhzDanB6zs6pOYrbxghATGf+X0kFInSvG3YjjZZlxelLLFIklRWhBYy1BTQJBFh44OVopVI7TQ==
+  dependencies:
+    "@contentful/f36-core" "^4.58.4"
     "@contentful/f36-tokens" "^4.0.4"
     dayjs "^1.11.5"
     emotion "^10.0.17"
 
-"@contentful/f36-drag-handle@^4.57.0", "@contentful/f36-drag-handle@^4.59.3":
-  version "4.59.3"
-  resolved "https://registry.yarnpkg.com/@contentful/f36-drag-handle/-/f36-drag-handle-4.59.3.tgz#79f0fdb006a4281cd8b09adf1d31df4a56160f4d"
-  integrity sha512-yQ8uWnjjT8pz++12hL8Qj2lFNvx43xFvWLEKMEytpt76+lAJoFqOlv4H+8XQDTlx6q87RbwD7HJPkZOZ+SBhtg==
+"@contentful/f36-datetime@^4.60.0":
+  version "4.60.0"
+  resolved "https://npm.pkg.github.com/download/@contentful/f36-datetime/4.60.0/78bc62f8e24900af5ccba98384256d3ed84c71d3#78bc62f8e24900af5ccba98384256d3ed84c71d3"
+  integrity sha512-OXyAXS8DS2akxisCOfN5AkG0miPflNbtHWlo+XR2JjuCPBY5YJ0Hm6EzC304g5BnZlOEQ5nf5if87Gfzca4eLw==
   dependencies:
-    "@contentful/f36-core" "^4.59.3"
+    "@contentful/f36-core" "^4.60.0"
+    "@contentful/f36-tokens" "^4.0.4"
+    dayjs "^1.11.5"
+    emotion "^10.0.17"
+
+"@contentful/f36-drag-handle@^4.57.0", "@contentful/f36-drag-handle@^4.58.4":
+  version "4.58.4"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-drag-handle/-/f36-drag-handle-4.58.4.tgz#ca92d2963627acda346d6589b57585ec034670fe"
+  integrity sha512-GgAdCik9yCimf0J/K/KooAkQytHDMo+Aq4EiLitsuRyNiC73KAeyh3HlLVIeXNId1wF3SnihegOQwjR+KSwurA==
+  dependencies:
+    "@contentful/f36-core" "^4.58.4"
     "@contentful/f36-icons" "^4.27.0"
     "@contentful/f36-tokens" "^4.0.4"
     "@contentful/f36-utils" "^4.24.3"
     emotion "^10.0.17"
 
-"@contentful/f36-empty-state@^4.57.0", "@contentful/f36-empty-state@^4.59.3":
-  version "4.59.3"
-  resolved "https://registry.yarnpkg.com/@contentful/f36-empty-state/-/f36-empty-state-4.59.3.tgz#2c63de877c5a70caa27caa3f46cf551bc77e41de"
-  integrity sha512-/wE2ZaDD9LfkF5e30o/S6SaQwegIsBI2/kdxYNijygLhiUv2Up2vzmtUvnbf2xrGskxCjIo9cffGp7M15C3kOA==
+"@contentful/f36-drag-handle@^4.60.0":
+  version "4.60.0"
+  resolved "https://npm.pkg.github.com/download/@contentful/f36-drag-handle/4.60.0/d165c331369518c7740027b3c48ec3af4f3d20b1#d165c331369518c7740027b3c48ec3af4f3d20b1"
+  integrity sha512-VZE+iZnGO+ZRdu/KFlKZn9wbMB3LzYWMH+LVSLXZkKDtZm1agWOzovSLHZxsxIFkmZA7s3YphBo7vs5FOxEoQw==
   dependencies:
-    "@contentful/f36-tokens" "^4.0.4"
-    "@contentful/f36-typography" "^4.59.3"
-    emotion "^10.0.17"
-
-"@contentful/f36-entity-list@^4.57.0", "@contentful/f36-entity-list@^4.59.3":
-  version "4.59.3"
-  resolved "https://registry.yarnpkg.com/@contentful/f36-entity-list/-/f36-entity-list-4.59.3.tgz#25270a7394d38695558db1077aa19f35eb415888"
-  integrity sha512-PTDJhRDQvGGq90CU1/2rqFI9TfKiEDunmvrfAXdpbgTuBvHKkMWx/8FBWDRQZXEXK0AFuam1ahLZZt9Gi/bBKA==
-  dependencies:
-    "@contentful/f36-badge" "^4.59.3"
-    "@contentful/f36-button" "^4.59.3"
-    "@contentful/f36-core" "^4.59.3"
-    "@contentful/f36-drag-handle" "^4.59.3"
-    "@contentful/f36-icon" "^4.59.3"
-    "@contentful/f36-icons" "^4.27.0"
-    "@contentful/f36-menu" "^4.59.3"
-    "@contentful/f36-skeleton" "^4.59.3"
-    "@contentful/f36-tokens" "^4.0.4"
-    "@contentful/f36-typography" "^4.59.3"
-    emotion "^10.0.17"
-
-"@contentful/f36-forms@^4.57.0", "@contentful/f36-forms@^4.59.3":
-  version "4.59.3"
-  resolved "https://registry.yarnpkg.com/@contentful/f36-forms/-/f36-forms-4.59.3.tgz#2ea79e05afbe99079d1f3ce684fee257ddf7c3da"
-  integrity sha512-GT7Dd1LWac2pPl/vqmjbjIeoEip8CztHu6rY8qmetUS7Vl3EqSdVaSSfnYxUy+deQlnrVKWabnvhfYPgiDlaNA==
-  dependencies:
-    "@contentful/f36-core" "^4.59.3"
+    "@contentful/f36-core" "^4.60.0"
     "@contentful/f36-icons" "^4.27.0"
     "@contentful/f36-tokens" "^4.0.4"
-    "@contentful/f36-typography" "^4.59.3"
     "@contentful/f36-utils" "^4.24.3"
     emotion "^10.0.17"
 
-"@contentful/f36-icon@^4.45.0", "@contentful/f36-icon@^4.48.0", "@contentful/f36-icon@^4.57.0", "@contentful/f36-icon@^4.59.3":
-  version "4.59.3"
-  resolved "https://registry.yarnpkg.com/@contentful/f36-icon/-/f36-icon-4.59.3.tgz#df64ede39dc26d594bfdb53b4f5ddb9929b20fc5"
-  integrity sha512-xhk4KzuBmtu84hJZSSy5JcbZyqv5e19gHlt+tVv3Rxx2cuZR668f1LNz0D4l1udXUEYtIWaH190Z92vCO+agpg==
+"@contentful/f36-empty-state@^4.57.0", "@contentful/f36-empty-state@^4.58.4":
+  version "4.58.4"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-empty-state/-/f36-empty-state-4.58.4.tgz#3aca7fb23879a9d3908f37e89bc7d8f2fd427e21"
+  integrity sha512-G2adxImI181asA8xalP8+hDWdUTzrwl7AMXvjLEKDKJeJzGOyDUgJQLvzKnwZGcNNyrNMIFHzphdvow4U7LeOQ==
   dependencies:
-    "@contentful/f36-core" "^4.59.3"
+    "@contentful/f36-tokens" "^4.0.4"
+    "@contentful/f36-typography" "^4.58.4"
+    emotion "^10.0.17"
+
+"@contentful/f36-empty-state@^4.60.0":
+  version "4.60.0"
+  resolved "https://npm.pkg.github.com/download/@contentful/f36-empty-state/4.60.0/7fc3bb6fa5933a987721e7868a49f352a334f2c7#7fc3bb6fa5933a987721e7868a49f352a334f2c7"
+  integrity sha512-P6k3l4sSo/VXxsGO19SPsf70eeUoL/cL1VvMmnGpFRbDexcJBs3pfcusArc0OBblYdsAVHOPSRxePiD7x/L4rg==
+  dependencies:
+    "@contentful/f36-tokens" "^4.0.4"
+    "@contentful/f36-typography" "^4.60.0"
+    emotion "^10.0.17"
+
+"@contentful/f36-entity-list@^4.57.0", "@contentful/f36-entity-list@^4.58.4":
+  version "4.58.4"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-entity-list/-/f36-entity-list-4.58.4.tgz#7bcc715e365c1b0e9524248f98634aee220d188b"
+  integrity sha512-I/+xNQ/936H1XtGUWvnI1bS1TT3ahdvXHnc3GqdgcOVyggdXCpUUAaa1iMP7I/jFklf2sFVwhAMXeanOZT4t8g==
+  dependencies:
+    "@contentful/f36-badge" "^4.58.4"
+    "@contentful/f36-button" "^4.58.4"
+    "@contentful/f36-core" "^4.58.4"
+    "@contentful/f36-drag-handle" "^4.58.4"
+    "@contentful/f36-icon" "^4.58.4"
+    "@contentful/f36-icons" "^4.27.0"
+    "@contentful/f36-menu" "^4.58.4"
+    "@contentful/f36-skeleton" "^4.58.4"
+    "@contentful/f36-tokens" "^4.0.4"
+    "@contentful/f36-typography" "^4.58.4"
+    emotion "^10.0.17"
+
+"@contentful/f36-entity-list@^4.60.0":
+  version "4.60.0"
+  resolved "https://npm.pkg.github.com/download/@contentful/f36-entity-list/4.60.0/aec7a824f0d7bda9f2b2183a6b4e9e61a2fa2a4c#aec7a824f0d7bda9f2b2183a6b4e9e61a2fa2a4c"
+  integrity sha512-O5i3MTg1bew3aSP/8mod7rONBcDpdReULcRq554z5WZUrzs4afMy3aP0qU/RBo/4T62sT142jJ09mulLbRYHwg==
+  dependencies:
+    "@contentful/f36-badge" "^4.60.0"
+    "@contentful/f36-button" "^4.60.0"
+    "@contentful/f36-core" "^4.60.0"
+    "@contentful/f36-drag-handle" "^4.60.0"
+    "@contentful/f36-icon" "^4.60.0"
+    "@contentful/f36-icons" "^4.27.0"
+    "@contentful/f36-menu" "^4.60.0"
+    "@contentful/f36-skeleton" "^4.60.0"
+    "@contentful/f36-tokens" "^4.0.4"
+    "@contentful/f36-typography" "^4.60.0"
+    emotion "^10.0.17"
+
+"@contentful/f36-forms@^4.57.0", "@contentful/f36-forms@^4.58.4":
+  version "4.58.4"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-forms/-/f36-forms-4.58.4.tgz#6e84fade4e0eee9fcf408cb7bc49a47311fc58b9"
+  integrity sha512-fnsuhkN8DQn05oaSB1mEyWr66Po3wmnzZxnc3kUSFP0I/8eoB5wFV8BYbM0/D31sjW1hIuWYgMggkaKZOahfCA==
+  dependencies:
+    "@contentful/f36-core" "^4.58.4"
+    "@contentful/f36-icons" "^4.27.0"
+    "@contentful/f36-tokens" "^4.0.4"
+    "@contentful/f36-typography" "^4.58.4"
+    "@contentful/f36-utils" "^4.24.3"
+    emotion "^10.0.17"
+
+"@contentful/f36-forms@^4.60.0":
+  version "4.60.0"
+  resolved "https://npm.pkg.github.com/download/@contentful/f36-forms/4.60.0/0ee942088770739cfc17b7cc43d3209bca359720#0ee942088770739cfc17b7cc43d3209bca359720"
+  integrity sha512-m4JoJJEYkP6DwQCwaU8EPnTCAtca1j8aL+QDtEn/Pp92BjPD1hAT7FM7lWKhnAdDXOsK9j+1U6Tp6Oyce157WQ==
+  dependencies:
+    "@contentful/f36-core" "^4.60.0"
+    "@contentful/f36-icons" "^4.27.0"
+    "@contentful/f36-tokens" "^4.0.4"
+    "@contentful/f36-typography" "^4.60.0"
+    "@contentful/f36-utils" "^4.24.3"
+    emotion "^10.0.17"
+
+"@contentful/f36-icon@^4.45.0", "@contentful/f36-icon@^4.48.0", "@contentful/f36-icon@^4.57.0", "@contentful/f36-icon@^4.58.4":
+  version "4.58.4"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-icon/-/f36-icon-4.58.4.tgz#e38d17b3592bffcfac4e4da55eb8f84f541835c5"
+  integrity sha512-Wd4bn4BT+4c8N1ksHcOapTRHi7JzPxE8vcmJiF4sWN9Wbp3j0GPYkKC8NjgQQobWz6U1Ql+1ZQRFQBKr9t/87w==
+  dependencies:
+    "@contentful/f36-core" "^4.58.4"
+    "@contentful/f36-tokens" "^4.0.4"
+    emotion "^10.0.17"
+
+"@contentful/f36-icon@^4.60.0":
+  version "4.60.0"
+  resolved "https://npm.pkg.github.com/download/@contentful/f36-icon/4.60.0/00d47db650abc294de8ff22c91366cf85caeeaff#00d47db650abc294de8ff22c91366cf85caeeaff"
+  integrity sha512-+zbMsTd0duRhdvTviW49l1xCskgMhlSbE+31xORODqgoeC5bkbLMJNcI5PT4oc/CGGQqbl5NV0fVgBiKOUmSYw==
+  dependencies:
+    "@contentful/f36-core" "^4.60.0"
     "@contentful/f36-tokens" "^4.0.4"
     emotion "^10.0.17"
 
@@ -2109,46 +2526,82 @@
     "@contentful/f36-tokens" "^4.0.1"
     emotion "^10.0.17"
 
-"@contentful/f36-list@^4.57.0", "@contentful/f36-list@^4.59.3":
-  version "4.59.3"
-  resolved "https://registry.yarnpkg.com/@contentful/f36-list/-/f36-list-4.59.3.tgz#5517e1587c3ff976b88e5421b4c8ee22f51abf37"
-  integrity sha512-i/VMmQA44JDM7osSj5cDlqqsV3ugIn8g2T4QwthMkGkhx2lBoswiXVZx3qWMtgCaAH9Ko5iv0UBsrsJk77SgXQ==
+"@contentful/f36-list@^4.57.0", "@contentful/f36-list@^4.58.4":
+  version "4.58.4"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-list/-/f36-list-4.58.4.tgz#f3c015935f5c211f9afab2c1c0536c2463b4d980"
+  integrity sha512-lkU+04qhTW5GdKKHFwo4EVOLJhGFLGe7YV80m4XkyLug3OTHRFlrEq00+rzp4rfp82uINape3NwheNqugvwZXw==
   dependencies:
-    "@contentful/f36-core" "^4.59.3"
+    "@contentful/f36-core" "^4.58.4"
     "@contentful/f36-tokens" "^4.0.4"
     emotion "^10.0.17"
 
-"@contentful/f36-menu@^4.45.0", "@contentful/f36-menu@^4.57.0", "@contentful/f36-menu@^4.59.3":
-  version "4.59.3"
-  resolved "https://registry.yarnpkg.com/@contentful/f36-menu/-/f36-menu-4.59.3.tgz#7c85baf60fea53622930c738240bb7d99e2ea2d1"
-  integrity sha512-oURXSs4MPLkNsklrwLaCQIQZu/N3XU1GOAhNuO98EMwmJfmVBaZ4AQU3h7GJbhhWjgc3uEkJOZM74pIrKgsZbA==
+"@contentful/f36-list@^4.60.0":
+  version "4.60.0"
+  resolved "https://npm.pkg.github.com/download/@contentful/f36-list/4.60.0/d94c1ce4cb4bdcff8246417198d3c1d91a44fb2a#d94c1ce4cb4bdcff8246417198d3c1d91a44fb2a"
+  integrity sha512-KPUqf/Y9GaD3HWMMZmeBVY1aoN3s7cDzY0z080yvaGCaQpbE0tTOkE/ZFRK8pE0eU94iabrcKg92MTreEEwWeA==
   dependencies:
-    "@contentful/f36-core" "^4.59.3"
-    "@contentful/f36-icons" "^4.27.0"
-    "@contentful/f36-popover" "^4.59.3"
+    "@contentful/f36-core" "^4.60.0"
     "@contentful/f36-tokens" "^4.0.4"
-    "@contentful/f36-typography" "^4.59.3"
+    emotion "^10.0.17"
+
+"@contentful/f36-menu@^4.45.0", "@contentful/f36-menu@^4.57.0", "@contentful/f36-menu@^4.58.4":
+  version "4.58.4"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-menu/-/f36-menu-4.58.4.tgz#f085263a39938228ee225cc7008e43ad0d1e1b0d"
+  integrity sha512-XSLeb4N0ZLGrYTsZZDew6Lyw4rNz+CciQOB/ptk0WnUuwRCFzN7Wdzf2GNxnT6thpabRv+xqJ5HLlenGYhH6Jw==
+  dependencies:
+    "@contentful/f36-core" "^4.58.4"
+    "@contentful/f36-icons" "^4.27.0"
+    "@contentful/f36-popover" "^4.58.4"
+    "@contentful/f36-tokens" "^4.0.4"
+    "@contentful/f36-typography" "^4.58.4"
     "@contentful/f36-utils" "^4.24.3"
     emotion "^10.0.17"
 
-"@contentful/f36-modal@^4.57.0", "@contentful/f36-modal@^4.59.3":
-  version "4.59.3"
-  resolved "https://registry.yarnpkg.com/@contentful/f36-modal/-/f36-modal-4.59.3.tgz#8ce8a1c8ba32475035c5763b613a43b9dc46231b"
-  integrity sha512-CWAprCQnA7TFwAulZ97KmvRF4/+bDVW6hbGOkhXtvgMfU3OzVGMIKdLBfyvyOOlGZLkB6/xXZQOC2Ubxw+PpWA==
+"@contentful/f36-menu@^4.60.0":
+  version "4.60.0"
+  resolved "https://npm.pkg.github.com/download/@contentful/f36-menu/4.60.0/1432b225ec0cdc0b552506fa5ec398ab5ebcdcae#1432b225ec0cdc0b552506fa5ec398ab5ebcdcae"
+  integrity sha512-Rjn6WrGrJIPpkJaNQdj17KSHoYC3xj82W9YObtzl/W/huNhXV2IoH8p7q9kOaEuZjG80ERvuuno84xkLMiAaig==
   dependencies:
-    "@contentful/f36-button" "^4.59.3"
-    "@contentful/f36-core" "^4.59.3"
+    "@contentful/f36-core" "^4.60.0"
+    "@contentful/f36-icons" "^4.27.0"
+    "@contentful/f36-popover" "^4.60.0"
+    "@contentful/f36-tokens" "^4.0.4"
+    "@contentful/f36-typography" "^4.60.0"
+    "@contentful/f36-utils" "^4.24.3"
+    emotion "^10.0.17"
+
+"@contentful/f36-modal@^4.57.0", "@contentful/f36-modal@^4.58.4":
+  version "4.58.4"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-modal/-/f36-modal-4.58.4.tgz#a1eba43732c85152c48172067402c190598a1445"
+  integrity sha512-KkOLdqt0p6d50cWqy1PXrGbrjNRJh/LDfT+kUIfMuvKAbBbdIixCWfCegz2Y9pLsZ/87qKxhwvu7KfMJTFyMOw==
+  dependencies:
+    "@contentful/f36-button" "^4.58.4"
+    "@contentful/f36-core" "^4.58.4"
     "@contentful/f36-icons" "^4.27.0"
     "@contentful/f36-tokens" "^4.0.4"
-    "@contentful/f36-typography" "^4.59.3"
+    "@contentful/f36-typography" "^4.58.4"
+    "@types/react-modal" "^3.13.1"
+    emotion "^10.0.17"
+    react-modal "^3.16.1"
+
+"@contentful/f36-modal@^4.60.0":
+  version "4.60.0"
+  resolved "https://npm.pkg.github.com/download/@contentful/f36-modal/4.60.0/52a959c31f0ebc711ff6db93362435319e41a5a7#52a959c31f0ebc711ff6db93362435319e41a5a7"
+  integrity sha512-9IixUm5RgOgtOviMhvmQKImjKK24XykoJymromOoQPBgI1rIqUxBhlwGWIPOYYtoA32mJNIL2erJhYM+zrR2+A==
+  dependencies:
+    "@contentful/f36-button" "^4.60.0"
+    "@contentful/f36-core" "^4.60.0"
+    "@contentful/f36-icons" "^4.27.0"
+    "@contentful/f36-tokens" "^4.0.4"
+    "@contentful/f36-typography" "^4.60.0"
     "@types/react-modal" "^3.13.1"
     emotion "^10.0.17"
     react-modal "^3.16.1"
 
 "@contentful/f36-navbar@^4.1.0":
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/@contentful/f36-navbar/-/f36-navbar-4.1.1.tgz#139c0280f14f3a923d40bfa7290984eb60486119"
-  integrity sha512-nCLtZ7EgfKhmXWrGZYrZEQOoulOOVPOuZBk0CC4JgQRQmCYeYr2iAnM8zualISFaxX/O+GVvHPQf2hKeoeFRPA==
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-navbar/-/f36-navbar-4.1.0.tgz#81c501260b4e132d233e05d5406acc1987c0cc1a"
+  integrity sha512-tFzg4px28dGq2zD+/rKsVmZ684WItZ+xNGI7et6QeAmevwIzifE1JGblJr/BC1Nn2nWLlF0LZn4URekIf7ijkA==
   dependencies:
     "@contentful/f36-core" "^4.45.0"
     "@contentful/f36-icon" "^4.45.0"
@@ -2159,118 +2612,233 @@
     "@contentful/f36-utils" "^4.23.2"
     emotion "^10.0.17"
 
-"@contentful/f36-note@^4.2.8", "@contentful/f36-note@^4.57.0", "@contentful/f36-note@^4.59.3":
-  version "4.59.3"
-  resolved "https://registry.yarnpkg.com/@contentful/f36-note/-/f36-note-4.59.3.tgz#c2b542c18f03dbc12c2d5ffb443a7d3e6728c897"
-  integrity sha512-k9HLeCP9CUw5I9M7L3uy/GIsBBK6SES2yOcg/UmKCDyKl/YjbMtEASpqMfzAkrcXjeTuBcmXwKJXI7svufwazQ==
+"@contentful/f36-note@^4.2.8", "@contentful/f36-note@^4.57.0", "@contentful/f36-note@^4.58.4":
+  version "4.58.4"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-note/-/f36-note-4.58.4.tgz#d0d44bb523c9b8dd87fbea5c0408cfa8ce52f74e"
+  integrity sha512-0oFzxKWfHRJw2AclDeOUaKGYHYI3qLtdMt0P/sHTxxy8KnwregwmSTi4Sv94LqNTAQcX7SQAO6Q4+KvFbJIV9A==
   dependencies:
-    "@contentful/f36-button" "^4.59.3"
-    "@contentful/f36-core" "^4.59.3"
-    "@contentful/f36-icon" "^4.59.3"
+    "@contentful/f36-button" "^4.58.4"
+    "@contentful/f36-core" "^4.58.4"
+    "@contentful/f36-icon" "^4.58.4"
     "@contentful/f36-icons" "^4.27.0"
     "@contentful/f36-tokens" "^4.0.4"
-    "@contentful/f36-typography" "^4.59.3"
+    "@contentful/f36-typography" "^4.58.4"
     emotion "^10.0.17"
 
-"@contentful/f36-notification@^4.57.0", "@contentful/f36-notification@^4.59.3":
-  version "4.59.3"
-  resolved "https://registry.yarnpkg.com/@contentful/f36-notification/-/f36-notification-4.59.3.tgz#fbc3cf6784755a272befe1dd5f49934e802e4c16"
-  integrity sha512-IAIPx0MfrJcMHoy8w8X4cdyPhMkhkz+A5/qvTovVBaKfjt1zyRYg8qEp3ZYDxh3T4JQeY/hTzWQ4+35uq9dm7A==
+"@contentful/f36-note@^4.60.0":
+  version "4.60.0"
+  resolved "https://npm.pkg.github.com/download/@contentful/f36-note/4.60.0/61d52aaef6bd02df2984be8bed1c80703565ac59#61d52aaef6bd02df2984be8bed1c80703565ac59"
+  integrity sha512-XnOMEo2U3jbPzy20bZgoyQjR7bwsMWGUQrcrE3H0cXSHYQaKuvWo6uaEMCsqr00LWkP1537tuWfr3Yalp33aiQ==
   dependencies:
-    "@contentful/f36-button" "^4.59.3"
-    "@contentful/f36-core" "^4.59.3"
+    "@contentful/f36-button" "^4.60.0"
+    "@contentful/f36-core" "^4.60.0"
+    "@contentful/f36-icon" "^4.60.0"
     "@contentful/f36-icons" "^4.27.0"
-    "@contentful/f36-text-link" "^4.59.3"
     "@contentful/f36-tokens" "^4.0.4"
-    "@contentful/f36-typography" "^4.59.3"
+    "@contentful/f36-typography" "^4.60.0"
+    emotion "^10.0.17"
+
+"@contentful/f36-notification@^4.57.0", "@contentful/f36-notification@^4.58.4":
+  version "4.58.4"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-notification/-/f36-notification-4.58.4.tgz#2e819fede3c440980c3f6aeae14145df4efba900"
+  integrity sha512-Pvne6emM1tpIhK1x6+9d0kvl56D25PfAgejEWioI+0VaIsIpXvmmYNYIgqViUtP6sxu9+fQZDivmCr1CfbB+MQ==
+  dependencies:
+    "@contentful/f36-button" "^4.58.4"
+    "@contentful/f36-core" "^4.58.4"
+    "@contentful/f36-icons" "^4.27.0"
+    "@contentful/f36-text-link" "^4.58.4"
+    "@contentful/f36-tokens" "^4.0.4"
+    "@contentful/f36-typography" "^4.58.4"
     "@swc/helpers" "^0.4.14"
     emotion "^10.0.17"
     react-animate-height "^3.0.4"
 
-"@contentful/f36-pagination@^4.57.0", "@contentful/f36-pagination@^4.59.3":
-  version "4.59.3"
-  resolved "https://registry.yarnpkg.com/@contentful/f36-pagination/-/f36-pagination-4.59.3.tgz#e6e555b78e295586c6541c73d1722309e6bb60f5"
-  integrity sha512-777DP0tR5GimQXGoPu9Nmx2w9pbgk/KfZuArg2tFcTA3imda4xHLscBP34cp26YTePxajjLWjafAn5i/RqBESw==
+"@contentful/f36-notification@^4.60.0":
+  version "4.60.0"
+  resolved "https://npm.pkg.github.com/download/@contentful/f36-notification/4.60.0/0e8d0b398d69c6bda13de2bc58442f811549b2a5#0e8d0b398d69c6bda13de2bc58442f811549b2a5"
+  integrity sha512-1YZ+eQhBLNEIc1dBcm4Ee0Rq1oXP8VvkYxczRmTaopKLlxUTZpvnjPZEq0wZTZ0Dc/uy8m92yByCCeo0UAVpXw==
   dependencies:
-    "@contentful/f36-button" "^4.59.3"
-    "@contentful/f36-core" "^4.59.3"
-    "@contentful/f36-forms" "^4.59.3"
+    "@contentful/f36-button" "^4.60.0"
+    "@contentful/f36-core" "^4.60.0"
+    "@contentful/f36-icons" "^4.27.0"
+    "@contentful/f36-text-link" "^4.60.0"
+    "@contentful/f36-tokens" "^4.0.4"
+    "@contentful/f36-typography" "^4.60.0"
+    "@swc/helpers" "^0.4.14"
+    emotion "^10.0.17"
+    react-animate-height "^3.0.4"
+
+"@contentful/f36-pagination@^4.57.0", "@contentful/f36-pagination@^4.58.4":
+  version "4.58.4"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-pagination/-/f36-pagination-4.58.4.tgz#33879d6e1d8264894cff8cd24c56ba34780e39df"
+  integrity sha512-2w56B1w5kkm8g/Q/NGtlF25uMwkPoDJ7gr+ry5LqcYqFSfjJzKytVd4tDzbrdNRJajn9MpqSyHVLxG6icJSBOw==
+  dependencies:
+    "@contentful/f36-button" "^4.58.4"
+    "@contentful/f36-core" "^4.58.4"
+    "@contentful/f36-forms" "^4.58.4"
     "@contentful/f36-icons" "^4.27.0"
     "@contentful/f36-tokens" "^4.0.4"
-    "@contentful/f36-typography" "^4.59.3"
+    "@contentful/f36-typography" "^4.58.4"
     emotion "^10.0.17"
 
-"@contentful/f36-pill@^4.57.0", "@contentful/f36-pill@^4.59.3":
-  version "4.59.3"
-  resolved "https://registry.yarnpkg.com/@contentful/f36-pill/-/f36-pill-4.59.3.tgz#d7a223c7a4454f504b043d3388d225e47c50f78d"
-  integrity sha512-pAa5tOFPlTG64tbB8PiKtnf9P8fCOAP57uX1LfwaPn6QEVqlrvsH1+Vd3oerzPgyZsXxzAgojJ+QqLKzykw/Eg==
+"@contentful/f36-pagination@^4.60.0":
+  version "4.60.0"
+  resolved "https://npm.pkg.github.com/download/@contentful/f36-pagination/4.60.0/20063ece05da401deb3cc9fb33392ece6de37334#20063ece05da401deb3cc9fb33392ece6de37334"
+  integrity sha512-m/m+/wZxjO/EDPWGkdMDyGsxEe5iV6RnSMsVABk4QTOe7Zo05rqGUw6IjqzvecDgDwm1jUrYm/lhlNObwpcRlA==
   dependencies:
-    "@contentful/f36-button" "^4.59.3"
-    "@contentful/f36-core" "^4.59.3"
-    "@contentful/f36-drag-handle" "^4.59.3"
+    "@contentful/f36-button" "^4.60.0"
+    "@contentful/f36-core" "^4.60.0"
+    "@contentful/f36-forms" "^4.60.0"
     "@contentful/f36-icons" "^4.27.0"
     "@contentful/f36-tokens" "^4.0.4"
-    "@contentful/f36-tooltip" "^4.59.3"
+    "@contentful/f36-typography" "^4.60.0"
     emotion "^10.0.17"
 
-"@contentful/f36-popover@^4.57.0", "@contentful/f36-popover@^4.59.3":
-  version "4.59.3"
-  resolved "https://registry.yarnpkg.com/@contentful/f36-popover/-/f36-popover-4.59.3.tgz#8e6cd1c0bb31dfa1202a2e420e5455b5afd1e973"
-  integrity sha512-VIdoiC8UuizDrgQb2QPXOzpuZg0YWDkrmiu2VQxNp65X1rc0x8kES7VkPvnqEAPyWQUpi4jU6cvyb/1r+UwHKw==
+"@contentful/f36-pill@^4.57.0", "@contentful/f36-pill@^4.58.4":
+  version "4.58.4"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-pill/-/f36-pill-4.58.4.tgz#4f804cf8f8552149ac2448d4409c64f854f54805"
+  integrity sha512-q7sJfJkuOm1kCQ2eSay7vaJ5v+r5ATArESZ0il79VV3p5HSyje4PsuEJkS2YZZ03FWcs4mv+jdXwYZx4lX5u5g==
   dependencies:
-    "@contentful/f36-core" "^4.59.3"
+    "@contentful/f36-button" "^4.58.4"
+    "@contentful/f36-core" "^4.58.4"
+    "@contentful/f36-drag-handle" "^4.58.4"
+    "@contentful/f36-icons" "^4.27.0"
+    "@contentful/f36-tokens" "^4.0.4"
+    "@contentful/f36-tooltip" "^4.58.4"
+    emotion "^10.0.17"
+
+"@contentful/f36-pill@^4.60.0":
+  version "4.60.0"
+  resolved "https://npm.pkg.github.com/download/@contentful/f36-pill/4.60.0/b6707f505141e1718f5e94dce9508f57d5258031#b6707f505141e1718f5e94dce9508f57d5258031"
+  integrity sha512-1heXDtENtFUnDrgaVYu3GRTtIzP37AydxOw1BlpRUiKGvEzL8K217d7WVhKoMlUFk+uCS50j6t6cJxl/3E3Xtw==
+  dependencies:
+    "@contentful/f36-button" "^4.60.0"
+    "@contentful/f36-core" "^4.60.0"
+    "@contentful/f36-drag-handle" "^4.60.0"
+    "@contentful/f36-icons" "^4.27.0"
+    "@contentful/f36-tokens" "^4.0.4"
+    "@contentful/f36-tooltip" "^4.60.0"
+    emotion "^10.0.17"
+
+"@contentful/f36-popover@^4.57.0", "@contentful/f36-popover@^4.58.4":
+  version "4.58.4"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-popover/-/f36-popover-4.58.4.tgz#7ea07dbfbefe953f8fe69a76e43d1f82005bab84"
+  integrity sha512-Y9GTYoqeh63k6iZ0ciXoRfhQlig4ZWmBF0vo/rPg2+ZfhlVwYQI6uNJbXH59Fl8VptiPCTKoGa0TogZn5dLZ5A==
+  dependencies:
+    "@contentful/f36-core" "^4.58.4"
     "@contentful/f36-tokens" "^4.0.4"
     "@contentful/f36-utils" "^4.24.3"
     "@popperjs/core" "^2.11.5"
     emotion "^10.0.17"
     react-popper "^2.3.0"
 
-"@contentful/f36-skeleton@^4.45.0", "@contentful/f36-skeleton@^4.57.0", "@contentful/f36-skeleton@^4.59.3":
-  version "4.59.3"
-  resolved "https://registry.yarnpkg.com/@contentful/f36-skeleton/-/f36-skeleton-4.59.3.tgz#5c09eb5b936d9d15fe4d5360816332f059f61437"
-  integrity sha512-J06S1Cs2eQr/cNFOYDnrjl5qwCSvDgVJ0WKNcyQoJ4bO/9vwvpelYsnqm7g2qG+4X9CLbIFaxCaI5C+KLcfDow==
+"@contentful/f36-popover@^4.60.0":
+  version "4.60.0"
+  resolved "https://npm.pkg.github.com/download/@contentful/f36-popover/4.60.0/90b6247669ed1ec80000be5d394ffdd4cca7d2cd#90b6247669ed1ec80000be5d394ffdd4cca7d2cd"
+  integrity sha512-D0XNoO6//TLIzc/LLt7UnbdeGpDO3t/Eb3eKwK4Z0n+pI8bCEm6EltfbVO3mWMmPPSDhjLMa33q3hgGXt/BUAg==
   dependencies:
-    "@contentful/f36-core" "^4.59.3"
-    "@contentful/f36-table" "^4.59.3"
+    "@contentful/f36-core" "^4.60.0"
+    "@contentful/f36-tokens" "^4.0.4"
+    "@contentful/f36-utils" "^4.24.3"
+    "@popperjs/core" "^2.11.5"
+    emotion "^10.0.17"
+    react-popper "^2.3.0"
+
+"@contentful/f36-skeleton@^4.45.0", "@contentful/f36-skeleton@^4.57.0", "@contentful/f36-skeleton@^4.58.4":
+  version "4.58.4"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-skeleton/-/f36-skeleton-4.58.4.tgz#5589ad9ff7ac0624a239ea031583e0f4c3a0c825"
+  integrity sha512-vz1XPOYxy6dsTATjmVoe55f49tbPGaDU0WCEuFeCB94cHarC9SgKWjQg9vDQydUKPOcRfcxXYCogGHywWrrkqw==
+  dependencies:
+    "@contentful/f36-core" "^4.58.4"
+    "@contentful/f36-table" "^4.58.4"
     "@contentful/f36-tokens" "^4.0.4"
     emotion "^10.0.17"
 
-"@contentful/f36-spinner@^4.57.0", "@contentful/f36-spinner@^4.59.3":
-  version "4.59.3"
-  resolved "https://registry.yarnpkg.com/@contentful/f36-spinner/-/f36-spinner-4.59.3.tgz#9b3337ee5943f8baff0315822a58a001a7017765"
-  integrity sha512-ajVYvw8u69V2weJebG2zrXDuFwMvnrWvl1TyH8i6lFvIsudc3/fmddN32WCXleVcK/zA3bRgTUICm+ROs99vXQ==
+"@contentful/f36-skeleton@^4.60.0":
+  version "4.60.0"
+  resolved "https://npm.pkg.github.com/download/@contentful/f36-skeleton/4.60.0/4642350642ff451a7e558299cdb66fa3e9fcefab#4642350642ff451a7e558299cdb66fa3e9fcefab"
+  integrity sha512-5WsjDlOxofFpGSqkAVCEdOC7TCyrQ7/AYdxjhzFJClKHIZ0xR/ZqcZyE6yy8DV9dj+XMil8ZIAyrOnwDX6fRNQ==
   dependencies:
-    "@contentful/f36-core" "^4.59.3"
+    "@contentful/f36-core" "^4.60.0"
+    "@contentful/f36-table" "^4.60.0"
     "@contentful/f36-tokens" "^4.0.4"
     emotion "^10.0.17"
 
-"@contentful/f36-table@^4.57.0", "@contentful/f36-table@^4.59.3":
-  version "4.59.3"
-  resolved "https://registry.yarnpkg.com/@contentful/f36-table/-/f36-table-4.59.3.tgz#2cb29ffa232f336497b2237b7f540b0ea2aa341a"
-  integrity sha512-iCxwQGKbPToeK4WjFNxyr5g5UUCY022/U7wvnse/7+19NpRF7I9zqO99rcP5iSs1ogoVBAVCkJohLvV2P0dX0g==
+"@contentful/f36-spinner@^4.57.0", "@contentful/f36-spinner@^4.58.4":
+  version "4.58.4"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-spinner/-/f36-spinner-4.58.4.tgz#c3aaa1e017e82a19756f922b1d2a330ce9770880"
+  integrity sha512-GXdA4H0t1ktCX9fcc6TaHtgbCpPuroJhvlUOg+nFbJt9Zpa6g4MjH1UIqUFASyB0j4dIFcNLawklBvfDcPKB7w==
   dependencies:
-    "@contentful/f36-core" "^4.59.3"
+    "@contentful/f36-core" "^4.58.4"
+    "@contentful/f36-tokens" "^4.0.4"
+    emotion "^10.0.17"
+
+"@contentful/f36-spinner@^4.60.0":
+  version "4.60.0"
+  resolved "https://npm.pkg.github.com/download/@contentful/f36-spinner/4.60.0/97edbb8e11fc4fa6d185a690387ef5d3ee1c1861#97edbb8e11fc4fa6d185a690387ef5d3ee1c1861"
+  integrity sha512-T4Lyjr+sL0VC+2z7UVXAvOYxLZfsNECUpQGScI1iaEc6751Zz8HC+ccCFoKY3MUC/9k/bAE85vHTDoH6nmyutg==
+  dependencies:
+    "@contentful/f36-core" "^4.60.0"
+    "@contentful/f36-tokens" "^4.0.4"
+    emotion "^10.0.17"
+
+"@contentful/f36-table@^4.57.0", "@contentful/f36-table@^4.58.4":
+  version "4.58.4"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-table/-/f36-table-4.58.4.tgz#42f5807eaa22b9884045221c4c1b383472ad24b4"
+  integrity sha512-X8kRRqa7JMQVLHYDcPPPCEmVzWML9k00V/k47qfmDKxzCKvh3bFmx28QfEI9WBuyDh1duaEiGTPlMicOXeJOmQ==
+  dependencies:
+    "@contentful/f36-core" "^4.58.4"
     "@contentful/f36-icons" "^4.27.0"
     "@contentful/f36-tokens" "^4.0.4"
-    "@contentful/f36-typography" "^4.59.3"
+    "@contentful/f36-typography" "^4.58.4"
     emotion "^10.0.17"
 
-"@contentful/f36-tabs@^4.57.0", "@contentful/f36-tabs@^4.59.3":
-  version "4.59.3"
-  resolved "https://registry.yarnpkg.com/@contentful/f36-tabs/-/f36-tabs-4.59.3.tgz#42931ff78b4ff7742556694033ffec96897171fa"
-  integrity sha512-xhb1wN1eSJEPUSYIsqYocclU0CW5/mqEdCEPHhClTBPkwl2ItdggdcdWURN8ZE9vRmH6D/vcundJtgrzTpXYXA==
+"@contentful/f36-table@^4.60.0":
+  version "4.60.0"
+  resolved "https://npm.pkg.github.com/download/@contentful/f36-table/4.60.0/f2caa104d7d64b5ea97137ecaea97dd284791cd3#f2caa104d7d64b5ea97137ecaea97dd284791cd3"
+  integrity sha512-hOX1x62mWKs1vAC6LOFAxX0+jxwicjIiC693t1oifqaKENwDj+vXZsYZrh+pCAjWILRpFsxjMP79L4pRWrZ0Mw==
   dependencies:
-    "@contentful/f36-core" "^4.59.3"
+    "@contentful/f36-core" "^4.60.0"
+    "@contentful/f36-icons" "^4.27.0"
+    "@contentful/f36-tokens" "^4.0.4"
+    "@contentful/f36-typography" "^4.60.0"
+    emotion "^10.0.17"
+
+"@contentful/f36-tabs@^4.57.0", "@contentful/f36-tabs@^4.58.4":
+  version "4.58.4"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-tabs/-/f36-tabs-4.58.4.tgz#31621a1666c64a475c31f4609300be55b4e2b85a"
+  integrity sha512-3W2M978BZIvUe6k+rmHrwMejoCSXGxISX0kjpt1EJBvb9lX6nF+5WvpmTK7gUPuWLwQIcV8Lio95Pn9sYb8GyA==
+  dependencies:
+    "@contentful/f36-core" "^4.58.4"
     "@contentful/f36-tokens" "^4.0.4"
     "@radix-ui/react-tabs" "^1.0.1"
     emotion "^10.0.17"
 
-"@contentful/f36-text-link@^4.57.0", "@contentful/f36-text-link@^4.59.3":
-  version "4.59.3"
-  resolved "https://registry.yarnpkg.com/@contentful/f36-text-link/-/f36-text-link-4.59.3.tgz#e467a7249cc7b504f65df9b9acee13d8edb3d035"
-  integrity sha512-b/JioG8JbdUHR5SJSy2b2HlklbI25yQl6Ls3eA7zlSCPrgE5pBBprlUXU0SW3dFb/MoQErbPjcVcOPq6zIt1ZA==
+"@contentful/f36-tabs@^4.60.0":
+  version "4.60.0"
+  resolved "https://npm.pkg.github.com/download/@contentful/f36-tabs/4.60.0/2605ec4ead8b3c788d8f0a0cb28cf47cbfb3ae68#2605ec4ead8b3c788d8f0a0cb28cf47cbfb3ae68"
+  integrity sha512-4WzMJ847rbZMm+nWFAWhK4V2cYoPMXHkWif9FDuk4v6RPVhpoANUsSpTX9hBo2fyR99Cyj0qeGtqfJ39ifUTvw==
   dependencies:
-    "@contentful/f36-core" "^4.59.3"
+    "@contentful/f36-core" "^4.60.0"
+    "@contentful/f36-tokens" "^4.0.4"
+    "@radix-ui/react-tabs" "^1.0.1"
+    emotion "^10.0.17"
+
+"@contentful/f36-text-link@^4.57.0", "@contentful/f36-text-link@^4.58.4":
+  version "4.58.4"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-text-link/-/f36-text-link-4.58.4.tgz#753c6095186c1edef7f7a54c59526ec415f61519"
+  integrity sha512-PSrJ4qA+VSbZh2Rdo2Dm5nprONX+pXOixIjbmnglGLK9LUauWIrj4p86U92XZ7NY82XAdyOoaK0N/hJb+sdcTg==
+  dependencies:
+    "@contentful/f36-core" "^4.58.4"
+    "@contentful/f36-tokens" "^4.0.4"
+    emotion "^10.0.17"
+
+"@contentful/f36-text-link@^4.60.0":
+  version "4.60.0"
+  resolved "https://npm.pkg.github.com/download/@contentful/f36-text-link/4.60.0/7c4d254dedab05d0eef502a9a87513b7555bcd3b#7c4d254dedab05d0eef502a9a87513b7555bcd3b"
+  integrity sha512-gYP7O8iHQnflVactunb4Ui2Ynu1VD4KnKVDKbXQmk7BxDzMNKy5puvUUIgmI2MqmtA85eMcauWFSC677KJemMw==
+  dependencies:
+    "@contentful/f36-core" "^4.60.0"
     "@contentful/f36-tokens" "^4.0.4"
     emotion "^10.0.17"
 
@@ -2284,12 +2852,12 @@
   resolved "https://registry.yarnpkg.com/@contentful/f36-tokens/-/f36-tokens-4.0.4.tgz#1f2f3722fadfc232808e8a9151589527e8188ed9"
   integrity sha512-yPHNQjHVEuO+5nUoX3EbrQvLoU7ZjNc/w3RyCmYR3F/NWZCy/3n0Knhq5Jfow+CcXkVY6Ch526VlA3+ayEN2kA==
 
-"@contentful/f36-tooltip@^4.57.0", "@contentful/f36-tooltip@^4.59.3":
-  version "4.59.3"
-  resolved "https://registry.yarnpkg.com/@contentful/f36-tooltip/-/f36-tooltip-4.59.3.tgz#0ee58969d756429464754b0d5a82db23a5168431"
-  integrity sha512-PdWLh8Ch9p5Btz0by55WnkKNgjzVw0Cr9Sp0j4i0ejlgKbnICMjXmIPWQ/4FQ4/YgqOcromye2sVMKrteTYFnw==
+"@contentful/f36-tooltip@^4.57.0", "@contentful/f36-tooltip@^4.58.4":
+  version "4.58.4"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-tooltip/-/f36-tooltip-4.58.4.tgz#e9fefc1cdcf866deec688b9d8d54f8da5e7b4017"
+  integrity sha512-VuNFYBSbrUK4N1qvgqATdHanWqmPXw1RZOvZEYyHu5UCZMHMaKYARhtTU6zdKesTHilU3+rFOCNE8ZE0368Ugg==
   dependencies:
-    "@contentful/f36-core" "^4.59.3"
+    "@contentful/f36-core" "^4.58.4"
     "@contentful/f36-tokens" "^4.0.4"
     "@contentful/f36-utils" "^4.24.3"
     "@popperjs/core" "^2.11.5"
@@ -2297,12 +2865,35 @@
     emotion "^10.0.17"
     react-popper "^2.3.0"
 
-"@contentful/f36-typography@^4.57.0", "@contentful/f36-typography@^4.59.3":
-  version "4.59.3"
-  resolved "https://registry.yarnpkg.com/@contentful/f36-typography/-/f36-typography-4.59.3.tgz#b5edfd0511d631272ceb8545d1808a7787e60470"
-  integrity sha512-BNspYw9THmOv+EbXc7SIwtrKnQFdUXvv6aaKmq5GOYRcikjraVIYRn+DW8uS1qpipfWkDxYFJRWAP+uW3NrPQQ==
+"@contentful/f36-tooltip@^4.60.0":
+  version "4.60.0"
+  resolved "https://npm.pkg.github.com/download/@contentful/f36-tooltip/4.60.0/2c04d04c9e5041aa622aeea3f656d73d79a7d213#2c04d04c9e5041aa622aeea3f656d73d79a7d213"
+  integrity sha512-qIdLgj9oOqr69RuRA/9LrV1VlOSHOWuRtSsSZDx87rQwk8OlvdflvCd3Y1TPyrFiAbsRV7QtSmxau+1UKhqQ8A==
   dependencies:
-    "@contentful/f36-core" "^4.59.3"
+    "@contentful/f36-core" "^4.60.0"
+    "@contentful/f36-tokens" "^4.0.4"
+    "@contentful/f36-utils" "^4.24.3"
+    "@popperjs/core" "^2.11.5"
+    csstype "^3.1.1"
+    emotion "^10.0.17"
+    react-popper "^2.3.0"
+
+"@contentful/f36-typography@^4.57.0", "@contentful/f36-typography@^4.58.4":
+  version "4.58.4"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-typography/-/f36-typography-4.58.4.tgz#67068f0ec85474143ac04cfa61e87970ca862058"
+  integrity sha512-d292/4NuLKqsFNWrP0GOQxxjszhSZKIPViHtkAvQOggOVDYBPy7MQ4vbNrtOMJNNZmbEYcHhSi+GaoUWmgCIAQ==
+  dependencies:
+    "@contentful/f36-core" "^4.58.4"
+    "@contentful/f36-tokens" "^4.0.4"
+    "@contentful/f36-utils" "^4.24.3"
+    emotion "^10.0.17"
+
+"@contentful/f36-typography@^4.60.0":
+  version "4.60.0"
+  resolved "https://npm.pkg.github.com/download/@contentful/f36-typography/4.60.0/0f2c507d9341fb6aaf4fa68876f643c5021b589b#0f2c507d9341fb6aaf4fa68876f643c5021b589b"
+  integrity sha512-iEg1VT0wH3nUKZs8jSCxKnQPWVgrqckRuG3UpLzk4FKfyDHopimFMCLqy+XswWpA+aDRueMC4Il+TVVTO5N7qQ==
+  dependencies:
+    "@contentful/f36-core" "^4.60.0"
     "@contentful/f36-tokens" "^4.0.4"
     "@contentful/f36-utils" "^4.24.3"
     emotion "^10.0.17"
@@ -2494,9 +3085,9 @@
     lodash "^4.17.20"
 
 "@contentful/mimetype@^2.2.29":
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/@contentful/mimetype/-/mimetype-2.3.0.tgz#90ba9f280940f422f58cbfb839a9abd81280d200"
-  integrity sha512-6FFVVs7ziQDo0wH7/Dkrj1oELIbwIdgIDhDFDdgj75tWknr3buIxJgWhj0wt9ffvomE3KketIqI1b/KTRIClqQ==
+  version "2.2.29"
+  resolved "https://registry.yarnpkg.com/@contentful/mimetype/-/mimetype-2.2.29.tgz#717b1d11d3bc94cf4a146cd07f623682f34279b0"
+  integrity sha512-ktfQegKPoBrOTMdnfQPQIGc/CWFnEBdBT0bZJITptGALIh9O2XW/kyvuYgHCyI0kZJFvAmduXnO7Zn2mhA9XyQ==
   dependencies:
     lodash "^4.17.20"
 
@@ -2508,20 +3099,20 @@
     "@contentful/rich-text-types" "^15.15.1"
 
 "@contentful/rich-text-plain-text-renderer@^16.0.4":
-  version "16.0.11"
-  resolved "https://registry.yarnpkg.com/@contentful/rich-text-plain-text-renderer/-/rich-text-plain-text-renderer-16.0.11.tgz#f39a127497b63a4edcbdc48502f58dfcab970bba"
-  integrity sha512-TlAgcJaddoKtqLJigd8hULch1hWJWTeh9q3hKtUQCWXG6aoOm/9creGYz/TYECU3nhKj+dUzCUwGlmyz1bbUmA==
+  version "16.0.7"
+  resolved "https://registry.yarnpkg.com/@contentful/rich-text-plain-text-renderer/-/rich-text-plain-text-renderer-16.0.7.tgz#2bac73d725420d7d6aae7490041bb7e45c666660"
+  integrity sha512-ryFZP3Q279kG5xfL5XmdxFv2peoivGdVq+ZglOlGPfSmpV/fXlrEW9eg/zY7vRJpLQt/XOpf2dQo4giecKPhCA==
   dependencies:
-    "@contentful/rich-text-types" "^16.3.4"
+    "@contentful/rich-text-types" "^16.3.0"
 
 "@contentful/rich-text-react-renderer@^15.16.4":
-  version "15.19.4"
-  resolved "https://registry.yarnpkg.com/@contentful/rich-text-react-renderer/-/rich-text-react-renderer-15.19.4.tgz#129a4040e9ac3115a0936dcc36a8d6868e504f85"
-  integrity sha512-pXBX0utaXLdkloQautphPi6cMWSDU99NwM8oLWwExyNhOzKB2DN0resnp/ZmXj728He7aYXX48VA1nVTRqS77g==
+  version "15.19.0"
+  resolved "https://registry.yarnpkg.com/@contentful/rich-text-react-renderer/-/rich-text-react-renderer-15.19.0.tgz#9aa9f485170354cea6bbef5d63e0118b84f58c96"
+  integrity sha512-2lFDmoWocUXNxk+yvHNSUIgdhm7FCyE57KjYxuTnoC8R2nPVY+mC0I2c0aTOcP4CX/2QqZe/FAoospjU6nk1uw==
   dependencies:
-    "@contentful/rich-text-types" "^16.3.4"
+    "@contentful/rich-text-types" "^16.3.0"
 
-"@contentful/rich-text-types@16.3.0", "@contentful/rich-text-types@^15.12.1", "@contentful/rich-text-types@^15.15.1", "@contentful/rich-text-types@^16.0.2", "@contentful/rich-text-types@^16.3.0", "@contentful/rich-text-types@^16.3.4":
+"@contentful/rich-text-types@16.3.0", "@contentful/rich-text-types@^15.12.1", "@contentful/rich-text-types@^15.15.1", "@contentful/rich-text-types@^16.0.2", "@contentful/rich-text-types@^16.3.0":
   version "16.3.0"
   resolved "https://registry.yarnpkg.com/@contentful/rich-text-types/-/rich-text-types-16.3.0.tgz#d44145a43b32d61eb4d6a82d3001cdfddbbda42e"
   integrity sha512-OfQmAu5bxE0CgQA3WlUleVej+ifFG/iXmB2DmUl4EyWyFue1aiIvfjxQhcDRSH4n1jUNMJ6L1wInZL8uV5m3TQ==
@@ -3751,9 +4342,9 @@
   integrity sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==
 
 "@jridgewell/trace-mapping@^0.3.12", "@jridgewell/trace-mapping@^0.3.17", "@jridgewell/trace-mapping@^0.3.18", "@jridgewell/trace-mapping@^0.3.20", "@jridgewell/trace-mapping@^0.3.9":
-  version "0.3.22"
-  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.22.tgz#72a621e5de59f5f1ef792d0793a82ee20f645e4c"
-  integrity sha512-Wf963MzWtA2sjrNt+g18IAln9lKnlRp+K2eH4jjIoF1wYeq3aMREpG09xhlhdzS0EjwU7qmUJYangWa+151vZw==
+  version "0.3.21"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.21.tgz#5dc1df7b3dc4a6209e503a924e1ca56097a2bb15"
+  integrity sha512-SRfKmRe1KvYnxjEMtxEr+J4HIeMX5YBg/qhRHpxEIGjhX1rshcHlnFUE9K0GazhVKWM7B+nARSkV8LuvJdJ5/g==
   dependencies:
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
@@ -3891,9 +4482,9 @@
     "@lezer/lr" "^1.0.0"
 
 "@lezer/lr@^1.0.0":
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/@lezer/lr/-/lr-1.4.0.tgz#ed52a75dbbfbb0d1eb63710ea84c35ee647cb67e"
-  integrity sha512-Wst46p51km8gH0ZUmeNrtpRYmdlRHUpN1DQd3GFAyKANi8WVz8c2jHYTf1CVScFaCjQw1iO3ZZdqGDxQPRErTg==
+  version "1.3.14"
+  resolved "https://registry.yarnpkg.com/@lezer/lr/-/lr-1.3.14.tgz#59d4a3b25698bdac0ef182fa6eadab445fc4f29a"
+  integrity sha512-z5mY4LStlA3yL7aHT/rqgG614cfcvklS+8oFRFBYrs4YaWLJyKKM4+nN6KopToX0o9Hj6zmH6M5kinOYuy06ug==
   dependencies:
     "@lezer/common" "^1.0.0"
 
@@ -4771,9 +5362,9 @@
     picomatch "^2.2.2"
 
 "@rushstack/eslint-patch@^1.1.0":
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/@rushstack/eslint-patch/-/eslint-patch-1.7.2.tgz#2d4260033e199b3032a08b41348ac10de21c47e9"
-  integrity sha512-RbhOOTCNoCrbfkRyoXODZp75MlpiHMgbE5MEBZAnnnLyQNgrigEj4p0lzsMDyc1zVsJDLrivB58tgg3emX0eEA==
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@rushstack/eslint-patch/-/eslint-patch-1.7.0.tgz#b5bc1e081428794f6a4d239707b359404be35ce2"
+  integrity sha512-Jh4t/593gxs0lJZ/z3NnasKlplXT2f+4y/LZYuaKZW5KAaiVFL/fThhs+17EbUd53jUVJ0QudYCBGbN/psvaqg==
 
 "@samverschueren/stream-to-observable@^0.3.0":
   version "0.3.1"
@@ -4794,10 +5385,10 @@
     import-from "^3.0.0"
     lodash "^4.17.4"
 
-"@sideway/address@^4.1.5":
-  version "4.1.5"
-  resolved "https://registry.yarnpkg.com/@sideway/address/-/address-4.1.5.tgz#4bc149a0076623ced99ca8208ba780d65a99b9d5"
-  integrity sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==
+"@sideway/address@^4.1.4":
+  version "4.1.4"
+  resolved "https://registry.yarnpkg.com/@sideway/address/-/address-4.1.4.tgz#03dccebc6ea47fdc226f7d3d1ad512955d4783f0"
+  integrity sha512-7vwq+rOHVWjyXxVlR76Agnvhy8I9rpzjosTESvmhNeXOXdZZB15Fl+TI9x1SiHZH5Jv2wTGduSxFDIaq0m3DUw==
   dependencies:
     "@hapi/hoek" "^9.0.0"
 
@@ -4868,9 +5459,9 @@
     type-detect "4.0.8"
 
 "@sinonjs/commons@^3.0.0":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-3.0.1.tgz#1029357e44ca901a615585f6d27738dbc89084cd"
-  integrity sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-3.0.0.tgz#beb434fe875d965265e04722ccfc21df7f755d72"
+  integrity sha512-jXBtWAF4vmdNmZgD5FoKsVLv3rPgDnLgPbU84LIJ3otV44vJlDRokVng5v8NFJdCf/da9legHcKaRuZs4L7faA==
   dependencies:
     type-detect "4.0.8"
 
@@ -5052,15 +5643,15 @@
     ts-dedent "^2.0.0"
     util-deprecate "^1.0.2"
 
-"@storybook/builder-manager@7.6.14":
-  version "7.6.14"
-  resolved "https://registry.yarnpkg.com/@storybook/builder-manager/-/builder-manager-7.6.14.tgz#fd1f0ca3862e0060c1e9e1fd78fa243ef10b182b"
-  integrity sha512-pID/g2Bnr3tjmkh8c+O6TZei3f1TWHW/UWi/skNQ3wGJ+9dqJIK2vQY5SwnXBWkmJdUqGVXaW5BvzR8jjfpTxQ==
+"@storybook/builder-manager@7.6.15":
+  version "7.6.15"
+  resolved "https://registry.yarnpkg.com/@storybook/builder-manager/-/builder-manager-7.6.15.tgz#32e40e03ba1cd4d7755ac2072d2d3472accedff0"
+  integrity sha512-vfpfCywiasyP7vtbgLJhjssBEwUjZhBsRsubDAzumgOochPiKKPNwsSc5NU/4ZIGaC5zRO26kUaUqFIbJdTEUQ==
   dependencies:
     "@fal-works/esbuild-plugin-global-externals" "^2.1.2"
-    "@storybook/core-common" "7.6.14"
-    "@storybook/manager" "7.6.14"
-    "@storybook/node-logger" "7.6.14"
+    "@storybook/core-common" "7.6.15"
+    "@storybook/manager" "7.6.15"
+    "@storybook/node-logger" "7.6.15"
     "@types/ejs" "^3.1.1"
     "@types/find-cache-dir" "^3.2.1"
     "@yarnpkg/esbuild-plugin-pnp" "^3.0.0-rc.10"
@@ -5130,23 +5721,35 @@
     telejson "^7.2.0"
     tiny-invariant "^1.3.1"
 
-"@storybook/cli@7.6.14":
-  version "7.6.14"
-  resolved "https://registry.yarnpkg.com/@storybook/cli/-/cli-7.6.14.tgz#fda38360cf728b4d90e633cbca031daed542c5e8"
-  integrity sha512-2xqcGRPtj/OE+9ro92C5MFCT8VHdMCDDuZZRnmgPi83iqSZtYbO8xHZwz78j4TvmouHstOV1SedeWv0IsFIxLw==
+"@storybook/channels@7.6.15":
+  version "7.6.15"
+  resolved "https://registry.yarnpkg.com/@storybook/channels/-/channels-7.6.15.tgz#12e57275643fd2af790fe2903dc247a348ddc472"
+  integrity sha512-UPDYRzGkygYFa8QUpEiumWrvZm4u4RKVzgiBt9C4RmHORqkkZzL9LXhaZJp2SmIz1ND5gx6KR5ze8ZnAdwxxoQ==
+  dependencies:
+    "@storybook/client-logger" "7.6.15"
+    "@storybook/core-events" "7.6.15"
+    "@storybook/global" "^5.0.0"
+    qs "^6.10.0"
+    telejson "^7.2.0"
+    tiny-invariant "^1.3.1"
+
+"@storybook/cli@7.6.15":
+  version "7.6.15"
+  resolved "https://registry.yarnpkg.com/@storybook/cli/-/cli-7.6.15.tgz#003516e816cf057c2d4f3780b24771db953f6ccf"
+  integrity sha512-2QRqCyVGDSkraHxX2JPYkkFccbu5Uo+JYFaFJo4vmMXzDurjWON+Ga2B8FCTd4A8P4C02Ca/79jgQoyBB3xoew==
   dependencies:
     "@babel/core" "^7.23.2"
     "@babel/preset-env" "^7.23.2"
     "@babel/types" "^7.23.0"
     "@ndelangen/get-tarball" "^3.0.7"
-    "@storybook/codemod" "7.6.14"
-    "@storybook/core-common" "7.6.14"
-    "@storybook/core-events" "7.6.14"
-    "@storybook/core-server" "7.6.14"
-    "@storybook/csf-tools" "7.6.14"
-    "@storybook/node-logger" "7.6.14"
-    "@storybook/telemetry" "7.6.14"
-    "@storybook/types" "7.6.14"
+    "@storybook/codemod" "7.6.15"
+    "@storybook/core-common" "7.6.15"
+    "@storybook/core-events" "7.6.15"
+    "@storybook/core-server" "7.6.15"
+    "@storybook/csf-tools" "7.6.15"
+    "@storybook/node-logger" "7.6.15"
+    "@storybook/telemetry" "7.6.15"
+    "@storybook/types" "7.6.15"
     "@types/semver" "^7.3.4"
     "@yarnpkg/fslib" "2.10.3"
     "@yarnpkg/libzip" "2.3.0"
@@ -5183,18 +5786,25 @@
   dependencies:
     "@storybook/global" "^5.0.0"
 
-"@storybook/codemod@7.6.14":
-  version "7.6.14"
-  resolved "https://registry.yarnpkg.com/@storybook/codemod/-/codemod-7.6.14.tgz#86dd6595deb0b4aebaa0ef9e153dba4445c68c7a"
-  integrity sha512-Sq/Q12KmvzaSUtmbtD26cEEGVmZLUA+iiNHbl0n65MMka6QBGG/VgSPvSgu+GEpKowbVoqfMpH4Ic16A6XsNFg==
+"@storybook/client-logger@7.6.15":
+  version "7.6.15"
+  resolved "https://registry.yarnpkg.com/@storybook/client-logger/-/client-logger-7.6.15.tgz#fc75c91376202801f55696b8949f266c44c76578"
+  integrity sha512-n+K8IqnombqiQNnywVovS+lK61tvv/XSfgPt0cgvoF/hJZB0VDOMRjWsV+v9qQpj1TQEl1lLWeJwZMthTWupJA==
+  dependencies:
+    "@storybook/global" "^5.0.0"
+
+"@storybook/codemod@7.6.15":
+  version "7.6.15"
+  resolved "https://registry.yarnpkg.com/@storybook/codemod/-/codemod-7.6.15.tgz#dc749a31660ef5f211016198b1576f35e89647d0"
+  integrity sha512-NiEbTLCdacj6TMxC7G49IImXeMzkG8wpPr8Ayxm9HeG6q5UkiF5/DiZdqbJm2zaosOsOKWwvXg1t6Pq6Nivytg==
   dependencies:
     "@babel/core" "^7.23.2"
     "@babel/preset-env" "^7.23.2"
     "@babel/types" "^7.23.0"
     "@storybook/csf" "^0.1.2"
-    "@storybook/csf-tools" "7.6.14"
-    "@storybook/node-logger" "7.6.14"
-    "@storybook/types" "7.6.14"
+    "@storybook/csf-tools" "7.6.15"
+    "@storybook/node-logger" "7.6.15"
+    "@storybook/types" "7.6.15"
     "@types/cross-spawn" "^6.0.2"
     cross-spawn "^7.0.3"
     globby "^11.0.2"
@@ -5256,6 +5866,35 @@
     resolve-from "^5.0.0"
     ts-dedent "^2.0.0"
 
+"@storybook/core-common@7.6.15":
+  version "7.6.15"
+  resolved "https://registry.yarnpkg.com/@storybook/core-common/-/core-common-7.6.15.tgz#8ba894b91c514c9dd03b20f963118c7233e4a78f"
+  integrity sha512-VGmcLJ5U1r1s8/YnLbKcyB4GnNL+/sZIPqwlcSKzDXO76HoVFv1kywf7PbASote7P3gdhLSxBdg95LH2bdIbmw==
+  dependencies:
+    "@storybook/core-events" "7.6.15"
+    "@storybook/node-logger" "7.6.15"
+    "@storybook/types" "7.6.15"
+    "@types/find-cache-dir" "^3.2.1"
+    "@types/node" "^18.0.0"
+    "@types/node-fetch" "^2.6.4"
+    "@types/pretty-hrtime" "^1.0.0"
+    chalk "^4.1.0"
+    esbuild "^0.18.0"
+    esbuild-register "^3.5.0"
+    file-system-cache "2.3.0"
+    find-cache-dir "^3.0.0"
+    find-up "^5.0.0"
+    fs-extra "^11.1.0"
+    glob "^10.0.0"
+    handlebars "^4.7.7"
+    lazy-universal-dotenv "^4.0.0"
+    node-fetch "^2.0.0"
+    picomatch "^2.3.0"
+    pkg-dir "^5.0.0"
+    pretty-hrtime "^1.0.3"
+    resolve-from "^5.0.0"
+    ts-dedent "^2.0.0"
+
 "@storybook/core-events@7.6.14":
   version "7.6.14"
   resolved "https://registry.yarnpkg.com/@storybook/core-events/-/core-events-7.6.14.tgz#4ba595ea6df1bd760e8ed5c9ec8a39a722e09339"
@@ -5263,26 +5902,33 @@
   dependencies:
     ts-dedent "^2.0.0"
 
-"@storybook/core-server@7.6.14":
-  version "7.6.14"
-  resolved "https://registry.yarnpkg.com/@storybook/core-server/-/core-server-7.6.14.tgz#87e80529354a7c757176aa184d5a1e2688651c15"
-  integrity sha512-OSUunvjXyUiyfGet8ZBz7/Lka6dSgbbVMH7lU6wELIYCd2ZUxU5HQMl9JPesl61wWB4L3JaWFAoMRaCVI7q0xQ==
+"@storybook/core-events@7.6.15":
+  version "7.6.15"
+  resolved "https://registry.yarnpkg.com/@storybook/core-events/-/core-events-7.6.15.tgz#8c9b78a4b09099548bace869d689ad92d237d229"
+  integrity sha512-i4YnjGecbpGyrFe0340sPhQ9QjZZEBqvMy6kF4XWt6DYLHxZmsTj1HEdvxVl4Ej7V49Vw0Dm8MepJ1d4Y8MKrQ==
+  dependencies:
+    ts-dedent "^2.0.0"
+
+"@storybook/core-server@7.6.15":
+  version "7.6.15"
+  resolved "https://registry.yarnpkg.com/@storybook/core-server/-/core-server-7.6.15.tgz#d7529ba79e8f880869ed09ab1c73f1c91fe6a70b"
+  integrity sha512-iIlxEAkrmKTSA3iGNqt/4QG7hf5suxBGYIB3DZAOfBo8EdZogMYaEmuCm5dbuaJr0mcVwlqwdhQiWb1VsR/NhA==
   dependencies:
     "@aw-web-design/x-default-browser" "1.4.126"
     "@discoveryjs/json-ext" "^0.5.3"
-    "@storybook/builder-manager" "7.6.14"
-    "@storybook/channels" "7.6.14"
-    "@storybook/core-common" "7.6.14"
-    "@storybook/core-events" "7.6.14"
+    "@storybook/builder-manager" "7.6.15"
+    "@storybook/channels" "7.6.15"
+    "@storybook/core-common" "7.6.15"
+    "@storybook/core-events" "7.6.15"
     "@storybook/csf" "^0.1.2"
-    "@storybook/csf-tools" "7.6.14"
+    "@storybook/csf-tools" "7.6.15"
     "@storybook/docs-mdx" "^0.1.0"
     "@storybook/global" "^5.0.0"
-    "@storybook/manager" "7.6.14"
-    "@storybook/node-logger" "7.6.14"
-    "@storybook/preview-api" "7.6.14"
-    "@storybook/telemetry" "7.6.14"
-    "@storybook/types" "7.6.14"
+    "@storybook/manager" "7.6.15"
+    "@storybook/node-logger" "7.6.15"
+    "@storybook/preview-api" "7.6.15"
+    "@storybook/telemetry" "7.6.15"
+    "@storybook/types" "7.6.15"
     "@types/detect-port" "^1.3.0"
     "@types/node" "^18.0.0"
     "@types/pretty-hrtime" "^1.0.0"
@@ -5344,6 +5990,21 @@
     recast "^0.23.1"
     ts-dedent "^2.0.0"
 
+"@storybook/csf-tools@7.6.15":
+  version "7.6.15"
+  resolved "https://registry.yarnpkg.com/@storybook/csf-tools/-/csf-tools-7.6.15.tgz#aee2a6ec77f708246d3567310e1ffe79cfefe59e"
+  integrity sha512-8iKgg2cmbFTpVhRRJOqouhPcEh0c8ywabG4S8ICZvnJooSXUI9mD9p3tYCS7MYuSiHj0epa1Kkn9DtXJRo9o6g==
+  dependencies:
+    "@babel/generator" "^7.23.0"
+    "@babel/parser" "^7.23.0"
+    "@babel/traverse" "^7.23.2"
+    "@babel/types" "^7.23.0"
+    "@storybook/csf" "^0.1.2"
+    "@storybook/types" "7.6.15"
+    fs-extra "^11.1.0"
+    recast "^0.23.1"
+    ts-dedent "^2.0.0"
+
 "@storybook/csf@^0.0.1":
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/@storybook/csf/-/csf-0.0.1.tgz#95901507dc02f0bc6f9ac8ee1983e2fc5bb98ce6"
@@ -5401,10 +6062,10 @@
     telejson "^7.2.0"
     ts-dedent "^2.0.0"
 
-"@storybook/manager@7.6.14":
-  version "7.6.14"
-  resolved "https://registry.yarnpkg.com/@storybook/manager/-/manager-7.6.14.tgz#589933b68766f79235a73788a7dfa2042f9a3576"
-  integrity sha512-lgowunC/pm2y6d+3j7UJ/CkHpWC0o+nZ9b7mDbkJ6PmezW5Hpy83kbeCxbwRGosYoPQ0izBzVB5ZqGgKrNNDjA==
+"@storybook/manager@7.6.15":
+  version "7.6.15"
+  resolved "https://registry.yarnpkg.com/@storybook/manager/-/manager-7.6.15.tgz#2894be039b93b3dfdb75fc568f9def06e19d0b79"
+  integrity sha512-GGV2ElV5AOIApy/FSDzoSlLUbyd2VhQVD3TdNGRxNauYRjEO8ulXHw2tNbT6ludtpYpDTAILzI6zT/iag8hmPQ==
 
 "@storybook/mdx2-csf@^1.0.0":
   version "1.1.0"
@@ -5415,6 +6076,11 @@
   version "7.6.14"
   resolved "https://registry.yarnpkg.com/@storybook/node-logger/-/node-logger-7.6.14.tgz#3ab4094a68e606733363fd1692590673b1d83fa2"
   integrity sha512-prKUMGxGzeX3epdlin1UU6M1//CoAJM1GrffrFeNntnPr3h6GMTgxNzl85flUhWd4ky/wjC/36dGOI8QRYVtoA==
+
+"@storybook/node-logger@7.6.15":
+  version "7.6.15"
+  resolved "https://registry.yarnpkg.com/@storybook/node-logger/-/node-logger-7.6.15.tgz#df14693e10ca82c9580bba68363d062215f74655"
+  integrity sha512-C+sCvRjR+5uVU3VTrfyv7/RlPBxesAjIucUAK0keGyIZ7sFQYCPdkm4m/C4s+TcubgAzVvuoUHlRrSppdA7WzQ==
 
 "@storybook/postinstall@7.6.14":
   version "7.6.14"
@@ -5455,6 +6121,26 @@
     "@storybook/csf" "^0.1.2"
     "@storybook/global" "^5.0.0"
     "@storybook/types" "7.6.14"
+    "@types/qs" "^6.9.5"
+    dequal "^2.0.2"
+    lodash "^4.17.21"
+    memoizerific "^1.11.3"
+    qs "^6.10.0"
+    synchronous-promise "^2.0.15"
+    ts-dedent "^2.0.0"
+    util-deprecate "^1.0.2"
+
+"@storybook/preview-api@7.6.15":
+  version "7.6.15"
+  resolved "https://registry.yarnpkg.com/@storybook/preview-api/-/preview-api-7.6.15.tgz#d0b099b324eeeeaef714a01f81dd8b1d5b8f31f7"
+  integrity sha512-2KN9vlizF6sFlYsJEGnFqcQaJXs4TTdawC1VazVdtaMSHANDxxDu8F1cP+u7lpPH3DkNZUmTGQDBYfYY9xR0eQ==
+  dependencies:
+    "@storybook/channels" "7.6.15"
+    "@storybook/client-logger" "7.6.15"
+    "@storybook/core-events" "7.6.15"
+    "@storybook/csf" "^0.1.2"
+    "@storybook/global" "^5.0.0"
+    "@storybook/types" "7.6.15"
     "@types/qs" "^6.9.5"
     dequal "^2.0.2"
     lodash "^4.17.21"
@@ -5533,14 +6219,14 @@
     memoizerific "^1.11.3"
     qs "^6.10.0"
 
-"@storybook/telemetry@7.6.14":
-  version "7.6.14"
-  resolved "https://registry.yarnpkg.com/@storybook/telemetry/-/telemetry-7.6.14.tgz#a12a97c6bff49444433ebae8891321b12090d6d1"
-  integrity sha512-F+a9Q4dHCpuBLQmB05DOLosU8p1Otj3Vd+/5EF9QUFSn4C64z1gmMc3jzF3iUgktY53HdoUqR871w3GoOJ7g9A==
+"@storybook/telemetry@7.6.15":
+  version "7.6.15"
+  resolved "https://registry.yarnpkg.com/@storybook/telemetry/-/telemetry-7.6.15.tgz#648e40b108b835c6c25c61a28e92e3fb6d87e561"
+  integrity sha512-klhKXLUS3OXozGEtMbbhKZLDfm+m3nNk2jvGwD6kkBenzFUzb0P2m8awxU7h1pBcKZKH/27U9t3KVzNFzWoWPw==
   dependencies:
-    "@storybook/client-logger" "7.6.14"
-    "@storybook/core-common" "7.6.14"
-    "@storybook/csf-tools" "7.6.14"
+    "@storybook/client-logger" "7.6.15"
+    "@storybook/core-common" "7.6.15"
+    "@storybook/csf-tools" "7.6.15"
     chalk "^4.1.0"
     detect-package-manager "^2.0.1"
     fetch-retry "^5.0.2"
@@ -5563,6 +6249,16 @@
   integrity sha512-sJ3qn45M2XLXlOi+wkhXK5xsXbSVzi8YGrusux//DttI3s8wCP3BQSnEgZkBiEktloxPferINHT1er8/9UK7Xw==
   dependencies:
     "@storybook/channels" "7.6.14"
+    "@types/babel__core" "^7.0.0"
+    "@types/express" "^4.7.0"
+    file-system-cache "2.3.0"
+
+"@storybook/types@7.6.15":
+  version "7.6.15"
+  resolved "https://registry.yarnpkg.com/@storybook/types/-/types-7.6.15.tgz#80411ea62bb56a0bc28ce5ece6f577957f3d049f"
+  integrity sha512-tLH0lK6SXECSfMpKin9bge+7XiHZII17n6jc9ZI1TfSBZJyq3M6VzWh2r1C2lC97FlkcKXjIwM3n8h1xNjnI+A==
+  dependencies:
+    "@storybook/channels" "7.6.15"
     "@types/babel__core" "^7.0.0"
     "@types/express" "^4.7.0"
     file-system-cache "2.3.0"
@@ -5838,7 +6534,12 @@
     "@swc/core-win32-ia32-msvc" "1.4.1"
     "@swc/core-win32-x64-msvc" "1.4.1"
 
-"@swc/counter@^0.1.1", "@swc/counter@^0.1.2", "@swc/counter@^0.1.3":
+"@swc/counter@^0.1.1":
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/@swc/counter/-/counter-0.1.2.tgz#bf06d0770e47c6f1102270b744e17b934586985e"
+  integrity sha512-9F4ys4C74eSTEUNndnER3VJ15oru2NumfQxS8geE+f3eB5xvfxpWyqE5XlVnxb/R14uoXi6SLbBwwiDSkv+XEw==
+
+"@swc/counter@^0.1.2", "@swc/counter@^0.1.3":
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/@swc/counter/-/counter-0.1.3.tgz#cc7463bd02949611c6329596fccd2b0ec782b0e9"
   integrity sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==
@@ -6214,7 +6915,7 @@
     "@types/estree" "*"
     "@types/json-schema" "*"
 
-"@types/estree@*", "@types/estree@^1.0.0", "@types/estree@^1.0.5":
+"@types/estree@*", "@types/estree@^1.0.0":
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.5.tgz#a6ce3e556e00fd9895dd872dd172ad0d4bd687f4"
   integrity sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==
@@ -6230,9 +6931,9 @@
   integrity sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==
 
 "@types/express-serve-static-core@*", "@types/express-serve-static-core@^4.17.33":
-  version "4.17.43"
-  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.43.tgz#10d8444be560cb789c4735aea5eac6e5af45df54"
-  integrity sha512-oaYtiBirUOPQGSWNGPWnzyAFJ0BP3cwvN4oWZQY+zUBwpVIGsKUkpBpSztp74drYcjavs7SKFZ4DX1V2QeN8rg==
+  version "4.17.41"
+  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.41.tgz#5077defa630c2e8d28aa9ffc2c01c157c305bef6"
+  integrity sha512-OaJ7XLaelTgrvlZD8/aa0vvvxZdUmlCn6MtWeB7TkiKW70BQLc9XEPpDLPdbo52ZhXUCrznlWdCHWxJWtdyajA==
   dependencies:
     "@types/node" "*"
     "@types/qs" "*"
@@ -6277,16 +6978,16 @@
     "@types/node" "*"
 
 "@types/hast@^2.0.0":
-  version "2.3.10"
-  resolved "https://registry.yarnpkg.com/@types/hast/-/hast-2.3.10.tgz#5c9d9e0b304bbb8879b857225c5ebab2d81d7643"
-  integrity sha512-McWspRw8xx8J9HurkVBfYj0xKoE25tOFlHGdx4MJ5xORQrMGZNqJhVQWaIbm6Oyla5kYOXtDiopzKRJzEOkwJw==
+  version "2.3.9"
+  resolved "https://registry.yarnpkg.com/@types/hast/-/hast-2.3.9.tgz#a9a1b5bbce46e8a1312e977364bacabc8e93d2cf"
+  integrity sha512-pTHyNlaMD/oKJmS+ZZUyFUcsZeBZpC0lmGquw98CqRVNgAdJZJeD7GoeLiT6Xbx5rU9VCjSt0RwEvDgzh4obFw==
   dependencies:
     "@types/unist" "^2"
 
 "@types/hast@^3.0.0":
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/@types/hast/-/hast-3.0.4.tgz#1d6b39993b82cea6ad783945b0508c25903e15aa"
-  integrity sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@types/hast/-/hast-3.0.3.tgz#7f75e6b43bc3f90316046a287d9ad3888309f7e1"
+  integrity sha512-2fYGlaDy/qyLlhidX42wAH0KBi2TCjKMH8CHmBXgRlJ3Y+OXTiqsPQ6IWarZKwF1JoUcAJdPogv1d4b0COTpmQ==
   dependencies:
     "@types/unist" "*"
 
@@ -6347,9 +7048,9 @@
     "@types/istanbul-lib-report" "*"
 
 "@types/jest@*":
-  version "29.5.12"
-  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-29.5.12.tgz#7f7dc6eb4cf246d2474ed78744b05d06ce025544"
-  integrity sha512-eDC8bTvT/QhYdxJAulQikueigY5AsdBRH2yDKW3yveW7svY3+DzN84/2NUgkw10RTiJbWqZrTtoGVdYlvFJdLw==
+  version "29.5.11"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-29.5.11.tgz#0c13aa0da7d0929f078ab080ae5d4ced80fa2f2c"
+  integrity sha512-S2mHmYIVe13vrm6q4kN6fLYYAka15ALQki/vgDC3mIukEOx8WJlv0kQPM+d4w8Gp6u0uSdKND04IlTXBv0rwnQ==
   dependencies:
     expect "^29.0.0"
     pretty-format "^29.0.0"
@@ -6428,9 +7129,9 @@
     "@types/unist" "*"
 
 "@types/mdx@^2.0.0":
-  version "2.0.11"
-  resolved "https://registry.yarnpkg.com/@types/mdx/-/mdx-2.0.11.tgz#21f4c166ed0e0a3a733869ba04cd8daea9834b8e"
-  integrity sha512-HM5bwOaIQJIQbAYfax35HCKxx7a3KrK3nBtIqJgSOitivTD1y3oW9P3rxY9RkXYPUk7y/AjAohfHKmFpGE79zw==
+  version "2.0.10"
+  resolved "https://registry.yarnpkg.com/@types/mdx/-/mdx-2.0.10.tgz#0d7b57fb1d83e27656156e4ee0dfba96532930e4"
+  integrity sha512-Rllzc5KHk0Al5/WANwgSPl1/CwjqCy+AZrGd78zuK+jO9aDM6ffblZ+zIjgPNAaEBmlO0RYDvLNh7wD0zKVgEg==
 
 "@types/mime-types@^2.1.0":
   version "2.1.4"
@@ -6483,16 +7184,23 @@
     "@types/node" "*"
 
 "@types/node@*", "@types/node@^20.0.0", "@types/node@^20.6.5":
-  version "20.11.17"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.11.17.tgz#cdd642d0e62ef3a861f88ddbc2b61e32578a9292"
-  integrity sha512-QmgQZGWu1Yw9TDyAP9ZzpFJKynYNeOvwMJmaxABfieQoVoiVOS6MN1WSpqpRcbeA5+RW82kraAVxCCJg+780Qw==
+  version "20.11.5"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.11.5.tgz#be10c622ca7fcaa3cf226cf80166abc31389d86e"
+  integrity sha512-g557vgQjUUfN76MZAN/dt1z3dzcUsimuysco0KeluHgrPdJXkP/XdAURgyO2W9fZWHRtRBiVKzKn8vyOAwlG+w==
   dependencies:
     undici-types "~5.26.4"
 
-"@types/node@^18.0.0", "@types/node@^18.17.5":
+"@types/node@^18.0.0":
   version "18.19.15"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.19.15.tgz#313a9d75435669a57fc28dc8694e7f4c4319f419"
   integrity sha512-AMZ2UWx+woHNfM11PyAEQmfSxi05jm9OlkxczuHeEqmvwPkYj6MWv44gbzDPefYOLysTOFyI3ziiy2ONmUZfpA==
+  dependencies:
+    undici-types "~5.26.4"
+
+"@types/node@^18.17.5":
+  version "18.19.8"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.19.8.tgz#c1e42b165e5a526caf1f010747e0522cb2c9c36a"
+  integrity sha512-g1pZtPhsvGVTwmeVoexWZLTQaOvXwoSq//pTL0DHeNzUDrFnir4fgETdhjhIxjVnN+hKOuh98+E1eMLnUXstFg==
   dependencies:
     undici-types "~5.26.4"
 
@@ -6562,9 +7270,9 @@
     "@types/react" "*"
 
 "@types/react-dom@>=16.9.0":
-  version "18.2.19"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.2.19.tgz#b84b7c30c635a6c26c6a6dfbb599b2da9788be58"
-  integrity sha512-aZvQL6uUbIJpjZk4U8JZGbau9KDeAwMfmhyWorxgBkqDIEf6ROjRozcmPIicqsUwPUjbkDfHKgGee1Lq65APcA==
+  version "18.2.18"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.2.18.tgz#16946e6cd43971256d874bc3d0a72074bb8571dd"
+  integrity sha512-TJxDm6OfAX2KJWJdMEVTwWke5Sc/E/RlnPGvGfS0W7+6ocy2xhDVQVh/KvC2Uf7kACs+gDytdusDSdWfWkaNzw==
   dependencies:
     "@types/react" "*"
 
@@ -6635,9 +7343,9 @@
   integrity sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==
 
 "@types/semver@^7.3.12", "@types/semver@^7.3.4", "@types/semver@^7.5.0":
-  version "7.5.7"
-  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.5.7.tgz#326f5fdda70d13580777bcaa1bc6fa772a5aef0e"
-  integrity sha512-/wdoPq1QqkSj9/QOeKkFquEuPzQbHTWAMPH/PaUMB+JuR31lXhlWXRZ52IpfDYVlDOUBvX09uBrPwxGT1hjNBg==
+  version "7.5.6"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.5.6.tgz#c65b2bfce1bec346582c07724e3f8c1017a20339"
+  integrity sha512-dn1l8LaMea/IjDoHNd9J52uBbInB796CDffS6VdIxvqYCPSG0V0DzHp76GpaWnlhg88uYyPbXCDIowa86ybd5A==
 
 "@types/send@*":
   version "0.17.4"
@@ -8372,13 +9080,13 @@ arr-union@^3.1.0:
   resolved "https://registry.yarnpkg.com/arr-union/-/arr-union-3.1.0.tgz#e39b09aea9def866a8f206e288af63919bae39c4"
   integrity sha512-sKpyeERZ02v1FeCZT8lrfJq5u6goHCtpTAzPwJYe7c8SPFOboNjNg1vz2L4VTn9T4PQxEx13TbXLmYUcS6Ug7Q==
 
-array-buffer-byte-length@^1.0.0, array-buffer-byte-length@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/array-buffer-byte-length/-/array-buffer-byte-length-1.0.1.tgz#1e5583ec16763540a27ae52eed99ff899223568f"
-  integrity sha512-ahC5W1xgou+KTXix4sAO8Ki12Q+jf4i0+tmk3sC+zgcynshkHxzpXdImBehiUYKKKDwvfFiJl1tZt6ewscS1Mg==
+array-buffer-byte-length@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/array-buffer-byte-length/-/array-buffer-byte-length-1.0.0.tgz#fabe8bc193fea865f317fe7807085ee0dee5aead"
+  integrity sha512-LPuwb2P+NrQw3XhxGc36+XSvuBPopovXYTR9Ew++Du9Yb/bx5AzBfrIsBoj0EZUifjQU+sHL21sseZ3jerWO/A==
   dependencies:
-    call-bind "^1.0.5"
-    is-array-buffer "^3.0.4"
+    call-bind "^1.0.2"
+    is-array-buffer "^3.0.1"
 
 array-differ@^3.0.0:
   version "3.0.0"
@@ -8443,27 +9151,16 @@ array-unique@^0.3.2:
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.3.2.tgz#a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428"
   integrity sha512-SleRWjh9JUud2wH1hPs9rZBZ33H6T9HOiL0uwGnGx9FpE6wKGyfWugmbkEOIs6qWrZhg0LWeLziLrEwQJhs5mQ==
 
-array.prototype.filter@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/array.prototype.filter/-/array.prototype.filter-1.0.3.tgz#423771edeb417ff5914111fff4277ea0624c0d0e"
-  integrity sha512-VizNcj/RGJiUyQBgzwxzE5oHdeuXY5hSbbmKMlphj1cy1Vl7Pn2asCGbSrru6hSQjmCzqTBPVWAF/whmEOVHbw==
+array.prototype.findlastindex@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.3.tgz#b37598438f97b579166940814e2c0493a4f50207"
+  integrity sha512-LzLoiOMAxvy+Gd3BAq3B7VeIgPdo+Q8hthvKtXybMvRV0jrXfJM/t8mw7nNlpEcVlVUnCnM2KSX4XU5HmpodOA==
   dependencies:
     call-bind "^1.0.2"
     define-properties "^1.2.0"
     es-abstract "^1.22.1"
-    es-array-method-boxes-properly "^1.0.0"
-    is-string "^1.0.7"
-
-array.prototype.findlastindex@^1.2.3:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.4.tgz#d1c50f0b3a9da191981ff8942a0aedd82794404f"
-  integrity sha512-hzvSHUshSpCflDR1QMUBLHGHP1VIEBegT4pix9H/Z92Xw3ySoy6c2qh7lJWTJnRJ8JCZ9bJNCgTyYaJGcJu6xQ==
-  dependencies:
-    call-bind "^1.0.5"
-    define-properties "^1.2.1"
-    es-abstract "^1.22.3"
-    es-errors "^1.3.0"
-    es-shim-unscopables "^1.0.2"
+    es-shim-unscopables "^1.0.0"
+    get-intrinsic "^1.2.1"
 
 array.prototype.flat@^1.3.1, array.prototype.flat@^1.3.2:
   version "1.3.2"
@@ -8508,28 +9205,27 @@ array.prototype.reduce@^1.0.6:
     is-string "^1.0.7"
 
 array.prototype.tosorted@^1.1.1:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/array.prototype.tosorted/-/array.prototype.tosorted-1.1.3.tgz#c8c89348337e51b8a3c48a9227f9ce93ceedcba8"
-  integrity sha512-/DdH4TiTmOKzyQbp/eadcCVexiCb36xJg7HshYOYJnNZFDj33GEv0P7GxsynpShhq4OLYJzbGcBDkLsDt7MnNg==
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/array.prototype.tosorted/-/array.prototype.tosorted-1.1.2.tgz#620eff7442503d66c799d95503f82b475745cefd"
+  integrity sha512-HuQCHOlk1Weat5jzStICBCd83NxiIMwqDg/dHEsoefabn/hJRj5pVdWcPUSpRrwhwxZOsQassMpgN/xRYFBMIg==
   dependencies:
-    call-bind "^1.0.5"
-    define-properties "^1.2.1"
-    es-abstract "^1.22.3"
-    es-errors "^1.1.0"
-    es-shim-unscopables "^1.0.2"
+    call-bind "^1.0.2"
+    define-properties "^1.2.0"
+    es-abstract "^1.22.1"
+    es-shim-unscopables "^1.0.0"
+    get-intrinsic "^1.2.1"
 
 arraybuffer.prototype.slice@^1.0.2:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.3.tgz#097972f4255e41bc3425e37dc3f6421cf9aefde6"
-  integrity sha512-bMxMKAjg13EBSVscxTaYA4mRc5t1UAXa2kXiGTNfZ079HIWXEkKmkgFrh/nJqamaLSrXO5H4WFFkPEaLJWbs3A==
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.2.tgz#98bd561953e3e74bb34938e77647179dfe6e9f12"
+  integrity sha512-yMBKppFur/fbHu9/6USUe03bZ4knMYiwFBcyiaXB8Go0qNehwX6inYPzK9U0NeQvGxKthcmHcaR8P5MStSRBAw==
   dependencies:
-    array-buffer-byte-length "^1.0.1"
-    call-bind "^1.0.5"
-    define-properties "^1.2.1"
-    es-abstract "^1.22.3"
-    es-errors "^1.2.1"
-    get-intrinsic "^1.2.3"
-    is-array-buffer "^3.0.4"
+    array-buffer-byte-length "^1.0.0"
+    call-bind "^1.0.2"
+    define-properties "^1.2.0"
+    es-abstract "^1.22.1"
+    get-intrinsic "^1.2.1"
+    is-array-buffer "^3.0.2"
     is-shared-array-buffer "^1.0.2"
 
 arrify@^1.0.1:
@@ -8712,10 +9408,10 @@ autoprefixer@^9.6.1:
     postcss "^7.0.32"
     postcss-value-parser "^4.1.0"
 
-available-typed-arrays@^1.0.5, available-typed-arrays@^1.0.6:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.6.tgz#ac812d8ce5a6b976d738e1c45f08d0b00bc7d725"
-  integrity sha512-j1QzY8iPNPG4o4xmO3ptzpRxTciqD3MgEHtifP/YnJpIo58Xu+ne4BejlbkuaLfXn/nz6HFiw29bLpj2PNMdGg==
+available-typed-arrays@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz#92f95616501069d07d10edb2fc37d3e1c65123b7"
+  integrity sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==
 
 aws-sign2@~0.7.0:
   version "0.7.0"
@@ -8754,9 +9450,9 @@ axios@^0.26.0:
     follow-redirects "^1.14.8"
 
 axios@^1.0.0, axios@^1.4.0, axios@^1.6.0, axios@^1.6.1, axios@^1.6.2:
-  version "1.6.7"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.6.7.tgz#7b48c2e27c96f9c68a2f8f31e2ab19f59b06b0a7"
-  integrity sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==
+  version "1.6.5"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.6.5.tgz#2c090da14aeeab3770ad30c3a1461bc970fb0cd8"
+  integrity sha512-Ii012v05KEVuUoFWmMW/UQv9aRIc3ZwkWDcM+h5Il8izZCtRVpDUfwpoFf7eOtajT3QiGR4yDUx7lPqHJULgbg==
   dependencies:
     follow-redirects "^1.15.4"
     form-data "^4.0.0"
@@ -8939,7 +9635,7 @@ babel-plugin-named-asset-import@^0.3.7, babel-plugin-named-asset-import@^0.3.8:
   resolved "https://registry.yarnpkg.com/babel-plugin-named-asset-import/-/babel-plugin-named-asset-import-0.3.8.tgz#6b7fa43c59229685368683c28bc9734f24524cc2"
   integrity sha512-WXiAc++qo7XcJ1ZnTYGtLxmBCVbddAml3CEXgWaBzNzLNoxtQ8AiGEFDMOhot9XjTCQbvP5E77Fj9Gk924f00Q==
 
-babel-plugin-polyfill-corejs2@^0.4.8:
+babel-plugin-polyfill-corejs2@^0.4.7, babel-plugin-polyfill-corejs2@^0.4.8:
   version "0.4.8"
   resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.8.tgz#dbcc3c8ca758a290d47c3c6a490d59429b0d2269"
   integrity sha512-OtIuQfafSzpo/LhnJaykc0R/MMnuLSSVjVYy9mHArIZ9qTCSZ6TpWCuEKZYVoN//t8HqBNScHrOtCrIK5IaGLg==
@@ -8947,6 +9643,14 @@ babel-plugin-polyfill-corejs2@^0.4.8:
     "@babel/compat-data" "^7.22.6"
     "@babel/helper-define-polyfill-provider" "^0.5.0"
     semver "^6.3.1"
+
+babel-plugin-polyfill-corejs3@^0.8.7:
+  version "0.8.7"
+  resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.8.7.tgz#941855aa7fdaac06ed24c730a93450d2b2b76d04"
+  integrity sha512-KyDvZYxAzkC0Aj2dAPyDzi2Ym15e5JKZSK+maI7NAwSqofvuFglbSsxE7wUOvTg9oFVnHMzVzBKcqEb4PJgtOA==
+  dependencies:
+    "@babel/helper-define-polyfill-provider" "^0.4.4"
+    core-js-compat "^3.33.1"
 
 babel-plugin-polyfill-corejs3@^0.9.0:
   version "0.9.0"
@@ -8956,7 +9660,7 @@ babel-plugin-polyfill-corejs3@^0.9.0:
     "@babel/helper-define-polyfill-provider" "^0.5.0"
     core-js-compat "^3.34.0"
 
-babel-plugin-polyfill-regenerator@^0.5.5:
+babel-plugin-polyfill-regenerator@^0.5.4, babel-plugin-polyfill-regenerator@^0.5.5:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.5.5.tgz#8b0c8fc6434239e5d7b8a9d1f832bb2b0310f06a"
   integrity sha512-OJGYZlhLqBh2DDHeqAxWB1XIvr49CxiJ2gIt61/PU55CQK4Z58OzMqjDe1zwQdQk+rBYsRc+1rJmdajM3gimHg==
@@ -9446,7 +10150,17 @@ browserslist@4.14.2:
     escalade "^3.0.2"
     node-releases "^1.1.61"
 
-browserslist@^4.0.0, browserslist@^4.12.0, browserslist@^4.14.5, browserslist@^4.18.1, browserslist@^4.21.10, browserslist@^4.21.4, browserslist@^4.22.2, browserslist@^4.6.2, browserslist@^4.6.4, browserslist@^4.9.1:
+browserslist@^4.0.0, browserslist@^4.12.0, browserslist@^4.14.5, browserslist@^4.18.1, browserslist@^4.21.4, browserslist@^4.22.2, browserslist@^4.6.2, browserslist@^4.6.4, browserslist@^4.9.1:
+  version "4.22.2"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.22.2.tgz#704c4943072bd81ea18997f3bd2180e89c77874b"
+  integrity sha512-0UgcrvQmBDvZHFGdYUehrCNIazki7/lUP3kkoi/r3YB2amZbFM9J43ZRkJTXBUZK4gmx56+Sqk9+Vs9mwZx9+A==
+  dependencies:
+    caniuse-lite "^1.0.30001565"
+    electron-to-chromium "^1.4.601"
+    node-releases "^2.0.14"
+    update-browserslist-db "^1.0.13"
+
+browserslist@^4.22.3:
   version "4.22.3"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.22.3.tgz#299d11b7e947a6b843981392721169e27d60c5a6"
   integrity sha512-UAp55yfwNv0klWNapjs/ktHoguxuQNGnOzxYmfnXIS+8AsRDZkSDxg7R1AX3GKzn078SBI5dzwzj/Yx0Or0e3A==
@@ -9680,16 +10394,14 @@ cachedir@^2.3.0:
   resolved "https://registry.yarnpkg.com/cachedir/-/cachedir-2.4.0.tgz#7fef9cf7367233d7c88068fe6e34ed0d355a610d"
   integrity sha512-9EtFOZR8g22CL7BWjJ9BUx1+A/djkofnyW3aOXZORNW2kxoUpx2h+uN2cOqwPmFhnpVmxg+KW2OjOSgChTEvsQ==
 
-call-bind@^1.0.0, call-bind@^1.0.2, call-bind@^1.0.5, call-bind@^1.0.6:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.7.tgz#06016599c40c56498c18769d2730be242b6fa3b9"
-  integrity sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==
+call-bind@^1.0.0, call-bind@^1.0.2, call-bind@^1.0.4, call-bind@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.5.tgz#6fa2b7845ce0ea49bf4d8b9ef64727a2c2e2e513"
+  integrity sha512-C3nQxfFZxFRVoJoGKKI8y3MOEo129NQ+FgQ08iye+Mk4zNZZGdjfs06bVTr+DBSlA66Q2VEcMki/cUCP4SercQ==
   dependencies:
-    es-define-property "^1.0.0"
-    es-errors "^1.3.0"
     function-bind "^1.1.2"
-    get-intrinsic "^1.2.4"
-    set-function-length "^1.2.1"
+    get-intrinsic "^1.2.1"
+    set-function-length "^1.1.1"
 
 caller-callsite@^2.0.0:
   version "2.0.0"
@@ -9783,7 +10495,12 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001125, caniuse-lite@^1.0.30001578, caniuse-lite@^1.0.30001580:
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001125, caniuse-lite@^1.0.30001565, caniuse-lite@^1.0.30001578:
+  version "1.0.30001579"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001579.tgz#45c065216110f46d6274311a4b3fcf6278e0852a"
+  integrity sha512-u5AUVkixruKHJjw/pj9wISlcMpgFWzSrczLZbrqBSxukQixmg0SJ5sZTpvaFvxU0HoQKd4yoyAogyrAz9pzJnA==
+
+caniuse-lite@^1.0.30001580:
   version "1.0.30001587"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001587.tgz#a0bce920155fa56a1885a69c74e1163fc34b4881"
   integrity sha512-HMFNotUmLXn71BQxg8cijvqxnIAofforZOwGsxyXJ0qugTdspUF4sPSJ2vhgprHCB996tIDzEq1ubumPDV8ULA==
@@ -9977,9 +10694,9 @@ chokidar@^2.1.8:
     fsevents "^1.2.7"
 
 chokidar@^3.0.0, chokidar@^3.4.1, chokidar@^3.4.2, chokidar@^3.5.3:
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.6.0.tgz#197c6cc669ef2a8dc5e7b4d97ee4e092c3eb0d5b"
-  integrity sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.3.tgz#1cf37c8707b932bd1af1ae22c0432e2acd1903bd"
+  integrity sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==
   dependencies:
     anymatch "~3.1.2"
     braces "~3.0.2"
@@ -10664,9 +11381,9 @@ contentful-cli@1.3.29:
     zlib "^1.0.5"
 
 contentful-export@^7.8.16:
-  version "7.19.121"
-  resolved "https://registry.yarnpkg.com/contentful-export/-/contentful-export-7.19.121.tgz#6f3438d8df2b9444b6ac5194cd8a087c02c389ee"
-  integrity sha512-a+qO1r7xALMGDxvQM2g48lOmukPepbarpr6NOC3Q0nd66dBuS1jdhxFmlzw3NA/s10+GFVYpQaQBuVHRUa00Lg==
+  version "7.19.113"
+  resolved "https://registry.yarnpkg.com/contentful-export/-/contentful-export-7.19.113.tgz#1af253aa28bed8ce5ef2daebff1ccdd5ae30abb1"
+  integrity sha512-X0HVOkMZoZYc+7Oh2MVJGlRMqDcyn0Bg3rZpBmDnnm3sdW6z9UoEBX/HRitbBc1JRb2b9Q9k++svPed45p4mRw==
   dependencies:
     bfj "^8.0.0"
     bluebird "^3.3.3"
@@ -10717,9 +11434,9 @@ contentful-management@^10.0.0:
     type-fest "^4.0.0"
 
 "contentful-management@^10.0.0 || ^11.0.0", "contentful-management@^10.14.0 || ^11.0.0", contentful-management@^11.0.1:
-  version "11.15.0"
-  resolved "https://registry.yarnpkg.com/contentful-management/-/contentful-management-11.15.0.tgz#403024816e211484819d1e5f441a98e0879f1f12"
-  integrity sha512-u5it8laHTRJY+WQVHOSBGhzcb1ucgHg9MU12EMf+w088jcONdZcgyNq75cQWdmaQv8tl3/T8YrDNuCTLSz4H1g==
+  version "11.12.1"
+  resolved "https://registry.yarnpkg.com/contentful-management/-/contentful-management-11.12.1.tgz#34eb0e9f2e5da8e16165152c57c36388c28de940"
+  integrity sha512-1xxBoz31DAuGCEZN9/e7MKrrxitFXxD067xYNtBJ3lvwhhsdb9mVJ+QKNHR5Ys+ZfYOlLq6dDnRBf15KeUXggA==
   dependencies:
     "@contentful/rich-text-types" "^16.3.0"
     "@types/json-patch" "0.0.30"
@@ -10824,9 +11541,9 @@ contentful-sdk-core@^8.1.0:
     qs "^6.11.2"
 
 contentful@^10.6.9:
-  version "10.6.21"
-  resolved "https://registry.yarnpkg.com/contentful/-/contentful-10.6.21.tgz#7e2a8cae91f5f06297df27053538e937490035a7"
-  integrity sha512-ez3zNJ1A2dJTuoNxSkFhwjkhrQ/jYYTvc8jFeFIMwZuYMHjYwL+mFo1372pSASeJ6QAIf2srKOmukzCGiHtcSg==
+  version "10.6.16"
+  resolved "https://registry.yarnpkg.com/contentful/-/contentful-10.6.16.tgz#c238bf54bbed7a4300e2781ca48ced6a0d7ba4bc"
+  integrity sha512-3PF4VQAWOhy7CiGYm4KtQn9AN81p77BgSCDQNndFfWdggs6/b2wMWXkmN1UGSJI7OKBRpbiy12mNrr7SrvuVIA==
   dependencies:
     "@contentful/rich-text-types" "^16.0.2"
     axios "^1.6.0"
@@ -11005,7 +11722,21 @@ copy-to-clipboard@^3.3.1:
   dependencies:
     toggle-selection "^1.0.6"
 
-core-js-compat@^3.31.0, core-js-compat@^3.34.0, core-js-compat@^3.6.2:
+core-js-compat@^3.31.0, core-js-compat@^3.33.1:
+  version "3.35.0"
+  resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.35.0.tgz#c149a3d1ab51e743bc1da61e39cb51f461a41873"
+  integrity sha512-5blwFAddknKeNgsjBzilkdQ0+YK8L1PfqPYq40NOYMYFSS38qj+hpTcLLWwpIwA2A5bje/x5jmVn2tzUMg9IVw==
+  dependencies:
+    browserslist "^4.22.2"
+
+core-js-compat@^3.34.0:
+  version "3.36.0"
+  resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.36.0.tgz#087679119bc2fdbdefad0d45d8e5d307d45ba190"
+  integrity sha512-iV9Pd/PsgjNWBXeq8XRtWVSgz2tKAfhfvBs7qxYty+RlRd+OCksaWmOnc4JKrTc1cToXL1N0s3l/vwlxPtdElw==
+  dependencies:
+    browserslist "^4.22.3"
+
+core-js-compat@^3.6.2:
   version "3.35.1"
   resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.35.1.tgz#215247d7edb9e830efa4218ff719beb2803555e2"
   integrity sha512-sftHa5qUJY3rs9Zht1WEnmkvXputCyDBczPnr7QDgL8n3qrF3CMXY4VPSYtOLLiOUJcah2WNXREd48iOl6mQIw==
@@ -11013,9 +11744,9 @@ core-js-compat@^3.31.0, core-js-compat@^3.34.0, core-js-compat@^3.6.2:
     browserslist "^4.22.2"
 
 core-js-pure@^3.23.3, core-js-pure@^3.30.2:
-  version "3.35.1"
-  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.35.1.tgz#f33ad7fdf9dddae260339a30e5f8363f5c49a3bc"
-  integrity sha512-zcIdi/CL3MWbBJYo5YCeVAAx+Sy9yJE9I3/u9LkFABwbeaPhTMRWraM8mYFp9jW5Z50hOy7FVzCc8dCrpZqtIQ==
+  version "3.35.0"
+  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.35.0.tgz#4660033304a050215ae82e476bd2513a419fbb34"
+  integrity sha512-f+eRYmkou59uh7BPcyJ8MC76DiGhspj1KMxVIcF24tzP8NA9HVa1uC7BTW2tgx7E1QVCzDzsgp7kArrzhlz8Ew==
 
 core-js@^2.4.0:
   version "2.6.12"
@@ -11023,9 +11754,9 @@ core-js@^2.4.0:
   integrity sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==
 
 core-js@^3.19.2, core-js@^3.6.5:
-  version "3.35.1"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.35.1.tgz#9c28f8b7ccee482796f8590cc8d15739eaaf980c"
-  integrity sha512-IgdsbxNyMskrTFxa9lWHyMwAJU5gXOPP+1yO+K59d50VLVAIDAbs7gIv705KzALModfK3ZrSZTPNpC0PQgIZuw==
+  version "3.35.0"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.35.0.tgz#58e651688484f83c34196ca13f099574ee53d6b4"
+  integrity sha512-ntakECeqg81KqMueeGJ79Q5ZgQNR+6eaE8sxGCx62zMbAIj65q+uYvatToew3m6eAGdU4gNZwpZ34NMe4GYswg==
 
 core-util-is@1.0.2:
   version "1.0.2"
@@ -11285,15 +12016,15 @@ css-loader@4.3.0:
     semver "^7.3.2"
 
 css-loader@^6.5.1, css-loader@^6.7.1:
-  version "6.10.0"
-  resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-6.10.0.tgz#7c172b270ec7b833951b52c348861206b184a4b7"
-  integrity sha512-LTSA/jWbwdMlk+rhmElbDR2vbtQoTBPr7fkJE+mxrHj+7ru0hUmHafDRzWIjIHTwpitWVaqY2/UWGRca3yUgRw==
+  version "6.9.0"
+  resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-6.9.0.tgz#0cc2f14df94ed97c526c5ae42b6b13916d1d8d0e"
+  integrity sha512-3I5Nu4ytWlHvOP6zItjiHlefBNtrH+oehq8tnQa2kO305qpVyx9XNIT1CXIj5bgCJs7qICBCkgCYxQLKPANoLA==
   dependencies:
     icss-utils "^5.1.0"
-    postcss "^8.4.33"
+    postcss "^8.4.31"
     postcss-modules-extract-imports "^3.0.0"
-    postcss-modules-local-by-default "^4.0.4"
-    postcss-modules-scope "^3.1.1"
+    postcss-modules-local-by-default "^4.0.3"
+    postcss-modules-scope "^3.1.0"
     postcss-modules-values "^4.0.0"
     postcss-value-parser "^4.2.0"
     semver "^7.5.4"
@@ -11590,9 +12321,9 @@ cypress-plugin-tab@1.0.5:
     ally.js "^1.4.1"
 
 cypress@*:
-  version "13.6.4"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-13.6.4.tgz#42c88d3ee0342f1681abfacabf9c1f082676bc53"
-  integrity sha512-pYJjCfDYB+hoOoZuhysbbYhEmNW7DEDsqn+ToCLwuVowxUXppIWRr7qk4TVRIU471ksfzyZcH+mkoF0CQUKnpw==
+  version "13.6.3"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-13.6.3.tgz#54f03ca07ee56b2bc18211e7bd32abd2533982ba"
+  integrity sha512-d/pZvgwjAyZsoyJ3FOsJT5lDsqnxQ/clMqnNc++rkHjbkkiF2h9s0JsZSyyH4QXhVFW3zPFg82jD25roFLOdZA==
   dependencies:
     "@cypress/request" "^3.0.0"
     "@cypress/xvfb" "^1.2.4"
@@ -12004,15 +12735,14 @@ defer-to-connect@^2.0.0:
   resolved "https://registry.yarnpkg.com/defer-to-connect/-/defer-to-connect-2.0.1.tgz#8016bdb4143e4632b77a3449c6236277de520587"
   integrity sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==
 
-define-data-property@^1.0.1, define-data-property@^1.1.2:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/define-data-property/-/define-data-property-1.1.3.tgz#281845e04737d709c2de99e278546189b65d3055"
-  integrity sha512-h3GBouC+RPtNX2N0hHVLo2ZwPYurq8mLmXpOLTsw71gr7lHt5VaI4vVkDUNOfiWmm48JEXe3VM7PmLX45AMmmg==
+define-data-property@^1.0.1, define-data-property@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/define-data-property/-/define-data-property-1.1.1.tgz#c35f7cd0ab09883480d12ac5cb213715587800b3"
+  integrity sha512-E7uGkTzkk1d0ByLeSc6ZsFS79Axg+m1P/VsgYsxHgiuc3tFSj+MjMIwe90FC4lOAZzNBdY7kkO2P2wKdsQ1vgQ==
   dependencies:
-    es-errors "^1.3.0"
-    get-intrinsic "^1.2.4"
+    get-intrinsic "^1.2.1"
     gopd "^1.0.1"
-    has-property-descriptors "^1.0.1"
+    has-property-descriptors "^1.0.0"
 
 define-lazy-prop@^2.0.0:
   version "2.0.0"
@@ -12220,9 +12950,9 @@ diff@4.0.2:
   integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
 
 diff@^5.0.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/diff/-/diff-5.2.0.tgz#26ded047cd1179b78b9537d5ef725503ce1ae531"
-  integrity sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-5.1.0.tgz#bc52d298c5ea8df9194800224445ed43ffc87e40"
+  integrity sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==
 
 diffie-hellman@^5.0.0:
   version "5.0.3"
@@ -12443,9 +13173,9 @@ dotenv@^10.0.0, dotenv@~10.0.0:
   integrity sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==
 
 dotenv@^16.0.0:
-  version "16.4.3"
-  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.4.3.tgz#481235ec516c4e47d2612a478482ee36607f70c1"
-  integrity sha512-II98GFrje5psQTSve0E7bnwMFybNLqT8Vu8JIFWRjsE3khyNUm/loZupuy5DVzG2IXf/ysxvrixYOQnM6mjD3A==
+  version "16.3.1"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.3.1.tgz#369034de7d7e5b120972693352a3bf112172cc3e"
+  integrity sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==
 
 downshift@^6.1.12:
   version "6.1.12"
@@ -12528,10 +13258,15 @@ ejs@^3.1.6, ejs@^3.1.7, ejs@^3.1.8:
   dependencies:
     jake "^10.8.5"
 
-electron-to-chromium@^1.3.564, electron-to-chromium@^1.4.648:
-  version "1.4.667"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.667.tgz#2767d998548e5eeeaf8bdaffd67b56796bfbed3d"
-  integrity sha512-66L3pLlWhTNVUhnmSA5+qDM3fwnXsM6KAqE36e2w4KN0g6pkEtlT5bs41FQtQwVwKnfhNBXiWRLPs30HSxd7Kw==
+electron-to-chromium@^1.3.564, electron-to-chromium@^1.4.601:
+  version "1.4.637"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.637.tgz#ed8775cf5e0c380c3e8452e9818a0e4b7a671ac4"
+  integrity sha512-G7j3UCOukFtxVO1vWrPQUoDk3kL70mtvjc/DC/k2o7lE0wAdq+Vwp1ipagOow+BH0uVztFysLWbkM/RTIrbK3w==
+
+electron-to-chromium@^1.4.648:
+  version "1.4.668"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.668.tgz#5cfed14f3240cdc70a359a49790cb295b1f097f1"
+  integrity sha512-ZOBocMYCehr9W31+GpMclR+KBaDZOoAEabLdhpZ8oU1JFDwIaFY0UDbpXVEUFc0BIP2O2Qn3rkfCjQmMR4T/bQ==
 
 elegant-spinner@^1.0.1:
   version "1.0.1"
@@ -12695,9 +13430,9 @@ env-paths@^2.2.0:
   integrity sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==
 
 envinfo@^7.7.3, envinfo@^7.7.4:
-  version "7.11.1"
-  resolved "https://registry.yarnpkg.com/envinfo/-/envinfo-7.11.1.tgz#2ffef77591057081b0129a8fd8cf6118da1b94e1"
-  integrity sha512-8PiZgZNIB4q/Lw4AhOvAfB/ityHAd2bli3lESSWmWSzSsl5dKpy5N1d1Rfkd2teq/g9xN90lc6o98DOjMeYHpg==
+  version "7.11.0"
+  resolved "https://registry.yarnpkg.com/envinfo/-/envinfo-7.11.0.tgz#c3793f44284a55ff8c82faf1ffd91bc6478ea01f"
+  integrity sha512-G9/6xF1FPbIw0TtalAMaVPpiq2aDEuKLXM314jPVAO9r2fo2a4BLqMNkmRS7O/xPPZ+COAhGIz3ETvHEV3eUcg==
 
 err-code@^2.0.2:
   version "2.0.3"
@@ -12725,7 +13460,7 @@ error-stack-parser@^2.0.6:
   dependencies:
     stackframe "^1.3.4"
 
-es-abstract@^1.17.0-next.1, es-abstract@^1.17.2, es-abstract@^1.22.1, es-abstract@^1.22.3:
+es-abstract@^1.17.0-next.1, es-abstract@^1.17.2, es-abstract@^1.22.1:
   version "1.22.3"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.22.3.tgz#48e79f5573198de6dee3589195727f4f74bc4f32"
   integrity sha512-eiiY8HQeYfYH2Con2berK+To6GrK2RxbPawDkGq4UiCQQfZHb6wX9qQqkbpPqaxQFcl8d9QzZqo0tGE0VcrdwA==
@@ -12775,18 +13510,6 @@ es-array-method-boxes-properly@^1.0.0:
   resolved "https://registry.yarnpkg.com/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz#873f3e84418de4ee19c5be752990b2e44718d09e"
   integrity sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA==
 
-es-define-property@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/es-define-property/-/es-define-property-1.0.0.tgz#c7faefbdff8b2696cf5f46921edfb77cc4ba3845"
-  integrity sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==
-  dependencies:
-    get-intrinsic "^1.2.4"
-
-es-errors@^1.0.0, es-errors@^1.1.0, es-errors@^1.2.1, es-errors@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/es-errors/-/es-errors-1.3.0.tgz#05f75a25dab98e4fb1dcd5e1472c0546d5057c8f"
-  integrity sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==
-
 es-get-iterator@^1.0.2, es-get-iterator@^1.1.1, es-get-iterator@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/es-get-iterator/-/es-get-iterator-1.1.3.tgz#3ef87523c5d464d41084b2c3c9c214f1199763d6"
@@ -12803,32 +13526,31 @@ es-get-iterator@^1.0.2, es-get-iterator@^1.1.1, es-get-iterator@^1.1.3:
     stop-iteration-iterator "^1.0.0"
 
 es-iterator-helpers@^1.0.12, es-iterator-helpers@^1.0.15:
-  version "1.0.16"
-  resolved "https://registry.yarnpkg.com/es-iterator-helpers/-/es-iterator-helpers-1.0.16.tgz#495756d38dd5f9cc8e3091e913ee790d353e6f28"
-  integrity sha512-CREG2A9Vq7bpDRnldhFcMKuKArvkZtsH6Y0DHOHVg49qhf+LD8uEdUM3OkOAICv0EziGtDEnQtqY2/mfBILpFw==
+  version "1.0.15"
+  resolved "https://registry.yarnpkg.com/es-iterator-helpers/-/es-iterator-helpers-1.0.15.tgz#bd81d275ac766431d19305923707c3efd9f1ae40"
+  integrity sha512-GhoY8uYqd6iwUl2kgjTm4CZAf6oo5mHK7BPqx3rKgx893YSsy0LGHV6gfqqQvZt/8xM8xeOnfXBCfqclMKkJ5g==
   dependencies:
     asynciterator.prototype "^1.0.0"
-    call-bind "^1.0.6"
+    call-bind "^1.0.2"
     define-properties "^1.2.1"
-    es-abstract "^1.22.3"
-    es-errors "^1.3.0"
-    es-set-tostringtag "^2.0.2"
-    function-bind "^1.1.2"
-    get-intrinsic "^1.2.4"
+    es-abstract "^1.22.1"
+    es-set-tostringtag "^2.0.1"
+    function-bind "^1.1.1"
+    get-intrinsic "^1.2.1"
     globalthis "^1.0.3"
-    has-property-descriptors "^1.0.1"
+    has-property-descriptors "^1.0.0"
     has-proto "^1.0.1"
     has-symbols "^1.0.3"
-    internal-slot "^1.0.7"
+    internal-slot "^1.0.5"
     iterator.prototype "^1.1.2"
-    safe-array-concat "^1.1.0"
+    safe-array-concat "^1.0.1"
 
 es-module-lexer@^1.2.1, es-module-lexer@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-1.4.1.tgz#41ea21b43908fe6a287ffcbe4300f790555331f5"
   integrity sha512-cXLGjP0c4T3flZJKQSuziYoq7MlT+rnvfZjfp7h+I7K9BNX54kP9nyWvdbwjQ4u1iWbOL4u96fgeZLToQlZC7w==
 
-es-set-tostringtag@^2.0.1, es-set-tostringtag@^2.0.2:
+es-set-tostringtag@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/es-set-tostringtag/-/es-set-tostringtag-2.0.2.tgz#11f7cc9f63376930a5f20be4915834f4bc74f9c9"
   integrity sha512-BuDyupZt65P9D2D2vA/zqcI3G5xRsklm5N3xCwuiy+/vKy8i0ifdsQP1sLgO4tZDSCaQUSnmC48khknGMV3D2Q==
@@ -12837,7 +13559,7 @@ es-set-tostringtag@^2.0.1, es-set-tostringtag@^2.0.2:
     has-tostringtag "^1.0.0"
     hasown "^2.0.0"
 
-es-shim-unscopables@^1.0.0, es-shim-unscopables@^1.0.2:
+es-shim-unscopables@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/es-shim-unscopables/-/es-shim-unscopables-1.0.2.tgz#1f6942e71ecc7835ed1c8a83006d8771a63a3763"
   integrity sha512-J3yBRXCzDu4ULnQwxyToo/OjdMx6akgVC7K6few0a7F/0wLtmKKN7I73AH5T2836UuXRqN7Qg+IIUw/+YJksRw==
@@ -12920,9 +13642,9 @@ esbuild@^0.18.0:
     "@esbuild/win32-x64" "0.18.20"
 
 escalade@^3.0.2, escalade@^3.1.1:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.2.tgz#54076e9ab29ea5bf3d8f1ed62acffbb88272df27"
-  integrity sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40"
+  integrity sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==
 
 escape-html@~1.0.3:
   version "1.0.3"
@@ -13852,9 +14574,9 @@ fast-url-parser@1.1.3:
     punycode "^1.3.2"
 
 fastq@^1.6.0:
-  version "1.17.1"
-  resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.17.1.tgz#2a523f07a4e7b1e81a42b91b8bf2254107753b47"
-  integrity sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.16.0.tgz#83b9a9375692db77a822df081edb6a9cf6839320"
+  integrity sha512-ifCoaXsDrsdkWTtiNJX5uzHDsrck5TzfKKDcuFFTIrrc/BS076qgEIfoIy1VeZqViznfKiysPYTh/QeHtnIsYA==
   dependencies:
     reusify "^1.0.4"
 
@@ -14155,9 +14877,9 @@ flatten@^1.0.2:
   integrity sha512-dVsPA/UwQ8+2uoFe5GHtiBMu48dWLTdsuEd7CKGlZlD78r1TTWBvDuFaFGKCo/ZfEr95Uk56vZoX86OsHkUeIg==
 
 flow-parser@0.*:
-  version "0.228.0"
-  resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.228.0.tgz#0b801507c8cf44257338596b49bd0904caea2026"
-  integrity sha512-xPWkzCO07AnS8X+fQFpWm+tJ+C7aeaiVzJ+rSepbkCXUvUJ6l6squEl63axoMcixyH4wLjmypOzq/+zTD0O93w==
+  version "0.226.0"
+  resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.226.0.tgz#d552ab6762342e0e2b112fc937dd70b59e5e5d05"
+  integrity sha512-YlH+Y/P/5s0S7Vg14RwXlJMF/JsGfkG7gcKB/zljyoqaPNX9YVsGzx+g6MLTbhZaWbPhs4347aTpmSb9GgiPtw==
 
 flush-write-stream@^1.0.0:
   version "1.1.1"
@@ -14167,10 +14889,10 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
 
-focus-lock@^1.0.1:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/focus-lock/-/focus-lock-1.1.0.tgz#74fe85dc1a15360cc1a694de8e686c691e0dd5ed"
-  integrity sha512-7j9OR+mxVmGcfxpCU7qKT09R32TX4jlic2/iWT5pm58SYWB1lbREpb7hEkrXxx9MzkenDBOAGatBEcMbJ143UQ==
+focus-lock@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/focus-lock/-/focus-lock-1.0.0.tgz#2c50d8ce59d3d6608cda2672be9e65812459206c"
+  integrity sha512-a8Ge6cdKh9za/GZR/qtigTAk7SrGore56EFcoMshClsh7FLk1zwszc/ltuMfKhx56qeuyL/jWQ4J4axou0iJ9w==
   dependencies:
     tslib "^2.0.3"
 
@@ -14498,12 +15220,11 @@ get-caller-file@^2.0.1, get-caller-file@^2.0.5:
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
-get-intrinsic@^1.0.1, get-intrinsic@^1.1.1, get-intrinsic@^1.1.3, get-intrinsic@^1.2.1, get-intrinsic@^1.2.2, get-intrinsic@^1.2.3, get-intrinsic@^1.2.4:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.2.4.tgz#e385f5a4b5227d449c3eabbad05494ef0abbeadd"
-  integrity sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==
+get-intrinsic@^1.0.1, get-intrinsic@^1.0.2, get-intrinsic@^1.1.1, get-intrinsic@^1.1.3, get-intrinsic@^1.2.0, get-intrinsic@^1.2.1, get-intrinsic@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.2.2.tgz#281b7622971123e1ef4b3c90fd7539306da93f3b"
+  integrity sha512-0gSo4ml/0j98Y3lngkFEot/zhiCeWsbYIlZ+uZOVgzLyLaUw7wxUL+nCTP0XJvJg1AXulJRI3UJi8GsbDuxdGA==
   dependencies:
-    es-errors "^1.3.0"
     function-bind "^1.1.2"
     has-proto "^1.0.1"
     has-symbols "^1.0.3"
@@ -14584,13 +15305,12 @@ get-stream@^8.0.1:
   integrity sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==
 
 get-symbol-description@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/get-symbol-description/-/get-symbol-description-1.0.2.tgz#533744d5aa20aca4e079c8e5daf7fd44202821f5"
-  integrity sha512-g0QYk1dZBxGwk+Ngc+ltRH2IBp2f7zBkBMBJZCDerh6EhlhSR6+9irMCuT/09zD6qkarHUSn529sK/yL4S27mg==
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/get-symbol-description/-/get-symbol-description-1.0.0.tgz#7fdb81c900101fbd564dd5f1a30af5aadc1e58d6"
+  integrity sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==
   dependencies:
-    call-bind "^1.0.5"
-    es-errors "^1.3.0"
-    get-intrinsic "^1.2.4"
+    call-bind "^1.0.2"
+    get-intrinsic "^1.1.1"
 
 get-value@^2.0.3, get-value@^2.0.6:
   version "2.0.6"
@@ -15016,11 +15736,11 @@ has-flag@^4.0.0:
   integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
 
 has-property-descriptors@^1.0.0, has-property-descriptors@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz#963ed7d071dc7bf5f084c5bfbe0d1b6222586854"
-  integrity sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/has-property-descriptors/-/has-property-descriptors-1.0.1.tgz#52ba30b6c5ec87fd89fa574bc1c39125c6f65340"
+  integrity sha512-VsX8eaIewvas0xnvinAe9bw4WfIeODpGYikiWYLH+dma0Jw6KHYqWiWfhQlgOVK8D6PvjubK5Uc4P0iIhIcNVg==
   dependencies:
-    es-define-property "^1.0.0"
+    get-intrinsic "^1.2.2"
 
 has-proto@^1.0.1:
   version "1.0.1"
@@ -15032,12 +15752,12 @@ has-symbols@^1.0.0, has-symbols@^1.0.1, has-symbols@^1.0.2, has-symbols@^1.0.3:
   resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.3.tgz#bb7b2c4349251dce87b125f7bdf874aa7c8b39f8"
   integrity sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==
 
-has-tostringtag@^1.0.0, has-tostringtag@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/has-tostringtag/-/has-tostringtag-1.0.2.tgz#2cdc42d40bef2e5b4eeab7c01a73c54ce7ab5abc"
-  integrity sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==
+has-tostringtag@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-tostringtag/-/has-tostringtag-1.0.0.tgz#7e133818a7d394734f941e73c3d3f9291e658b25"
+  integrity sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==
   dependencies:
-    has-symbols "^1.0.3"
+    has-symbols "^1.0.2"
 
 has-unicode@2.0.1, has-unicode@^2.0.1:
   version "2.0.1"
@@ -15098,9 +15818,9 @@ hash.js@^1.0.0, hash.js@^1.0.3:
     minimalistic-assert "^1.0.1"
 
 hasown@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.1.tgz#26f48f039de2c0f8d3356c223fb8d50253519faa"
-  integrity sha512-1/th4MHjnwncwXsIW6QMzlvYL9kG5e/CpVvLRZe4XPa8TOUNbCELqmvhDmnkNsAjwaG4+I8gJJL0JBvTTLO9qA==
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.0.tgz#f4c513d454a57b7c7e1650778de226b11700546c"
+  integrity sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==
   dependencies:
     function-bind "^1.1.2"
 
@@ -15494,9 +16214,9 @@ https-proxy-agent@^5.0.0, https-proxy-agent@^5.0.1:
     debug "4"
 
 https-proxy-agent@^7.0.2:
-  version "7.0.3"
-  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-7.0.3.tgz#93f115f0f106a746faf364d1301b2e561cdf70de"
-  integrity sha512-kCnwztfX0KZJSLOBrcL0emLeFako55NWMovvyPP2AjsghNk9RB1yjSI+jVumPHYZsNXegNoqupSW9IY3afSH8w==
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-7.0.2.tgz#e2645b846b90e96c6e6f347fb5b2e41f1590b09b"
+  integrity sha512-NmLNjm6ucYwtcUmL7JQC1ZQ57LmHP4lT15FQ8D61nak1rO6DH+fz5qNK2Ap5UN4ZapYICE3/0KodcLYSPsPbaA==
   dependencies:
     agent-base "^7.0.2"
     debug "4"
@@ -15596,9 +16316,9 @@ ignore@^4.0.6:
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
 
 ignore@^5.0.0, ignore@^5.0.4, ignore@^5.0.5, ignore@^5.1.4, ignore@^5.1.8, ignore@^5.2.0, ignore@^5.2.4:
-  version "5.3.1"
-  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.3.1.tgz#5073e554cd42c5b33b394375f538b8593e34d4ef"
-  integrity sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.3.0.tgz#67418ae40d34d6999c95ff56016759c718c82f78"
+  integrity sha512-g7dmpshy+gD7mh88OC9NwSGTKoc3kyLAZQRU1mt53Aw/vnvfXnbC+F/7F7QoYVKbV+KNvJx8wArewKy1vXMtlg==
 
 immer@8.0.1:
   version "8.0.1"
@@ -15892,12 +16612,12 @@ internal-ip@^4.3.0:
     default-gateway "^4.2.0"
     ipaddr.js "^1.9.0"
 
-internal-slot@^1.0.4, internal-slot@^1.0.5, internal-slot@^1.0.7:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/internal-slot/-/internal-slot-1.0.7.tgz#c06dcca3ed874249881007b0a5523b172a190802"
-  integrity sha512-NGnrKwXzSms2qUUih/ILZ5JBqNTSa1+ZmP6flaIp6KmSElgE9qdndzS3cqjrDovwFdmwsGsLdeFgB6suw+1e9g==
+internal-slot@^1.0.4, internal-slot@^1.0.5:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/internal-slot/-/internal-slot-1.0.6.tgz#37e756098c4911c5e912b8edbf71ed3aa116f930"
+  integrity sha512-Xj6dv+PsbtwyPpEflsejS+oIZxmMlV44zAhG479uYu89MsjcYOhCFnNyKrkJrihbsiasQyY0afoCl/9BLR65bg==
   dependencies:
-    es-errors "^1.3.0"
+    get-intrinsic "^1.2.2"
     hasown "^2.0.0"
     side-channel "^1.0.4"
 
@@ -15912,14 +16632,6 @@ invariant@^2.2.2, invariant@^2.2.4:
   integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
   dependencies:
     loose-envify "^1.0.0"
-
-ip-address@^9.0.5:
-  version "9.0.5"
-  resolved "https://registry.yarnpkg.com/ip-address/-/ip-address-9.0.5.tgz#117a960819b08780c3bd1f14ef3c1cc1d3f3ea5a"
-  integrity sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==
-  dependencies:
-    jsbn "1.1.0"
-    sprintf-js "^1.1.3"
 
 ip-regex@^2.1.0:
   version "2.1.0"
@@ -15976,13 +16688,14 @@ is-arguments@^1.0.4, is-arguments@^1.1.1:
     call-bind "^1.0.2"
     has-tostringtag "^1.0.0"
 
-is-array-buffer@^3.0.2, is-array-buffer@^3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/is-array-buffer/-/is-array-buffer-3.0.4.tgz#7a1f92b3d61edd2bc65d24f130530ea93d7fae98"
-  integrity sha512-wcjaerHw0ydZwfhiKbXJWLDY8A7yV7KhjQOpb83hGgGfId/aQa4TOvwyzn2PuswW2gPCYEL/nEAiSVpdOj1lXw==
+is-array-buffer@^3.0.1, is-array-buffer@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/is-array-buffer/-/is-array-buffer-3.0.2.tgz#f2653ced8412081638ecb0ebbd0c41c6e0aecbbe"
+  integrity sha512-y+FyyR/w8vfIRq4eQcM1EYgSTnmHXPqaF+IgzgraytCFq5Xh8lllDVmAZolPJiZttZLeFSINPYMaEJ7/vWUa1w==
   dependencies:
     call-bind "^1.0.2"
-    get-intrinsic "^1.2.1"
+    get-intrinsic "^1.2.0"
+    is-typed-array "^1.1.10"
 
 is-arrayish@^0.2.1:
   version "0.2.1"
@@ -16467,12 +17180,12 @@ is-text-path@^2.0.0:
   dependencies:
     text-extensions "^2.0.0"
 
-is-typed-array@^1.1.10, is-typed-array@^1.1.12, is-typed-array@^1.1.13, is-typed-array@^1.1.3, is-typed-array@^1.1.9:
-  version "1.1.13"
-  resolved "https://registry.yarnpkg.com/is-typed-array/-/is-typed-array-1.1.13.tgz#d6c5ca56df62334959322d7d7dd1cca50debe229"
-  integrity sha512-uZ25/bUAlUY5fR4OKT4rZQEBrzQWYV9ZJYGGsUmEJ6thodVJ1HX64ePQ6Z0qPWP+m+Uq6e9UugrE38jeYsDSMw==
+is-typed-array@^1.1.10, is-typed-array@^1.1.12, is-typed-array@^1.1.3, is-typed-array@^1.1.9:
+  version "1.1.12"
+  resolved "https://registry.yarnpkg.com/is-typed-array/-/is-typed-array-1.1.12.tgz#d0bab5686ef4a76f7a73097b95470ab199c57d4a"
+  integrity sha512-Z14TF2JNG8Lss5/HMqt0//T9JeHXttXy5pH/DBU4vi98ozO2btxzq9MwYDZYnKwU8nRsz/+GVFVRDq3DkVuSPg==
   dependencies:
-    which-typed-array "^1.1.14"
+    which-typed-array "^1.1.11"
 
 is-typedarray@^1.0.0, is-typedarray@~1.0.0:
   version "1.0.0"
@@ -18009,13 +18722,13 @@ joi@^13.4.0:
     topo "3.x.x"
 
 joi@^17.11.0:
-  version "17.12.1"
-  resolved "https://registry.yarnpkg.com/joi/-/joi-17.12.1.tgz#3347ecf4cd3301962d42191c021b165eef1f395b"
-  integrity sha512-vtxmq+Lsc5SlfqotnfVjlViWfOL9nt/avKNbKYizwf6gsCfq9NYY/ceYRMFD8XDdrjJ9abJyScWmhmIiy+XRtQ==
+  version "17.12.0"
+  resolved "https://registry.yarnpkg.com/joi/-/joi-17.12.0.tgz#a3fb5715f198beb0471cd551dd26792089c308d5"
+  integrity sha512-HSLsmSmXz+PV9PYoi3p7cgIbj06WnEBNT28n+bbBNcPZXZFqCzzvGqpTBPujx/Z0nh1+KNQPDrNgdmQ8dq0qYw==
   dependencies:
     "@hapi/hoek" "^9.3.0"
     "@hapi/topo" "^5.1.0"
-    "@sideway/address" "^4.1.5"
+    "@sideway/address" "^4.1.4"
     "@sideway/formula" "^3.0.1"
     "@sideway/pinpoint" "^2.0.0"
 
@@ -18061,11 +18774,6 @@ js-yaml@^3.10.0, js-yaml@^3.13.1:
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
-
-jsbn@1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-1.1.0.tgz#b01307cb29b618a1ed26ec79e911f803c4da0040"
-  integrity sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==
 
 jsbn@~0.1.0:
   version "0.1.1"
@@ -18240,15 +18948,10 @@ json5@^2.0.0, json5@^2.1.2, json5@^2.2.0, json5@^2.2.2, json5@^2.2.3:
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
 
-jsonc-parser@3.2.0:
+jsonc-parser@3.2.0, jsonc-parser@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/jsonc-parser/-/jsonc-parser-3.2.0.tgz#31ff3f4c2b9793f89c67212627c51c6394f88e76"
   integrity sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==
-
-jsonc-parser@^3.2.0:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/jsonc-parser/-/jsonc-parser-3.2.1.tgz#031904571ccf929d7670ee8c547545081cb37f1a"
-  integrity sha512-AilxAyFOAcK5wA1+LeaySVBrHsGQvUFCDWXKpZjzaL0PqW+xfBOttn8GNtWKFWqneyMZj41MWF9Kl6iPWLwgOA==
 
 jsonfile@^4.0.0:
   version "4.0.0"
@@ -18750,9 +19453,9 @@ load-json-file@^4.0.0:
     strip-bom "^3.0.0"
 
 load-plugin@^6.0.0:
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/load-plugin/-/load-plugin-6.0.2.tgz#a3ec9e04fb6009cf97f226e4695bc0f7037a9280"
-  integrity sha512-3KRkTvCOsyNrx4zvBl/+ZMqPdVyp26TIf6xkmfEGuGwCfNQ/HzhktwbJCxd1KJpzPbK42t/WVOL3cX+TDaMRuQ==
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/load-plugin/-/load-plugin-6.0.1.tgz#ca30b33b40ec0e11c2f6b07d34cbcc78a70300dd"
+  integrity sha512-YZyxJaWfN4F1xfPCyKFNIOL26vlFukmJY7wegxsriav4y2/0ZiICota6uFvyy52GjUj+tsPSjGLX+2m7kiU0+g==
   dependencies:
     "@npmcli/config" "^8.0.0"
     import-meta-resolve "^4.0.0"
@@ -19023,9 +19726,9 @@ log-update@^4.0.0:
     wrap-ansi "^6.2.0"
 
 loglevel@^1.6.8:
-  version "1.9.1"
-  resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.9.1.tgz#d63976ac9bcd03c7c873116d41c2a85bafff1be7"
-  integrity sha512-hP3I3kCrDIMuRwAwHltphhDM1r8i55H33GgqjXbrisuJhF4kRhW1dNuxsRklp4bXl8DSdLaNLuiL4A/LWRfxvg==
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.8.1.tgz#5c621f83d5b48c54ae93b6156353f555963377b4"
+  integrity sha512-tCRIJM51SHjAayKwC+QAg8hT8vg6z7GSgLJKGvzuPb1Wc+hLzqtuVLxp6/HzSPOozuK+8ErAhy7U/sVzw8Dgfg==
 
 longest-streak@^3.0.0:
   version "3.1.0"
@@ -19092,9 +19795,9 @@ lru-cache@^7.4.4, lru-cache@^7.5.1, lru-cache@^7.7.1:
   integrity sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==
 
 "lru-cache@^9.1.1 || ^10.0.0":
-  version "10.2.0"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.2.0.tgz#0bd445ca57363465900f4d1f9bd8db343a4d95c3"
-  integrity sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.1.0.tgz#2098d41c2dc56500e6c88584aa656c84de7d0484"
+  integrity sha512-/1clY/ui8CzjKFyjdvwPWJUYKiFVXG2I2cY0ssG7h4+hwk+XOIX7ZSG9Q7TW8TW3Kp3BUSqgFWBLgL4PJ+Blag==
 
 lz-string@^1.4.4, lz-string@^1.5.0:
   version "1.5.0"
@@ -19237,9 +19940,9 @@ markdown-table@^3.0.0:
   integrity sha512-Z1NL3Tb1M9wH4XESsCDEksWoKTdlUafKc4pt0GRwjUyXaCFZ+dc3g2erqB6zm3szA2IUSi7VnPI+o/9jnxh9hw==
 
 markdown-to-jsx@^7.1.1, markdown-to-jsx@^7.1.8:
-  version "7.4.1"
-  resolved "https://registry.yarnpkg.com/markdown-to-jsx/-/markdown-to-jsx-7.4.1.tgz#1ed6a60f8f9cd944bec39d9923fbbc8d3d60dcb9"
-  integrity sha512-GbrbkTnHp9u6+HqbPRFJbObi369AgJNXi/sGqq5HRsoZW063xR1XDCaConqq+whfEIAlzB1YPnOgsPc7B7bc/A==
+  version "7.4.0"
+  resolved "https://registry.yarnpkg.com/markdown-to-jsx/-/markdown-to-jsx-7.4.0.tgz#4606c5c549a6f6cb87604c35f5ee4f42959ffb6b"
+  integrity sha512-zilc+MIkVVXPyTb4iIUTIz9yyqfcWjszGXnwF9K/aiBWcHXFcmdEMTkG01/oQhwSCH7SY1BnG6+ev5BzWmbPrg==
 
 marked@^0.8.0:
   version "0.8.2"
@@ -19394,9 +20097,9 @@ mdast-util-phrasing@^3.0.0:
     unist-util-is "^5.0.0"
 
 mdast-util-phrasing@^4.0.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz#7cc0a8dec30eaf04b7b1a9661a92adb3382aa6e3"
-  integrity sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/mdast-util-phrasing/-/mdast-util-phrasing-4.0.0.tgz#468cbbb277375523de807248b8ad969feb02a5c7"
+  integrity sha512-xadSsJayQIucJ9n053dfQwVu1kuXg7jCTdYsMK8rqzKZh52nLfSH/k0sAxE0u+pj/zKZX+o5wB+ML5mRayOxFA==
   dependencies:
     "@types/mdast" "^4.0.0"
     unist-util-is "^6.0.0"
@@ -19812,9 +20515,9 @@ micromark-util-character@^1.0.0:
     micromark-util-types "^1.0.0"
 
 micromark-util-character@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/micromark-util-character/-/micromark-util-character-2.1.0.tgz#31320ace16b4644316f6bf057531689c71e2aee1"
-  integrity sha512-KvOVV+X1yLBfs9dCBSopq/+G1PcgT3lAK07mC4BzXi5E7ahzMAF8oIupDDJ6mievI6F+lAATkbQQlQixJfT3aQ==
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/micromark-util-character/-/micromark-util-character-2.0.1.tgz#52b824c2e2633b6fb33399d2ec78ee2a90d6b298"
+  integrity sha512-3wgnrmEAJ4T+mGXAUfMvMAbxU9RDG43XmGce4j6CwPtVxB3vfwXSZ6KhFwDzZ3mZHhmPimMAXg71veiBGzeAZw==
   dependencies:
     micromark-util-symbol "^2.0.0"
     micromark-util-types "^2.0.0"
@@ -20163,12 +20866,11 @@ mini-css-extract-plugin@0.11.3:
     webpack-sources "^1.1.0"
 
 mini-css-extract-plugin@^2.4.5:
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/mini-css-extract-plugin/-/mini-css-extract-plugin-2.8.0.tgz#1aeae2a90a954b6426c9e8311eab36b450f553a0"
-  integrity sha512-CxmUYPFcTgET1zImteG/LZOy/4T5rTojesQXkSNBiquhydn78tfbCE9sjIjnJ/UcjNjOC1bphTCCW5rrS7cXAg==
+  version "2.7.7"
+  resolved "https://registry.yarnpkg.com/mini-css-extract-plugin/-/mini-css-extract-plugin-2.7.7.tgz#4acf02f362c641c38fb913bfcb7ca2fc4a7cf339"
+  integrity sha512-+0n11YGyRavUR3IlaOzJ0/4Il1avMvJ1VJfhWfCn24ITQXhRr1gghbhhrda6tgtNcpZaWKdSuwKq20Jb7fnlyw==
   dependencies:
     schema-utils "^4.0.0"
-    tapable "^2.2.1"
 
 minimalistic-assert@^1.0.0, minimalistic-assert@^1.0.1:
   version "1.0.1"
@@ -20610,9 +21312,9 @@ node-dir@^0.1.17:
     minimatch "^3.0.2"
 
 node-fetch-native@^1.6.1:
-  version "1.6.2"
-  resolved "https://registry.yarnpkg.com/node-fetch-native/-/node-fetch-native-1.6.2.tgz#f439000d972eb0c8a741b65dcda412322955e1c6"
-  integrity sha512-69mtXOFZ6hSkYiXAVB5SqaRvrbITC/NPyqv7yuu/qw0nmgPyYbIMYYNIDhNtwPrzk0ptrimrLz/hhjvm4w5Z+w==
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/node-fetch-native/-/node-fetch-native-1.6.1.tgz#f95c74917d3cebc794cdae0cd2a9c7594aad0cb4"
+  integrity sha512-bW9T/uJDPAJB2YNYEpWzE54U5O3MQidXsOyTfnbKYtTtFexRvGzb1waphBN4ZwP6EcIvYYEOwW0b72BpAqydTw==
 
 node-fetch@2.6.7:
   version "2.6.7"
@@ -21079,13 +21781,13 @@ nx@15.9.7, "nx@>=15.5.2 < 16":
     "@nrwl/nx-win32-x64-msvc" "15.9.7"
 
 nypm@^0.3.3:
-  version "0.3.6"
-  resolved "https://registry.yarnpkg.com/nypm/-/nypm-0.3.6.tgz#940b558e6e56c2ed5dc43adf6dcf2c16577a80ff"
-  integrity sha512-2CATJh3pd6CyNfU5VZM7qSwFu0ieyabkEdnogE30Obn1czrmOYiZ8DOZLe1yBdLKWoyD3Mcy2maUs+0MR3yVjQ==
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/nypm/-/nypm-0.3.4.tgz#48ec8fc19fbf20fb747728716ceac3a4bd0456a3"
+  integrity sha512-1JLkp/zHBrkS3pZ692IqOaIKSYHmQXgqfELk6YTOfVBnwealAmPA1q2kKK7PHJAHSMBozerThEFZXP3G6o7Ukg==
   dependencies:
     citty "^0.1.5"
     execa "^8.0.1"
-    pathe "^1.1.2"
+    pathe "^1.1.1"
     ufo "^1.3.2"
 
 object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
@@ -21107,7 +21809,7 @@ object-hash@^3.0.0:
   resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-3.0.0.tgz#73f97f753e7baffc0e2cc9d6e079079744ac82e9"
   integrity sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==
 
-object-inspect@^1.13.1:
+object-inspect@^1.13.1, object-inspect@^1.9.0:
   version "1.13.1"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.13.1.tgz#b96c6109324ccfef6b12216a956ca4dc2ff94bc2"
   integrity sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==
@@ -21182,15 +21884,14 @@ object.getownpropertydescriptors@^2.0.3, object.getownpropertydescriptors@^2.1.0
     safe-array-concat "^1.0.0"
 
 object.groupby@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/object.groupby/-/object.groupby-1.0.2.tgz#494800ff5bab78fd0eff2835ec859066e00192ec"
-  integrity sha512-bzBq58S+x+uo0VjurFT0UktpKHOZmv4/xePiOA1nbB9pMqpGK7rUPNgf+1YC+7mE+0HzhTMqNUuCqvKhj6FnBw==
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/object.groupby/-/object.groupby-1.0.1.tgz#d41d9f3c8d6c778d9cbac86b4ee9f5af103152ee"
+  integrity sha512-HqaQtqLnp/8Bn4GL16cj+CUYbnpe1bh0TtEaWvybszDG4tgxCJuRpV8VGuvNaI1fAnI4lUJzDG55MXcOH4JZcQ==
   dependencies:
-    array.prototype.filter "^1.0.3"
-    call-bind "^1.0.5"
-    define-properties "^1.2.1"
-    es-abstract "^1.22.3"
-    es-errors "^1.0.0"
+    call-bind "^1.0.2"
+    define-properties "^1.2.0"
+    es-abstract "^1.22.1"
+    get-intrinsic "^1.2.1"
 
 object.hasown@^1.1.2:
   version "1.1.3"
@@ -21874,7 +22575,7 @@ path@^0.12.7:
     process "^0.11.1"
     util "^0.10.3"
 
-pathe@^1.1.1, pathe@^1.1.2:
+pathe@^1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/pathe/-/pathe-1.1.2.tgz#6c4cb47a945692e48a1ddd6e4094d170516437ec"
   integrity sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==
@@ -22038,9 +22739,9 @@ pnp-webpack-plugin@1.6.4:
     ts-pnp "^1.1.6"
 
 polished@^4.2.2:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/polished/-/polished-4.3.1.tgz#5a00ae32715609f83d89f6f31d0f0261c6170548"
-  integrity sha512-OBatVyC/N7SCW/FaDHrSd+vn0o5cS855TOmYi4OkdWUMSJCET/xip//ch8xGUvtr3i44X9LVyWwQlRMTN3pwSA==
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/polished/-/polished-4.2.2.tgz#2529bb7c3198945373c52e34618c8fe7b1aa84d1"
+  integrity sha512-Sz2Lkdxz6F2Pgnpi9U5Ng/WdWAUZxmHrNPoVlm3aAemxoy2Qy7LGjQg4uf8qKelDAUW94F4np3iH2YPf2qefcQ==
   dependencies:
     "@babel/runtime" "^7.17.8"
 
@@ -22664,7 +23365,7 @@ postcss-modules-local-by-default@^3.0.3:
     postcss-selector-parser "^6.0.2"
     postcss-value-parser "^4.1.0"
 
-postcss-modules-local-by-default@^4.0.4:
+postcss-modules-local-by-default@^4.0.3:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/postcss-modules-local-by-default/-/postcss-modules-local-by-default-4.0.4.tgz#7cbed92abd312b94aaea85b68226d3dec39a14e6"
   integrity sha512-L4QzMnOdVwRm1Qb8m4x8jsZzKAaPAgrUF1r/hjDR2Xj7R+8Zsf97jAlSQzWtKx5YNiNGN8QxmPFIc/sh+RQl+Q==
@@ -22681,10 +23382,10 @@ postcss-modules-scope@^2.2.0:
     postcss "^7.0.6"
     postcss-selector-parser "^6.0.0"
 
-postcss-modules-scope@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/postcss-modules-scope/-/postcss-modules-scope-3.1.1.tgz#32cfab55e84887c079a19bbb215e721d683ef134"
-  integrity sha512-uZgqzdTleelWjzJY+Fhti6F3C9iF1JR/dODLs/JDefozYcKTBCdD8BIl6nNPbTbcLnGrk56hzwZC2DaGNvYjzA==
+postcss-modules-scope@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/postcss-modules-scope/-/postcss-modules-scope-3.1.0.tgz#fbfddfda93a31f310f1d152c2bb4d3f3c5592ee0"
+  integrity sha512-SaIbK8XW+MZbd0xHPf7kdfA/3eOt7vxJ72IRecn3EzuZVLr1r0orzf0MX/pN8m+NMDoo6X/SQd8oeKqGZd8PXg==
   dependencies:
     postcss-selector-parser "^6.0.4"
 
@@ -23237,10 +23938,10 @@ postcss@^7, postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.14, postcss@^7.0.17, po
     picocolors "^0.2.1"
     source-map "^0.6.1"
 
-postcss@^8.1.0, postcss@^8.3.5, postcss@^8.4.23, postcss@^8.4.33, postcss@^8.4.4:
-  version "8.4.35"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.35.tgz#60997775689ce09011edf083a549cea44aabe2f7"
-  integrity sha512-u5U8qYpBCpN13BsiEB0CbR1Hhh4Gc0zLFuedrHJKMctHCHAGrMdG0PRM/KErzAL3CU6/eckEtmHNB3x6e3c0vA==
+postcss@^8.1.0, postcss@^8.3.5, postcss@^8.4.23, postcss@^8.4.31, postcss@^8.4.4:
+  version "8.4.33"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.33.tgz#1378e859c9f69bf6f638b990a0212f43e2aaa742"
+  integrity sha512-Kkpbhhdjw2qQs2O2DGX+8m5OVqEcbB9HRBvuYM9pgrjEFUg30A9LmXNlTAUj4S9kgtGyrMbTzVjH7E+s5Re2yg==
   dependencies:
     nanoid "^3.3.7"
     picocolors "^1.0.0"
@@ -23468,9 +24169,9 @@ prop-types@^15.0.0, prop-types@^15.5.7, prop-types@^15.6.1, prop-types@^15.6.2, 
     react-is "^16.13.1"
 
 property-information@^6.0.0:
-  version "6.4.1"
-  resolved "https://registry.yarnpkg.com/property-information/-/property-information-6.4.1.tgz#de8b79a7415fd2107dfbe65758bb2cc9dfcf60ac"
-  integrity sha512-OHYtXfu5aI2sS2LWFSN5rgJjrQ4pCy8i1jubJLe2QvMF8JJ++HXTUIVWFLfXJoaOfvYYjk2SN8J2wFUWIGXT4w==
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/property-information/-/property-information-6.4.0.tgz#6bc4c618b0c2d68b3bb8b552cbb97f8e300a0f82"
+  integrity sha512-9t5qARVofg2xQqKtytzt+lZ4d1Qvj8t5B8fEwXK6qOfgRLgH/b13QlgEyDh033NOS31nXeFbYv7CLUDG1CeifQ==
 
 propose@0.0.5:
   version "0.0.5"
@@ -23924,21 +24625,21 @@ react-fast-compare@^3.0.1:
   integrity sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==
 
 react-focus-lock@^2.9.1:
-  version "2.9.8"
-  resolved "https://registry.yarnpkg.com/react-focus-lock/-/react-focus-lock-2.9.8.tgz#32e9343d5ed9baa9e619adcac82e8756e8d00ae4"
-  integrity sha512-nLrUCTF8/BWGaWV00wvmIOPe56HTLWtqjqwWebHE80jB0fCMsm/Cl2zbp8ulbCoe5BOU7bWSCg5YhkYhDxykWw==
+  version "2.9.6"
+  resolved "https://registry.yarnpkg.com/react-focus-lock/-/react-focus-lock-2.9.6.tgz#cad168a150fdd72d5ab2419ba8e62780788011b1"
+  integrity sha512-B7gYnCjHNrNYwY2juS71dHbf0+UpXXojt02svxybj8N5bxceAkzPChKEncHuratjUHkIFNCn06k2qj1DRlzTug==
   dependencies:
     "@babel/runtime" "^7.0.0"
-    focus-lock "^1.0.1"
+    focus-lock "^1.0.0"
     prop-types "^15.6.2"
     react-clientside-effect "^1.2.6"
     use-callback-ref "^1.3.0"
     use-sidecar "^1.1.2"
 
 react-hotkeys-hook@^4.4.1:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/react-hotkeys-hook/-/react-hotkeys-hook-4.5.0.tgz#807b389b15256daf6a813a1ec09e6698064fe97f"
-  integrity sha512-Samb85GSgAWFQNvVt3PS90LPPGSf9mkH/r4au81ZP1yOIFayLC3QAvqTgGtJ8YEDMXtPmaVBs6NgipHO6h4Mug==
+  version "4.4.4"
+  resolved "https://registry.yarnpkg.com/react-hotkeys-hook/-/react-hotkeys-hook-4.4.4.tgz#5f055f39113218fe5e23f8723db68ccf99d155ab"
+  integrity sha512-wzZmqb/Obr0ds9Myc1sIFPJ52GA/Eeg/vXBWV0HA1LvHlVAW5Va3KB0q6EZNlNSHQWscWZ2K8+6w0GYSie2o7A==
 
 react-intersection-observer@9.4.0:
   version "9.4.0"
@@ -24450,15 +25151,14 @@ redeyed@~2.1.0:
     esprima "~4.0.0"
 
 reflect.getprototypeof@^1.0.4:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/reflect.getprototypeof/-/reflect.getprototypeof-1.0.5.tgz#e0bd28b597518f16edaf9c0e292c631eb13e0674"
-  integrity sha512-62wgfC8dJWrmxv44CA36pLDnP6KKl3Vhxb7PL+8+qrrFMMoJij4vgiMP8zV4O8+CBMXY1mHxI5fITGHXFHVmQQ==
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/reflect.getprototypeof/-/reflect.getprototypeof-1.0.4.tgz#aaccbf41aca3821b87bb71d9dcbc7ad0ba50a3f3"
+  integrity sha512-ECkTw8TmJwW60lOTR+ZkODISW6RQ8+2CL3COqtiJKLd6MmB45hN51HprHFziKLGkAuTGQhBb91V8cy+KHlaCjw==
   dependencies:
-    call-bind "^1.0.5"
-    define-properties "^1.2.1"
-    es-abstract "^1.22.3"
-    es-errors "^1.0.0"
-    get-intrinsic "^1.2.3"
+    call-bind "^1.0.2"
+    define-properties "^1.2.0"
+    es-abstract "^1.22.1"
+    get-intrinsic "^1.2.1"
     globalthis "^1.0.3"
     which-builtin-type "^1.1.3"
 
@@ -24515,14 +25215,13 @@ regex-parser@^2.2.11:
   integrity sha512-TVILVSz2jY5D47F4mA4MppkBrafEaiUWJO/TcZHEIuI13AqoZMkK1WMA4Om1YkYbTx+9Ki1/tSUXbceyr9saRg==
 
 regexp.prototype.flags@^1.3.0, regexp.prototype.flags@^1.5.0, regexp.prototype.flags@^1.5.1:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.5.2.tgz#138f644a3350f981a858c44f6bb1a61ff59be334"
-  integrity sha512-NcDiDkTLuPR+++OCKB0nWafEmhg/Da8aUPLPMQbK+bxKKCm1/S5he+AqYa4PlMCVBalb4/yxIRub6qkEx5yJbw==
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.5.1.tgz#90ce989138db209f81492edd734183ce99f9677e"
+  integrity sha512-sy6TXMN+hnP/wMy+ISxg3krXx7BAtWVO4UouuCN/ziM9UEne0euamVNafDfvC83bRNr95y0V5iijeDQFUNpvrg==
   dependencies:
-    call-bind "^1.0.6"
-    define-properties "^1.2.1"
-    es-errors "^1.3.0"
-    set-function-name "^2.0.1"
+    call-bind "^1.0.2"
+    define-properties "^1.2.0"
+    set-function-name "^2.0.0"
 
 regexpp@^3.1.0:
   version "3.2.0"
@@ -25153,9 +25852,9 @@ rework@1.0.1:
     css "^2.0.0"
 
 rfdc@^1.3.0:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/rfdc/-/rfdc-1.3.1.tgz#2b6d4df52dffe8bb346992a10ea9451f24373a8f"
-  integrity sha512-r5a3l5HzYlIC68TpmYKlxWjmOP6wiPJ1vWv2HeLhNsRZMrCkxeqxiHlQ21oXmQ4F3SiryXBHhAD7JZqvOJjFmg==
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/rfdc/-/rfdc-1.3.0.tgz#d0b7c441ab2720d05dc4cf26e01c89631d9da08b"
+  integrity sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==
 
 rgb-regex@^1.0.1:
   version "1.0.1"
@@ -25315,7 +26014,7 @@ sade@^1.7.3:
   dependencies:
     mri "^1.1.0"
 
-safe-array-concat@^1.0.0, safe-array-concat@^1.0.1, safe-array-concat@^1.1.0:
+safe-array-concat@^1.0.0, safe-array-concat@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/safe-array-concat/-/safe-array-concat-1.1.0.tgz#8d0cae9cb806d6d1c06e08ab13d847293ebe0692"
   integrity sha512-ZdQ0Jeb9Ofti4hbt5lX3T2JcAamT9hfzYU1MNB+z/jaEbB6wfFfPIR/zEORmZqobkCCJhSjodobH6WHNmJ97dg==
@@ -25336,12 +26035,12 @@ safe-buffer@5.2.1, safe-buffer@>=5.1.0, safe-buffer@^5.0.1, safe-buffer@^5.1.0, 
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
 
 safe-regex-test@^1.0.0:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/safe-regex-test/-/safe-regex-test-1.0.3.tgz#a5b4c0f06e0ab50ea2c395c14d8371232924c377"
-  integrity sha512-CdASjNJPvRa7roO6Ra/gLYBTzYzzPyyBXxIMdGW3USQLyjWEls2RgW5UBTXaQVp+OrpeCK3bLem8smtmheoRuw==
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/safe-regex-test/-/safe-regex-test-1.0.2.tgz#3ba32bdb3ea35f940ee87e5087c60ee786c3f6c5"
+  integrity sha512-83S9w6eFq12BBIJYvjMux6/dkirb8+4zJRA9cxNBVb7Wq5fJBW+Xze48WqR8pxua7bDuAaaAxtVVd4Idjp1dBQ==
   dependencies:
-    call-bind "^1.0.6"
-    es-errors "^1.3.0"
+    call-bind "^1.0.5"
+    get-intrinsic "^1.2.2"
     is-regex "^1.1.4"
 
 safe-regex@^1.1.0:
@@ -25542,17 +26241,10 @@ semver@7.3.8:
   dependencies:
     lru-cache "^6.0.0"
 
-semver@7.5.4:
+semver@7.5.4, semver@^7.0.0, semver@^7.1.1, semver@^7.2.1, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5, semver@^7.3.7, semver@^7.3.8, semver@^7.5.3, semver@^7.5.4:
   version "7.5.4"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.4.tgz#483986ec4ed38e1c6c48c34894a9182dbff68a6e"
   integrity sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==
-  dependencies:
-    lru-cache "^6.0.0"
-
-semver@7.6.0, semver@^7.0.0, semver@^7.1.1, semver@^7.2.1, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5, semver@^7.3.7, semver@^7.3.8, semver@^7.5.3, semver@^7.5.4:
-  version "7.6.0"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.6.0.tgz#1a46a4db4bffcccd97b743b5005c8325f23d4e2d"
-  integrity sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==
   dependencies:
     lru-cache "^6.0.0"
 
@@ -25663,15 +26355,14 @@ set-blocking@^2.0.0:
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==
 
-set-function-length@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/set-function-length/-/set-function-length-1.2.1.tgz#47cc5945f2c771e2cf261c6737cf9684a2a5e425"
-  integrity sha512-j4t6ccc+VsKwYHso+kElc5neZpjtq9EnRICFZtWyBsLojhmeF/ZBd/elqm22WJh/BziDe/SBiOeAt0m2mfLD0g==
+set-function-length@^1.1.1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/set-function-length/-/set-function-length-1.2.0.tgz#2f81dc6c16c7059bda5ab7c82c11f03a515ed8e1"
+  integrity sha512-4DBHDoyHlM1IRPGYcoxexgh67y4ueR53FKV1yyxwFMY7aCqcN/38M1+SwZ/qJQ8iLv7+ck385ot4CcisOAPT9w==
   dependencies:
-    define-data-property "^1.1.2"
-    es-errors "^1.3.0"
+    define-data-property "^1.1.1"
     function-bind "^1.1.2"
-    get-intrinsic "^1.2.3"
+    get-intrinsic "^1.2.2"
     gopd "^1.0.1"
     has-property-descriptors "^1.0.1"
 
@@ -25778,14 +26469,13 @@ shellwords@^0.1.1:
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
 
 side-channel@^1.0.3, side-channel@^1.0.4:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.0.5.tgz#9a84546599b48909fb6af1211708d23b1946221b"
-  integrity sha512-QcgiIWV4WV7qWExbN5llt6frQB/lBven9pqliLXfGPB+K9ZYXxDozp0wLkHS24kWCm+6YXH/f0HhnObZnZOBnQ==
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.0.4.tgz#efce5c8fdc104ee751b25c58d4290011fa5ea2cf"
+  integrity sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==
   dependencies:
-    call-bind "^1.0.6"
-    es-errors "^1.3.0"
-    get-intrinsic "^1.2.4"
-    object-inspect "^1.13.1"
+    call-bind "^1.0.0"
+    get-intrinsic "^1.0.2"
+    object-inspect "^1.9.0"
 
 signal-exit@3.0.7, signal-exit@^3.0.0, signal-exit@^3.0.2, signal-exit@^3.0.3, signal-exit@^3.0.7:
   version "3.0.7"
@@ -25998,11 +26688,11 @@ socks-proxy-agent@^7.0.0:
     socks "^2.6.2"
 
 socks@^2.6.2:
-  version "2.7.3"
-  resolved "https://registry.yarnpkg.com/socks/-/socks-2.7.3.tgz#7d8a75d7ce845c0a96f710917174dba0d543a785"
-  integrity sha512-vfuYK48HXCTFD03G/1/zkIls3Ebr2YNa4qU9gHDZdblHLiqhJrJGkY3+0Nx0JpN9qBhJbVObc1CNciT1bIZJxw==
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/socks/-/socks-2.7.1.tgz#d8e651247178fde79c0663043e07240196857d55"
+  integrity sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==
   dependencies:
-    ip-address "^9.0.5"
+    ip "^2.0.0"
     smart-buffer "^4.2.0"
 
 sort-keys-length@^1.0.0:
@@ -26145,9 +26835,9 @@ spdx-correct@^3.0.0:
     spdx-license-ids "^3.0.0"
 
 spdx-exceptions@^2.1.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/spdx-exceptions/-/spdx-exceptions-2.4.0.tgz#c07a4ede25b16e4f78e6707bbd84b15a45c19c1b"
-  integrity sha512-hcjppoJ68fhxA/cjbN4T8N6uCUejN8yFw69ttpqtBeCbF3u13n7mb31NB9jKwGTTWWnt9IbRA/mf1FprYS8wfw==
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz#3f28ce1a77a00372683eade4a433183527a2163d"
+  integrity sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==
 
 spdx-expression-parse@^3.0.0:
   version "3.0.1"
@@ -26158,9 +26848,9 @@ spdx-expression-parse@^3.0.0:
     spdx-license-ids "^3.0.0"
 
 spdx-license-ids@^3.0.0:
-  version "3.0.17"
-  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.17.tgz#887da8aa73218e51a1d917502d79863161a93f9c"
-  integrity sha512-sh8PWc/ftMqAAdFiBu6Fy6JUOYjqDJBJvIhpfDMyHrr0Rbp5liZqd4TjtQ/RgfLjKFZb+LMx5hpml5qOWy0qvg==
+  version "3.0.16"
+  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.16.tgz#a14f64e0954f6e25cc6587bd4f392522db0d998f"
+  integrity sha512-eWN+LnM3GR6gPu35WxNgbGl8rmY1AEmoMDvL/QD6zYmPWgywxWqJWNdLGT+ke8dKNWrcYgYjPpG5gbTfghP8rw==
 
 spdy-transport@^3.0.0:
   version "3.0.0"
@@ -26222,11 +26912,6 @@ split@^1.0.0:
   integrity sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==
   dependencies:
     through "2"
-
-sprintf-js@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.1.3.tgz#4914b903a2f8b685d17fdf78a70e917e872e444a"
-  integrity sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==
 
 sprintf-js@~1.0.2:
   version "1.0.3"
@@ -26359,11 +27044,11 @@ storybook-addon-swc@1.2.0:
     swc-loader "^0.1.15"
 
 storybook@^7.6.14:
-  version "7.6.14"
-  resolved "https://registry.yarnpkg.com/storybook/-/storybook-7.6.14.tgz#4af87bec32098e1115b417de0a149a242c3bab01"
-  integrity sha512-4WMb/Dyzl4QzAd1X1b13cJXwynI7fGbT3qGy+X169hsXn6u73tlRcuPXrTsEO9a+rNBxZiBEBJf5poYxCH2j5Q==
+  version "7.6.15"
+  resolved "https://registry.yarnpkg.com/storybook/-/storybook-7.6.15.tgz#a53247cb5f719b78a1e8a6780696580c1f26fe80"
+  integrity sha512-Ybezq9JRk5CBhzjgzZ/oT7mnU45UwhyVSGKW+PUKZGGUG9VH2hCrTEES9f/zEF82kj/5COVPyqR/5vlXuuS39A==
   dependencies:
-    "@storybook/cli" "7.6.14"
+    "@storybook/cli" "7.6.15"
 
 stream-browserify@^2.0.1:
   version "2.0.2"
@@ -27097,7 +27782,7 @@ terser-webpack-plugin@^1.4.3:
     webpack-sources "^1.4.0"
     worker-farm "^1.7.0"
 
-terser-webpack-plugin@^5.2.5, terser-webpack-plugin@^5.3.1, terser-webpack-plugin@^5.3.10, terser-webpack-plugin@^5.3.7:
+terser-webpack-plugin@^5.2.5, terser-webpack-plugin@^5.3.1, terser-webpack-plugin@^5.3.7:
   version "5.3.10"
   resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-5.3.10.tgz#904f4c9193c6fd2a03f693a2150c62a92f40d199"
   integrity sha512-BKFPWlPDndPs+NGGCr1U59t0XScL5317Y0UReNrHaw9/FwhPENlq6bfgs+4yPfyP51vqC1bQ4rp1EfXW5ZSH9w==
@@ -27437,9 +28122,9 @@ trough@^1.0.0:
   integrity sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==
 
 trough@^2.0.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/trough/-/trough-2.2.0.tgz#94a60bd6bd375c152c1df911a4b11d5b0256f50f"
-  integrity sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/trough/-/trough-2.1.0.tgz#0f7b511a4fde65a46f18477ab38849b22c554876"
+  integrity sha512-AqTiAOLcj85xS7vQ8QkAV41hPDIJ71XJB4RCUrzo/1GM2CQwhkJGaf9Hgr7BOugMRpgGUrqRg/DrBDl4H40+8g==
 
 truncate@^3.0.0:
   version "3.0.0"
@@ -27452,9 +28137,9 @@ tryer@^1.0.1:
   integrity sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA==
 
 ts-api-utils@^1.0.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/ts-api-utils/-/ts-api-utils-1.2.1.tgz#f716c7e027494629485b21c0df6180f4d08f5e8b"
-  integrity sha512-RIYA36cJn2WiH9Hy77hdF9r7oEwxAtB/TS9/S4Qd90Ap4z5FSiin5zEiTL44OII1Y3IIlEvxwxFUVgrHSZ/UpA==
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/ts-api-utils/-/ts-api-utils-1.0.3.tgz#f12c1c781d04427313dbac808f453f050e54a331"
+  integrity sha512-wNMeqtMz5NtwpT/UZGY5alT+VoKdSsOOP/kqHFcUW1P/VRhH2wJ48+DN2WwUliNbQ976ETwDL0Ifd2VVvgonvg==
 
 ts-dedent@^2.0.0, ts-dedent@^2.2.0:
   version "2.2.0"
@@ -27671,9 +28356,9 @@ type-fest@^3.8.0:
   integrity sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==
 
 type-fest@^4.0.0:
-  version "4.10.2"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-4.10.2.tgz#3abdb144d93c5750432aac0d73d3e85fcab45738"
-  integrity sha512-anpAG63wSpdEbLwOqH8L84urkL6PiVIov3EMmgIhhThevh9aiMQov+6Btx0wldNcvm4wV+e2/Rt1QdDwKHFbHw==
+  version "4.9.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-4.9.0.tgz#d29c8efe5b1e703feeb29cef23d887b2f479844d"
+  integrity sha512-KS/6lh/ynPGiHD/LnAobrEFq3Ad4pBzOlJ1wAnJx9N4EYoqFhMfLIBjUT2UEx4wg5ZE+cC1ob6DCSpppVo+rtg==
 
 type-is@~1.6.18:
   version "1.6.18"
@@ -27694,13 +28379,13 @@ type@^2.7.2:
   integrity sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw==
 
 typed-array-buffer@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/typed-array-buffer/-/typed-array-buffer-1.0.1.tgz#0608ffe6bca71bf15a45bff0ca2604107a1325f5"
-  integrity sha512-RSqu1UEuSlrBhHTWC8O9FnPjOduNs4M7rJ4pRKoEjtx1zUNOPN2sSXHLDX+Y2WPbHIxbvg4JFo2DNAEfPIKWoQ==
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/typed-array-buffer/-/typed-array-buffer-1.0.0.tgz#18de3e7ed7974b0a729d3feecb94338d1472cd60"
+  integrity sha512-Y8KTSIglk9OZEr8zywiIHG/kmQ7KWyjseXs1CbSo8vC42w7hg2HgYTxSWwP0+is7bWDc1H+Fo026CpHFwm8tkw==
   dependencies:
-    call-bind "^1.0.6"
-    es-errors "^1.3.0"
-    is-typed-array "^1.1.13"
+    call-bind "^1.0.2"
+    get-intrinsic "^1.2.1"
+    is-typed-array "^1.1.10"
 
 typed-array-byte-length@^1.0.0:
   version "1.0.0"
@@ -27767,9 +28452,9 @@ ucfirst@^1.0.0:
   integrity sha512-xbB/CQ0GdkxqH4IElZqenn/dL/tnyx7DCDASWJPE92ePbFM21kKemXI2LBeYtEvblf1Ol98hyJJS43Wu5JMQSQ==
 
 ufo@^1.3.2:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/ufo/-/ufo-1.4.0.tgz#39845b31be81b4f319ab1d99fd20c56cac528d32"
-  integrity sha512-Hhy+BhRBleFjpJ2vchUNN40qgkh0366FWJGqVLYBHev0vpHTrXSA0ryT+74UiW6KWsldNurQMKGqCm1M2zBciQ==
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/ufo/-/ufo-1.3.2.tgz#c7d719d0628a1c80c006d2240e0d169f6e3c0496"
+  integrity sha512-o+ORpgGwaYQXgqGDwd+hkS4PuZ3QnmqMMxRuajK/a38L6fTpcE5GPIfrf+L/KemFzfUpeUQc1rRS1iDBozvnFA==
 
 uglify-js@^3.1.4:
   version "3.17.4"
@@ -28839,9 +29524,9 @@ webpack-dev-server@^4.6.0:
     ws "^8.13.0"
 
 webpack-hot-middleware@^2.25.1:
-  version "2.26.1"
-  resolved "https://registry.yarnpkg.com/webpack-hot-middleware/-/webpack-hot-middleware-2.26.1.tgz#87214f1e3f9f3acab9271fef9e6ed7b637d719c0"
-  integrity sha512-khZGfAeJx6I8K9zKohEWWYN6KDlVw2DHownoe+6Vtwj1LP9WFgegXnVMSkZ/dBEBtXFwrkkydsaPFlB7f8wU2A==
+  version "2.26.0"
+  resolved "https://registry.yarnpkg.com/webpack-hot-middleware/-/webpack-hot-middleware-2.26.0.tgz#0a103c9b2836c1f27d7f74bbe0e96c99c82d0265"
+  integrity sha512-okzjec5sAEy4t+7rzdT8eRyxsk0FDSmBPN2KwX4Qd+6+oQCfe5Ve07+u7cJvofgB+B4w5/4dO4Pz0jhhHyyPLQ==
   dependencies:
     ansi-html-community "0.0.8"
     html-entities "^2.1.0"
@@ -28934,18 +29619,18 @@ webpack@4.44.2:
     webpack-sources "^1.4.1"
 
 webpack@5, webpack@^5.64.4:
-  version "5.90.1"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.90.1.tgz#62ab0c097d7cbe83d32523dbfbb645cdb7c3c01c"
-  integrity sha512-SstPdlAC5IvgFnhiRok8hqJo/+ArAbNv7rhU4fnWGHNVfN59HSQFaxZDSAL3IFG2YmqxuRs+IU33milSxbPlog==
+  version "5.89.0"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.89.0.tgz#56b8bf9a34356e93a6625770006490bf3a7f32dc"
+  integrity sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==
   dependencies:
     "@types/eslint-scope" "^3.7.3"
-    "@types/estree" "^1.0.5"
+    "@types/estree" "^1.0.0"
     "@webassemblyjs/ast" "^1.11.5"
     "@webassemblyjs/wasm-edit" "^1.11.5"
     "@webassemblyjs/wasm-parser" "^1.11.5"
     acorn "^8.7.1"
     acorn-import-assertions "^1.9.0"
-    browserslist "^4.21.10"
+    browserslist "^4.14.5"
     chrome-trace-event "^1.0.2"
     enhanced-resolve "^5.15.0"
     es-module-lexer "^1.2.1"
@@ -28959,7 +29644,7 @@ webpack@5, webpack@^5.64.4:
     neo-async "^2.6.2"
     schema-utils "^3.2.0"
     tapable "^2.1.1"
-    terser-webpack-plugin "^5.3.10"
+    terser-webpack-plugin "^5.3.7"
     watchpack "^2.4.0"
     webpack-sources "^3.2.3"
 
@@ -29114,16 +29799,16 @@ which-module@^2.0.0:
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.1.tgz#776b1fe35d90aebe99e8ac15eb24093389a4a409"
   integrity sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==
 
-which-typed-array@^1.1.13, which-typed-array@^1.1.14, which-typed-array@^1.1.2, which-typed-array@^1.1.9:
-  version "1.1.14"
-  resolved "https://registry.yarnpkg.com/which-typed-array/-/which-typed-array-1.1.14.tgz#1f78a111aee1e131ca66164d8bdc3ab062c95a06"
-  integrity sha512-VnXFiIW8yNn9kIHN88xvZ4yOWchftKDsRJ8fEPacX/wl1lOvBrhsJ/OeJCXq7B0AaijRuqgzSKalJoPk+D8MPg==
+which-typed-array@^1.1.11, which-typed-array@^1.1.13, which-typed-array@^1.1.2, which-typed-array@^1.1.9:
+  version "1.1.13"
+  resolved "https://registry.yarnpkg.com/which-typed-array/-/which-typed-array-1.1.13.tgz#870cd5be06ddb616f504e7b039c4c24898184d36"
+  integrity sha512-P5Nra0qjSncduVPEAr7xhoF5guty49ArDTwzJ/yNuPIbZppyRxFQsRCWrocxIY+CnMVG+qfbU2FmDKyvSGClow==
   dependencies:
-    available-typed-arrays "^1.0.6"
-    call-bind "^1.0.5"
+    available-typed-arrays "^1.0.5"
+    call-bind "^1.0.4"
     for-each "^0.3.3"
     gopd "^1.0.1"
-    has-tostringtag "^1.0.1"
+    has-tostringtag "^1.0.0"
 
 which@2.0.2, which@^2.0.1, which@^2.0.2:
   version "2.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1832,7 +1832,7 @@
 
 "@contentful/f36-accordion@^4.60.0":
   version "4.60.0"
-  resolved "https://npm.pkg.github.com/download/@contentful/f36-accordion/4.60.0/868e0fea89425a99720f56371bf175ac364c28ed#868e0fea89425a99720f56371bf175ac364c28ed"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-accordion/-/f36-accordion-4.60.0.tgz#868e0fea89425a99720f56371bf175ac364c28ed"
   integrity sha512-oAX1LIUwFcmFIJRvgbjYEwiZDT7XwGRZ37bwBMkoTRrMgrXTGSEdNxLnjpSUco6pxAIt393vyycbxcNEBTUKDA==
   dependencies:
     "@contentful/f36-collapse" "^4.60.0"
@@ -1856,7 +1856,7 @@
 
 "@contentful/f36-asset@^4.60.0":
   version "4.60.0"
-  resolved "https://npm.pkg.github.com/download/@contentful/f36-asset/4.60.0/455104d3b885e488ab91bd47c81c967ba7204f4f#455104d3b885e488ab91bd47c81c967ba7204f4f"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-asset/-/f36-asset-4.60.0.tgz#455104d3b885e488ab91bd47c81c967ba7204f4f"
   integrity sha512-93oH0l5whXCIWnK50WBzmnzEFTMzddgVdoLySbZj+fJcfD4dX7GGSNg5JOi9uJwIlZjCLLWlwS4G7QuwFLiX0Q==
   dependencies:
     "@contentful/f36-core" "^4.60.0"
@@ -1885,7 +1885,7 @@
 
 "@contentful/f36-autocomplete@^4.60.0":
   version "4.60.0"
-  resolved "https://npm.pkg.github.com/download/@contentful/f36-autocomplete/4.60.0/ca98fc707b6a2050dbc2bd15ed5d6d2cf716408c#ca98fc707b6a2050dbc2bd15ed5d6d2cf716408c"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-autocomplete/-/f36-autocomplete-4.60.0.tgz#ca98fc707b6a2050dbc2bd15ed5d6d2cf716408c"
   integrity sha512-sFf0mQuss52RcBoHo2NBfceVrMqgvv1TJUPqfImXBIFZiIeI5xRl+R0Rgt6Qc8nH9WG4lg6oYzQgrZOxEnbkzA==
   dependencies:
     "@contentful/f36-button" "^4.60.0"
@@ -1912,7 +1912,7 @@
 
 "@contentful/f36-badge@^4.60.0":
   version "4.60.0"
-  resolved "https://npm.pkg.github.com/download/@contentful/f36-badge/4.60.0/dbfad7478a48ded4db52609818678755ac7e0c07#dbfad7478a48ded4db52609818678755ac7e0c07"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-autocomplete/-/f36-autocomplete-4.60.0.tgz#dbfad7478a48ded4db52609818678755ac7e0c07"
   integrity sha512-tUceZPFS8/ynENGUKcw1tVSisIW3xrhH7S9QB5JRSSaL1ccOLT3AVZQjIxm5MmHUw2l1EhSZngpEPFZyHvWEdQ==
   dependencies:
     "@contentful/f36-core" "^4.60.0"
@@ -1933,7 +1933,7 @@
 
 "@contentful/f36-button@^4.60.0":
   version "4.60.0"
-  resolved "https://npm.pkg.github.com/download/@contentful/f36-button/4.60.0/834e78c44b1c690d716e6b3a42a99e7a7dd20356#834e78c44b1c690d716e6b3a42a99e7a7dd20356"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-button/-/f36-button-4.60.0.tgz#834e78c44b1c690d716e6b3a42a99e7a7dd20356"
   integrity sha512-F4wAzsW8FR1bZBVdj3MI6l9/ugAJfouROaBihaCCLV+ebpqYB9Yg5urv304ZHl3vXA71n3/D39LGTasxBTuIVg==
   dependencies:
     "@contentful/f36-core" "^4.60.0"
@@ -1964,7 +1964,7 @@
 
 "@contentful/f36-card@^4.60.0":
   version "4.60.0"
-  resolved "https://npm.pkg.github.com/download/@contentful/f36-card/4.60.0/32c46e8262b0da6307d912c0751ded32b42520d7#32c46e8262b0da6307d912c0751ded32b42520d7"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-card/-/f36-card-4.60.0.tgz#32c46e8262b0da6307d912c0751ded32b42520d7"
   integrity sha512-bl5BmrYipIZVSQARfKz8e6Ujgkb0pjCMfX2lM/2GslfNre3IlUJhv2/d4Cq7eatfhioMbQpk5lblV/wORvsAkw==
   dependencies:
     "@contentful/f36-asset" "^4.60.0"
@@ -1993,7 +1993,7 @@
 
 "@contentful/f36-collapse@^4.60.0":
   version "4.60.0"
-  resolved "https://npm.pkg.github.com/download/@contentful/f36-collapse/4.60.0/1c43cd75de9af6eef5b2613dee27b7628e4b6733#1c43cd75de9af6eef5b2613dee27b7628e4b6733"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-collapse/-/f36-collapse-4.60.0.tgz#1c43cd75de9af6eef5b2613dee27b7628e4b6733"
   integrity sha512-Q5Jk7irONzrfOpSFw5C+Xdh//dVU4ismnaGEVi1mk+DgMvAR8AkVrcuP5jgeAVX7zk/ZSFzzlNc+1WBWEAIFQQ==
   dependencies:
     "@contentful/f36-core" "^4.60.0"
@@ -2084,7 +2084,7 @@
 
 "@contentful/f36-components@^4.60.0":
   version "4.60.0"
-  resolved "https://npm.pkg.github.com/download/@contentful/f36-components/4.60.0/4bf2ac0f40074b564d6d5ff7a3252e65871dfd17#4bf2ac0f40074b564d6d5ff7a3252e65871dfd17"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-components/-/f36-components-4.60.0.tgz#4bf2ac0f40074b564d6d5ff7a3252e65871dfd17"
   integrity sha512-9vDuLm0hQJPyKG+XpBle41AXRzRDcLqPl10HZ19bA+E/K1Pen9XFfkqH3qZqigF/peEyGJvzYomAmr2PCfJGRA==
   dependencies:
     "@contentful/f36-accordion" "^4.60.0"
@@ -2137,7 +2137,7 @@
 
 "@contentful/f36-copybutton@^4.60.0":
   version "4.60.0"
-  resolved "https://npm.pkg.github.com/download/@contentful/f36-copybutton/4.60.0/5a7e222a6790c5103d95ba60150ec065f9a9331f#5a7e222a6790c5103d95ba60150ec065f9a9331f"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-copybutton/-/f36-copybutton-4.60.0.tgz#5a7e222a6790c5103d95ba60150ec065f9a9331f"
   integrity sha512-fkxC4bk4YDH/GKjC0Djg/wLCgrvvoOVP+Fcx21Vogf1jlSmnJN4Ju3yOzdDKT8vPoKLlDNWRz3CbYHmH2rdqvA==
   dependencies:
     "@contentful/f36-button" "^4.60.0"
@@ -2160,7 +2160,7 @@
 
 "@contentful/f36-core@^4.60.0":
   version "4.60.0"
-  resolved "https://npm.pkg.github.com/download/@contentful/f36-core/4.60.0/fcd13bb7c7882c924ffe1910453bed58fe704b71#fcd13bb7c7882c924ffe1910453bed58fe704b71"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-core/-/f36-core-4.60.0.tgz#fcd13bb7c7882c924ffe1910453bed58fe704b71"
   integrity sha512-gJhZzmgjb+6jljgofnQnuaz5s2dP+tSeHzlpIzppW2KbFNvZfk408jbIZn9Ny2xw9LodXcEiFTuCewyYVQ7Dzw==
   dependencies:
     "@contentful/f36-tokens" "^4.0.4"
@@ -2188,7 +2188,7 @@
 
 "@contentful/f36-datepicker@^4.60.0":
   version "4.60.0"
-  resolved "https://npm.pkg.github.com/download/@contentful/f36-datepicker/4.60.0/3e673b96a5b1220c699adc5f950fd6616603f17f#3e673b96a5b1220c699adc5f950fd6616603f17f"
+  resolved "hhttps://registry.yarnpkg.com/@contentful/f36-datepicker/-/f36-datepicker-4.60.0.tgz#3e673b96a5b1220c699adc5f950fd6616603f17f"
   integrity sha512-mnXYlPRy0nMaS3REoV86nSc/iJ1QuX43gz5msFxqz4ZHazjYYgXa0fk48Qd5WNpUC1jXbW2H0rGX84o2Aa5BFA==
   dependencies:
     "@contentful/f36-button" "^4.60.0"
@@ -2215,7 +2215,7 @@
 
 "@contentful/f36-datetime@^4.60.0":
   version "4.60.0"
-  resolved "https://npm.pkg.github.com/download/@contentful/f36-datetime/4.60.0/78bc62f8e24900af5ccba98384256d3ed84c71d3#78bc62f8e24900af5ccba98384256d3ed84c71d3"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-datetime/-/f36-datetime-4.60.0.tgz#78bc62f8e24900af5ccba98384256d3ed84c71d3"
   integrity sha512-OXyAXS8DS2akxisCOfN5AkG0miPflNbtHWlo+XR2JjuCPBY5YJ0Hm6EzC304g5BnZlOEQ5nf5if87Gfzca4eLw==
   dependencies:
     "@contentful/f36-core" "^4.60.0"
@@ -2236,7 +2236,7 @@
 
 "@contentful/f36-drag-handle@^4.60.0":
   version "4.60.0"
-  resolved "https://npm.pkg.github.com/download/@contentful/f36-drag-handle/4.60.0/d165c331369518c7740027b3c48ec3af4f3d20b1#d165c331369518c7740027b3c48ec3af4f3d20b1"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-drag-handle/-/f36-drag-handle-4.60.0.tgz#d165c331369518c7740027b3c48ec3af4f3d20b1"
   integrity sha512-VZE+iZnGO+ZRdu/KFlKZn9wbMB3LzYWMH+LVSLXZkKDtZm1agWOzovSLHZxsxIFkmZA7s3YphBo7vs5FOxEoQw==
   dependencies:
     "@contentful/f36-core" "^4.60.0"
@@ -2256,7 +2256,7 @@
 
 "@contentful/f36-empty-state@^4.60.0":
   version "4.60.0"
-  resolved "https://npm.pkg.github.com/download/@contentful/f36-empty-state/4.60.0/7fc3bb6fa5933a987721e7868a49f352a334f2c7#7fc3bb6fa5933a987721e7868a49f352a334f2c7"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-empty-state/-/f36-empty-state-4.60.0.tgz#7fc3bb6fa5933a987721e7868a49f352a334f2c7"
   integrity sha512-P6k3l4sSo/VXxsGO19SPsf70eeUoL/cL1VvMmnGpFRbDexcJBs3pfcusArc0OBblYdsAVHOPSRxePiD7x/L4rg==
   dependencies:
     "@contentful/f36-tokens" "^4.0.4"
@@ -2282,7 +2282,7 @@
 
 "@contentful/f36-entity-list@^4.60.0":
   version "4.60.0"
-  resolved "https://npm.pkg.github.com/download/@contentful/f36-entity-list/4.60.0/aec7a824f0d7bda9f2b2183a6b4e9e61a2fa2a4c#aec7a824f0d7bda9f2b2183a6b4e9e61a2fa2a4c"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-entity-list/-/f36-entity-list-4.60.0.tgz#aec7a824f0d7bda9f2b2183a6b4e9e61a2fa2a4c"
   integrity sha512-O5i3MTg1bew3aSP/8mod7rONBcDpdReULcRq554z5WZUrzs4afMy3aP0qU/RBo/4T62sT142jJ09mulLbRYHwg==
   dependencies:
     "@contentful/f36-badge" "^4.60.0"
@@ -2311,7 +2311,7 @@
 
 "@contentful/f36-forms@^4.60.0":
   version "4.60.0"
-  resolved "https://npm.pkg.github.com/download/@contentful/f36-forms/4.60.0/0ee942088770739cfc17b7cc43d3209bca359720#0ee942088770739cfc17b7cc43d3209bca359720"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-forms/-/f36-forms-4.60.0.tgz#0ee942088770739cfc17b7cc43d3209bca359720"
   integrity sha512-m4JoJJEYkP6DwQCwaU8EPnTCAtca1j8aL+QDtEn/Pp92BjPD1hAT7FM7lWKhnAdDXOsK9j+1U6Tp6Oyce157WQ==
   dependencies:
     "@contentful/f36-core" "^4.60.0"
@@ -2332,7 +2332,7 @@
 
 "@contentful/f36-icon@^4.60.0":
   version "4.60.0"
-  resolved "https://npm.pkg.github.com/download/@contentful/f36-icon/4.60.0/00d47db650abc294de8ff22c91366cf85caeeaff#00d47db650abc294de8ff22c91366cf85caeeaff"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-icon/-/f36-icon-4.60.0.tgz#00d47db650abc294de8ff22c91366cf85caeeaff"
   integrity sha512-+zbMsTd0duRhdvTviW49l1xCskgMhlSbE+31xORODqgoeC5bkbLMJNcI5PT4oc/CGGQqbl5NV0fVgBiKOUmSYw==
   dependencies:
     "@contentful/f36-core" "^4.60.0"
@@ -2360,7 +2360,7 @@
 
 "@contentful/f36-list@^4.60.0":
   version "4.60.0"
-  resolved "https://npm.pkg.github.com/download/@contentful/f36-list/4.60.0/d94c1ce4cb4bdcff8246417198d3c1d91a44fb2a#d94c1ce4cb4bdcff8246417198d3c1d91a44fb2a"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-list/-/f36-list-4.60.0.tgz#d94c1ce4cb4bdcff8246417198d3c1d91a44fb2a"
   integrity sha512-KPUqf/Y9GaD3HWMMZmeBVY1aoN3s7cDzY0z080yvaGCaQpbE0tTOkE/ZFRK8pE0eU94iabrcKg92MTreEEwWeA==
   dependencies:
     "@contentful/f36-core" "^4.60.0"
@@ -2382,7 +2382,7 @@
 
 "@contentful/f36-menu@^4.60.0":
   version "4.60.0"
-  resolved "https://npm.pkg.github.com/download/@contentful/f36-menu/4.60.0/1432b225ec0cdc0b552506fa5ec398ab5ebcdcae#1432b225ec0cdc0b552506fa5ec398ab5ebcdcae"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-menu/-/f36-menu-4.60.0.tgz#1432b225ec0cdc0b552506fa5ec398ab5ebcdcae"
   integrity sha512-Rjn6WrGrJIPpkJaNQdj17KSHoYC3xj82W9YObtzl/W/huNhXV2IoH8p7q9kOaEuZjG80ERvuuno84xkLMiAaig==
   dependencies:
     "@contentful/f36-core" "^4.60.0"
@@ -2409,7 +2409,7 @@
 
 "@contentful/f36-modal@^4.60.0":
   version "4.60.0"
-  resolved "https://npm.pkg.github.com/download/@contentful/f36-modal/4.60.0/52a959c31f0ebc711ff6db93362435319e41a5a7#52a959c31f0ebc711ff6db93362435319e41a5a7"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-modal/-/f36-modal-4.60.0.tgz#52a959c31f0ebc711ff6db93362435319e41a5a7"
   integrity sha512-9IixUm5RgOgtOviMhvmQKImjKK24XykoJymromOoQPBgI1rIqUxBhlwGWIPOYYtoA32mJNIL2erJhYM+zrR2+A==
   dependencies:
     "@contentful/f36-button" "^4.60.0"
@@ -2450,7 +2450,7 @@
 
 "@contentful/f36-note@^4.60.0":
   version "4.60.0"
-  resolved "https://npm.pkg.github.com/download/@contentful/f36-note/4.60.0/61d52aaef6bd02df2984be8bed1c80703565ac59#61d52aaef6bd02df2984be8bed1c80703565ac59"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-note/-/f36-note-4.60.0.tgz#61d52aaef6bd02df2984be8bed1c80703565ac59"
   integrity sha512-XnOMEo2U3jbPzy20bZgoyQjR7bwsMWGUQrcrE3H0cXSHYQaKuvWo6uaEMCsqr00LWkP1537tuWfr3Yalp33aiQ==
   dependencies:
     "@contentful/f36-button" "^4.60.0"
@@ -2478,7 +2478,7 @@
 
 "@contentful/f36-notification@^4.60.0":
   version "4.60.0"
-  resolved "https://npm.pkg.github.com/download/@contentful/f36-notification/4.60.0/0e8d0b398d69c6bda13de2bc58442f811549b2a5#0e8d0b398d69c6bda13de2bc58442f811549b2a5"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-notification/-/f36-notification-4.60.0.tgz#0e8d0b398d69c6bda13de2bc58442f811549b2a5"
   integrity sha512-1YZ+eQhBLNEIc1dBcm4Ee0Rq1oXP8VvkYxczRmTaopKLlxUTZpvnjPZEq0wZTZ0Dc/uy8m92yByCCeo0UAVpXw==
   dependencies:
     "@contentful/f36-button" "^4.60.0"
@@ -2506,7 +2506,7 @@
 
 "@contentful/f36-pagination@^4.60.0":
   version "4.60.0"
-  resolved "https://npm.pkg.github.com/download/@contentful/f36-pagination/4.60.0/20063ece05da401deb3cc9fb33392ece6de37334#20063ece05da401deb3cc9fb33392ece6de37334"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-pagination/-/f36-pagination-4.60.0.tgz#20063ece05da401deb3cc9fb33392ece6de37334"
   integrity sha512-m/m+/wZxjO/EDPWGkdMDyGsxEe5iV6RnSMsVABk4QTOe7Zo05rqGUw6IjqzvecDgDwm1jUrYm/lhlNObwpcRlA==
   dependencies:
     "@contentful/f36-button" "^4.60.0"
@@ -2532,7 +2532,7 @@
 
 "@contentful/f36-pill@^4.60.0":
   version "4.60.0"
-  resolved "https://npm.pkg.github.com/download/@contentful/f36-pill/4.60.0/b6707f505141e1718f5e94dce9508f57d5258031#b6707f505141e1718f5e94dce9508f57d5258031"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-pill/-/f36-pill-4.60.0.tgz#b6707f505141e1718f5e94dce9508f57d5258031"
   integrity sha512-1heXDtENtFUnDrgaVYu3GRTtIzP37AydxOw1BlpRUiKGvEzL8K217d7WVhKoMlUFk+uCS50j6t6cJxl/3E3Xtw==
   dependencies:
     "@contentful/f36-button" "^4.60.0"
@@ -2557,7 +2557,7 @@
 
 "@contentful/f36-popover@^4.60.0":
   version "4.60.0"
-  resolved "https://npm.pkg.github.com/download/@contentful/f36-popover/4.60.0/90b6247669ed1ec80000be5d394ffdd4cca7d2cd#90b6247669ed1ec80000be5d394ffdd4cca7d2cd"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-popover/-/f36-popover-4.60.0.tgz#90b6247669ed1ec80000be5d394ffdd4cca7d2cd"
   integrity sha512-D0XNoO6//TLIzc/LLt7UnbdeGpDO3t/Eb3eKwK4Z0n+pI8bCEm6EltfbVO3mWMmPPSDhjLMa33q3hgGXt/BUAg==
   dependencies:
     "@contentful/f36-core" "^4.60.0"
@@ -2579,7 +2579,7 @@
 
 "@contentful/f36-skeleton@^4.60.0":
   version "4.60.0"
-  resolved "https://npm.pkg.github.com/download/@contentful/f36-skeleton/4.60.0/4642350642ff451a7e558299cdb66fa3e9fcefab#4642350642ff451a7e558299cdb66fa3e9fcefab"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-skeleton/-/f36-skeleton-4.60.0.tgz#4642350642ff451a7e558299cdb66fa3e9fcefab"
   integrity sha512-5WsjDlOxofFpGSqkAVCEdOC7TCyrQ7/AYdxjhzFJClKHIZ0xR/ZqcZyE6yy8DV9dj+XMil8ZIAyrOnwDX6fRNQ==
   dependencies:
     "@contentful/f36-core" "^4.60.0"
@@ -2598,7 +2598,7 @@
 
 "@contentful/f36-spinner@^4.60.0":
   version "4.60.0"
-  resolved "https://npm.pkg.github.com/download/@contentful/f36-spinner/4.60.0/97edbb8e11fc4fa6d185a690387ef5d3ee1c1861#97edbb8e11fc4fa6d185a690387ef5d3ee1c1861"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-spinner/-/f36-spinner-4.60.0.tgz#97edbb8e11fc4fa6d185a690387ef5d3ee1c1861"
   integrity sha512-T4Lyjr+sL0VC+2z7UVXAvOYxLZfsNECUpQGScI1iaEc6751Zz8HC+ccCFoKY3MUC/9k/bAE85vHTDoH6nmyutg==
   dependencies:
     "@contentful/f36-core" "^4.60.0"
@@ -2618,7 +2618,7 @@
 
 "@contentful/f36-table@^4.60.0":
   version "4.60.0"
-  resolved "https://npm.pkg.github.com/download/@contentful/f36-table/4.60.0/f2caa104d7d64b5ea97137ecaea97dd284791cd3#f2caa104d7d64b5ea97137ecaea97dd284791cd3"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-table/-/f36-table-4.60.0.tgz#f2caa104d7d64b5ea97137ecaea97dd284791cd3"
   integrity sha512-hOX1x62mWKs1vAC6LOFAxX0+jxwicjIiC693t1oifqaKENwDj+vXZsYZrh+pCAjWILRpFsxjMP79L4pRWrZ0Mw==
   dependencies:
     "@contentful/f36-core" "^4.60.0"
@@ -2639,7 +2639,7 @@
 
 "@contentful/f36-tabs@^4.60.0":
   version "4.60.0"
-  resolved "https://npm.pkg.github.com/download/@contentful/f36-tabs/4.60.0/2605ec4ead8b3c788d8f0a0cb28cf47cbfb3ae68#2605ec4ead8b3c788d8f0a0cb28cf47cbfb3ae68"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-tabs/-/f36-tabs-4.60.0.tgz#2605ec4ead8b3c788d8f0a0cb28cf47cbfb3ae68"
   integrity sha512-4WzMJ847rbZMm+nWFAWhK4V2cYoPMXHkWif9FDuk4v6RPVhpoANUsSpTX9hBo2fyR99Cyj0qeGtqfJ39ifUTvw==
   dependencies:
     "@contentful/f36-core" "^4.60.0"
@@ -2658,7 +2658,7 @@
 
 "@contentful/f36-text-link@^4.60.0":
   version "4.60.0"
-  resolved "https://npm.pkg.github.com/download/@contentful/f36-text-link/4.60.0/7c4d254dedab05d0eef502a9a87513b7555bcd3b#7c4d254dedab05d0eef502a9a87513b7555bcd3b"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-text-link/-/f36-text-link-4.60.0.tgz#7c4d254dedab05d0eef502a9a87513b7555bcd3b"
   integrity sha512-gYP7O8iHQnflVactunb4Ui2Ynu1VD4KnKVDKbXQmk7BxDzMNKy5puvUUIgmI2MqmtA85eMcauWFSC677KJemMw==
   dependencies:
     "@contentful/f36-core" "^4.60.0"
@@ -2690,7 +2690,7 @@
 
 "@contentful/f36-tooltip@^4.60.0":
   version "4.60.0"
-  resolved "https://npm.pkg.github.com/download/@contentful/f36-tooltip/4.60.0/2c04d04c9e5041aa622aeea3f656d73d79a7d213#2c04d04c9e5041aa622aeea3f656d73d79a7d213"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-tooltip/-/f36-tooltip-4.60.0.tgz#2c04d04c9e5041aa622aeea3f656d73d79a7d213"
   integrity sha512-qIdLgj9oOqr69RuRA/9LrV1VlOSHOWuRtSsSZDx87rQwk8OlvdflvCd3Y1TPyrFiAbsRV7QtSmxau+1UKhqQ8A==
   dependencies:
     "@contentful/f36-core" "^4.60.0"
@@ -2713,7 +2713,7 @@
 
 "@contentful/f36-typography@^4.60.0":
   version "4.60.0"
-  resolved "https://npm.pkg.github.com/download/@contentful/f36-typography/4.60.0/0f2c507d9341fb6aaf4fa68876f643c5021b589b#0f2c507d9341fb6aaf4fa68876f643c5021b589b"
+  resolved "https://registry.yarnpkg.com/@contentful/f36-typography/-/f36-typography-4.60.0#0f2c507d9341fb6aaf4fa68876f643c5021b589b"
   integrity sha512-iEg1VT0wH3nUKZs8jSCxKnQPWVgrqckRuG3UpLzk4FKfyDHopimFMCLqy+XswWpA+aDRueMC4Il+TVVTO5N7qQ==
   dependencies:
     "@contentful/f36-core" "^4.60.0"


### PR DESCRIPTION
As a follow up to this [PR](https://github.com/contentful/field-editors/pull/1602) and updating the Forma `EntryCard` component to accept a Badge option in this [PR](https://github.com/contentful/forma-36/pull/2671#issuecomment-1943372919), this PR bumps the versions of Forma packages in `field-editor-reference` and passes the custom badge to `EntryCard` using the `badge` option instead of the `icon` option.