### PR TITLE
fix: update status badge for scheduled entry [TOL-1801]

### DIFF
--- a/packages/reference/src/entries/WrappedEntryCard/WrappedEntryCard.tsx
+++ b/packages/reference/src/entries/WrappedEntryCard/WrappedEntryCard.tsx
@@ -1,23 +1,14 @@
 import * as React from 'react';
 
 import { SpaceAPI } from '@contentful/app-sdk';
-import { EntryCard, MenuItem, MenuDivider } from '@contentful/f36-components';
-import { ClockIcon } from '@contentful/f36-icons';
-import tokens from '@contentful/f36-tokens';
+import { EntityStatusBadge, EntryCard, MenuDivider, MenuItem } from '@contentful/f36-components';
 import { entityHelpers, isValidImage } from '@contentful/field-editor-shared';
-import { css } from 'emotion';
 
 import { AssetThumbnail, MissingEntityCard, ScheduledIconWithTooltip } from '../../components';
 import { SpaceName } from '../../components/SpaceName/SpaceName';
 import { ContentType, Entry, File, RenderDragFn } from '../../types';
 
 const { getEntryTitle, getEntityDescription, getEntryStatus, getEntryImage } = entityHelpers;
-
-const styles = {
-  scheduleIcon: css({
-    marginRight: tokens.spacing2Xs,
-  }),
-};
 
 export interface WrappedEntryCardProps {
   getEntityScheduledActions: SpaceAPI['getEntityScheduledActions'];
@@ -110,8 +101,8 @@ export function WrappedEntryCard(props: WrappedEntryCardProps) {
       description={description}
       contentType={contentType?.name}
       size={props.size}
-      isSelected={props.isSelected}
       status={status}
+      isSelected={props.isSelected}
       icon={
         props.spaceName ? (
           <SpaceName
@@ -124,12 +115,7 @@ export function WrappedEntryCard(props: WrappedEntryCardProps) {
             entityType="Entry"
             entityId={props.entry.sys.id}
           >
-            <ClockIcon
-              className={styles.scheduleIcon}
-              size="small"
-              variant="muted"
-              testId="schedule-icon"
-            />
+            <EntityStatusBadge entityStatus={status} isScheduled />
           </ScheduledIconWithTooltip>
         )
       }


### PR DESCRIPTION
## Problem
we had a bug where the status of a scheduled entry looked different in the reference editor compared to the list view

## Bug screenshot
This is what it looked liked before the change
![image-20240202-090747](https://github.com/contentful/field-editors/assets/5754661/fbb23cef-8682-4bd8-9cf1-81cf0199a836)


## Fix screenshot
This is what it looks like now
<img width="1168" alt="Screenshot 2024-02-23 at 14 47 10" src="https://github.com/contentful/field-editors/assets/5754661/c9a3883f-ed1e-4f2e-ac32-c00f41b52653">
