### PR TITLE
chore: use new cross-space entity picker functions

### DIFF
--- a/cypress/component/reference/MultipleResourceReferenceEditor.spec.tsx
+++ b/cypress/component/reference/MultipleResourceReferenceEditor.spec.tsx
@@ -31,7 +31,7 @@ const commonProps = {
 };
 
 //TODO: Tests for custom cards after implementation of handling,
-//fix 'dialogs.selectSingleResourceEntry' error in linkExisting click handling
+//fix 'dialogs.selectSingleResourceEntity' error in linkExisting click handling
 
 describe('Multiple resource editor', () => {
   const findLinkExistingBtn = () => cy.findByTestId('linkEditor.linkExisting');

--- a/cypress/component/reference/SingleResourceReferenceEditor.spec.tsx
+++ b/cypress/component/reference/SingleResourceReferenceEditor.spec.tsx
@@ -31,7 +31,7 @@ const commonProps = {
 };
 
 //TODO: Tests for custom cards after implementation of handling,
-//fix 'dialogs.selectSingleResourceEntry' error in linkExisting click handling
+//fix 'dialogs.selectSingleResourceEntity' error in linkExisting click handling
 
 describe('Single resource editor', () => {
   const findLinkExistingBtn = () => cy.findByTestId('linkEditor.linkExisting');

--- a/packages/reference/src/resources/MultipleResourceReferenceEditor.spec.tsx
+++ b/packages/reference/src/resources/MultipleResourceReferenceEditor.spec.tsx
@@ -68,7 +68,7 @@ describe('Multiple resource editor', () => {
     fireEvent.click(button);
 
     // @ts-expect-error wait app-sdk version update
-    const dialogFn = sdk.dialogs.selectMultipleResourceEntries;
+    const dialogFn = sdk.dialogs.selectMultipleResourceEntities;
     expect(dialogFn).toHaveBeenCalledTimes(1);
     const options = dialogFn.mock.calls[0][0];
     expect(options).toEqual({

--- a/packages/reference/src/resources/SingleResourceReferenceEditor.spec.tsx
+++ b/packages/reference/src/resources/SingleResourceReferenceEditor.spec.tsx
@@ -63,7 +63,7 @@ describe('Single resource editor', () => {
     fireEvent.click(button);
 
     // @ts-expect-error wait app-sdk version update
-    const dialogFn = sdk.dialogs.selectSingleResourceEntry;
+    const dialogFn = sdk.dialogs.selectSingleResourceEntity;
     expect(dialogFn).toHaveBeenCalledTimes(1);
     const options = dialogFn.mock.calls[0][0];
     expect(options).toEqual({

--- a/packages/reference/src/resources/testHelpers/resourceEditorHelpers.ts
+++ b/packages/reference/src/resources/testHelpers/resourceEditorHelpers.ts
@@ -21,7 +21,7 @@ export function mockSdkForField(fieldDefinition: any, fieldValue?: any): FieldAp
         sys: {
           type: 'ResourceLink',
           linkType: 'Contentful:Entry',
-          urn: 'contentful:linkedEntryId',
+          urn: 'crn:contentful:::content:spaces/space-id/entries/example-entity-urn',
         },
       }),
       selectMultipleResourceEntities: jest.fn().mockResolvedValue([
@@ -29,7 +29,7 @@ export function mockSdkForField(fieldDefinition: any, fieldValue?: any): FieldAp
           sys: {
             type: 'ResourceLink',
             linkType: 'Contentful:Entry',
-            urn: 'contentful:linkedEntryId',
+            urn: 'crn:contentful:::content:spaces/space-id/entries/example-entity-urn',
           },
         },
       ]),

--- a/packages/reference/src/resources/testHelpers/resourceEditorHelpers.ts
+++ b/packages/reference/src/resources/testHelpers/resourceEditorHelpers.ts
@@ -17,31 +17,19 @@ export function mockSdkForField(fieldDefinition: any, fieldValue?: any): FieldAp
     },
     dialogs: {
       // @ts-expect-error wait app-sdk version update
-      selectSingleResourceEntry: jest.fn().mockResolvedValue({
+      selectSingleResourceEntity: jest.fn().mockResolvedValue({
         sys: {
-          type: 'Entry',
-          id: 'linkedEntryId',
-          space: {
-            sys: {
-              type: 'Link',
-              linkType: 'Space',
-              id: 'x-space',
-            },
-          },
+          type: 'ResourceLink',
+          linkType: 'Contentful:Entry',
+          urn: 'contentful:linkedEntryId',
         },
       }),
-      selectMultipleResourceEntries: jest.fn().mockResolvedValue([
+      selectMultipleResourceEntities: jest.fn().mockResolvedValue([
         {
           sys: {
-            type: 'Entry',
-            id: 'linkedEntryId',
-            space: {
-              sys: {
-                type: 'Link',
-                linkType: 'Space',
-                id: 'x-space',
-              },
-            },
+            type: 'ResourceLink',
+            linkType: 'Contentful:Entry',
+            urn: 'contentful:linkedEntryId',
           },
         },
       ]),

--- a/packages/rich-text/src/plugins/Hyperlink/HyperlinkModal.tsx
+++ b/packages/rich-text/src/plugins/Hyperlink/HyperlinkModal.tsx
@@ -145,10 +145,10 @@ export function HyperlinkModal(props: HyperlinkModalProps) {
       allowedResources: getAllowedResourcesForNodeType(props.sdk.field, INLINES.RESOURCE_HYPERLINK),
     };
     // @ts-expect-error wait for update of app-sdk version
-    const entryLink = await props.sdk.dialogs.selectSingleResourceEntity(options);
-    if (entryLink) {
+    const entityLink = await props.sdk.dialogs.selectSingleResourceEntity(options);
+    if (entityLink) {
       setLinkTarget('');
-      setLinkEntity(entryLink);
+      setLinkEntity(entityLink);
     }
   }
 

--- a/packages/rich-text/src/plugins/Hyperlink/HyperlinkModal.tsx
+++ b/packages/rich-text/src/plugins/Hyperlink/HyperlinkModal.tsx
@@ -116,13 +116,6 @@ export function HyperlinkModal(props: HyperlinkModalProps) {
     return { sys: { id, type: 'Link', linkType: type } };
   }
 
-  function entityToResourceLink(entity): Link {
-    const { urn } = entity.sys;
-
-    // @ts-expect-error wait for update of app-sdk version
-    return { sys: { urn, type: 'ResourceLink', linkType: 'Contentful:Entry' } };
-  }
-
   function isResourceLink(link: Link | ResourceLink | null): link is ResourceLink {
     return !!link && !!(link as ResourceLink).sys.urn;
   }
@@ -152,10 +145,10 @@ export function HyperlinkModal(props: HyperlinkModalProps) {
       allowedResources: getAllowedResourcesForNodeType(props.sdk.field, INLINES.RESOURCE_HYPERLINK),
     };
     // @ts-expect-error wait for update of app-sdk version
-    const entry = await props.sdk.dialogs.selectSingleResourceEntry(options);
-    if (entry) {
+    const entryLink = await props.sdk.dialogs.selectSingleResourceEntity(options);
+    if (entryLink) {
       setLinkTarget('');
-      setLinkEntity(entityToResourceLink(entry));
+      setLinkEntity(entryLink);
     }
   }
 
@@ -202,8 +195,7 @@ export function HyperlinkModal(props: HyperlinkModalProps) {
                     setLinkType(event.target.value)
                   }
                   testId="link-type-input"
-                  isDisabled={props.readonly}
-                >
+                  isDisabled={props.readonly}>
                   {enabledLinkTypes.map((nodeType) => (
                     <Select.Option key={nodeType} value={nodeType}>
                       {LINK_TYPE_SELECTION_VALUES[nodeType]}
@@ -245,8 +237,7 @@ export function HyperlinkModal(props: HyperlinkModalProps) {
                       <TextLink
                         testId="entity-selection-link"
                         onClick={resetLinkEntity}
-                        className={styles.removeSelectionLabel}
-                      >
+                        className={styles.removeSelectionLabel}>
                         Remove selection
                       </TextLink>
                     )}
@@ -308,8 +299,7 @@ export function HyperlinkModal(props: HyperlinkModalProps) {
             onClick={() => props.onClose(null)}
             variant="secondary"
             testId="cancel-cta"
-            size="small"
-          >
+            size="small">
             Cancel
           </Button>
           <Button
@@ -318,8 +308,7 @@ export function HyperlinkModal(props: HyperlinkModalProps) {
             size="small"
             isDisabled={props.readonly || !isLinkComplete()}
             onClick={handleOnSubmit}
-            testId="confirm-cta"
-          >
+            testId="confirm-cta">
             {props.linkType ? 'Update' : 'Insert'}
           </Button>
         </ModalControls>

--- a/packages/rich-text/src/plugins/shared/EmbeddedInlineUtil.ts
+++ b/packages/rich-text/src/plugins/shared/EmbeddedInlineUtil.ts
@@ -32,29 +32,28 @@ export function getWithEmbeddedEntryInlineEvents(
   };
 }
 
-const getLink = (nodeType: INLINES, entity) => {
-  if (nodeType === INLINES.EMBEDDED_RESOURCE) {
-    return {
-      urn: entity.sys.urn,
-      type: 'ResourceLink',
-      linkType: 'Contentful:Entry',
-    };
-  }
-  return {
-    id: entity.sys.id,
-    type: 'Link',
-    linkType: entity.sys.type,
-  };
-};
-
 const createInlineEntryNode = (nodeType, entity) => {
   return {
     type: nodeType,
     children: [{ text: '' }],
     data: {
       target: {
-        sys: getLink(nodeType, entity),
+        sys: {
+          id: entity.sys.id,
+          type: 'Link',
+          linkType: entity.sys.type,
+        },
       },
+    },
+  };
+};
+
+const createInlineResourceEntryNode = (nodeType, entityLink) => {
+  return {
+    type: nodeType,
+    children: [{ text: '' }],
+    data: {
+      target: entityLink,
     },
   };
 };
@@ -105,15 +104,15 @@ export async function selectResourceEntityAndInsert(
   };
 
   const { selection } = editor;
-  const entry = await dialogs.selectSingleResourceEntry(config);
+  const entryLink = await dialogs.selectSingleResourceEntity(config);
 
-  if (!entry) {
+  if (!entryLink) {
     logAction('cancelCreateEmbedDialog', { nodeType });
   } else {
     // Selection prevents incorrect position of inserted ref when RTE doesn't have focus
     // (i.e. when using hotkeys and slide-in)
     select(editor, selection);
-    insertNodes(editor, createInlineEntryNode(nodeType, entry));
+    insertNodes(editor, createInlineResourceEntryNode(nodeType, entryLink));
     logAction('insert', { nodeType });
   }
 }

--- a/packages/rich-text/src/plugins/shared/EmbeddedInlineUtil.ts
+++ b/packages/rich-text/src/plugins/shared/EmbeddedInlineUtil.ts
@@ -32,28 +32,22 @@ export function getWithEmbeddedEntryInlineEvents(
   };
 }
 
+const getLink = (entity) => {
+  return {
+    sys: {
+      id: entity.sys.id,
+      type: 'Link',
+      linkType: entity.sys.type,
+    },
+  };
+};
+
 const createInlineEntryNode = (nodeType, entity) => {
   return {
     type: nodeType,
     children: [{ text: '' }],
     data: {
-      target: {
-        sys: {
-          id: entity.sys.id,
-          type: 'Link',
-          linkType: entity.sys.type,
-        },
-      },
-    },
-  };
-};
-
-const createInlineResourceEntryNode = (nodeType, entityLink) => {
-  return {
-    type: nodeType,
-    children: [{ text: '' }],
-    data: {
-      target: entityLink,
+      target: nodeType === INLINES.EMBEDDED_RESOURCE ? entity : getLink(entity),
     },
   };
 };
@@ -112,7 +106,7 @@ export async function selectResourceEntityAndInsert(
     // Selection prevents incorrect position of inserted ref when RTE doesn't have focus
     // (i.e. when using hotkeys and slide-in)
     select(editor, selection);
-    insertNodes(editor, createInlineResourceEntryNode(nodeType, entryLink));
+    insertNodes(editor, createInlineEntryNode(nodeType, entryLink));
     logAction('insert', { nodeType });
   }
 }

--- a/packages/rich-text/stories/RichTextEditor.stories.tsx
+++ b/packages/rich-text/stories/RichTextEditor.stories.tsx
@@ -73,24 +73,40 @@ const DemoRichTextEditor = () => {
     //@ts-expect-error
     if (window.parent.Cypress) {
       return window.localStorage.getItem('shouldConfirm') === 'true'
+        ? fnName === 'selectSingleResourceEntity'
+          ? {
+              sys: {
+                type: 'ResourceLink',
+                linkType: 'Contentful:Entry',
+                urn: 'crn:contentful:::content:spaces/space-id/entries/example-entity-urn',
+              },
+            }
+          : {
+              sys: {
+                id: 'example-entity-id',
+                urn: 'crn:contentful:::content:spaces/space-id/entries/example-entity-urn',
+                type,
+              },
+            }
+        : null;
+    }
+
+    return confirm(`sdk.dialogs.${fnName}()\nSimulate selecting a random entity or cancel?`)
+      ? fnName === 'selectSingleResourceEntity'
         ? {
+            sys: {
+              type: 'ResourceLink',
+              linkType: 'Contentful:Entry',
+              urn: 'crn:contentful:::content:spaces/space-id/entries/example-entity-urn',
+            },
+          }
+        : {
             sys: {
               id: 'example-entity-id',
               urn: 'crn:contentful:::content:spaces/space-id/entries/example-entity-urn',
               type,
             },
           }
-        : null;
-    }
-
-    return confirm(`sdk.dialogs.${fnName}()\nSimulate selecting a random entity or cancel?`)
-      ? {
-          sys: {
-            id: 'example-entity-id',
-            urn: 'crn:contentful:::content:spaces/space-id/entries/example-entity-urn',
-            type,
-          },
-        }
       : null; // Simulate cancellation.
   };
 
@@ -167,8 +183,8 @@ const DemoRichTextEditor = () => {
     dialogs: {
       selectSingleAsset: newEntitySelectorDummyDialog('selectSingleAsset', 'Asset'),
       selectSingleEntry: newEntitySelectorDummyDialog('selectSingleEntry', 'Entry'),
-      selectSingleResourceEntry: newEntitySelectorDummyDialog(
-        'selectSingleResourceEntry',
+      selectSingleResourceEntity: newEntitySelectorDummyDialog(
+        'selectSingleResourceEntity',
         'Contentful:Entry'
       ),
     },


### PR DESCRIPTION
Update _reference_ and _rich text_ field editors to use the new cross-space entity picker functions (`selectSingleResourceEntity` and `selectMultipleResourceEntities`). The new functions return resource links which means we no longer have to convert entries to links in the field editors and this PR is mostly clean up. 