### PR TITLE
chore: revert "fix: update status badge for scheduled entry (#1615)" [TOL-1801]

### DIFF
--- a/packages/reference/src/entries/WrappedEntryCard/WrappedEntryCard.tsx
+++ b/packages/reference/src/entries/WrappedEntryCard/WrappedEntryCard.tsx
@@ -1,14 +1,23 @@
 import * as React from 'react';
 
 import { SpaceAPI } from '@contentful/app-sdk';
-import { EntityStatusBadge, EntryCard, MenuDivider, MenuItem } from '@contentful/f36-components';
+import { EntryCard, MenuItem, MenuDivider } from '@contentful/f36-components';
+import { ClockIcon } from '@contentful/f36-icons';
+import tokens from '@contentful/f36-tokens';
 import { entityHelpers, isValidImage } from '@contentful/field-editor-shared';
+import { css } from 'emotion';
 
 import { AssetThumbnail, MissingEntityCard, ScheduledIconWithTooltip } from '../../components';
 import { SpaceName } from '../../components/SpaceName/SpaceName';
 import { ContentType, Entry, File, RenderDragFn } from '../../types';
 
 const { getEntryTitle, getEntityDescription, getEntryStatus, getEntryImage } = entityHelpers;
+
+const styles = {
+  scheduleIcon: css({
+    marginRight: tokens.spacing2Xs,
+  }),
+};
 
 export interface WrappedEntryCardProps {
   getEntityScheduledActions: SpaceAPI['getEntityScheduledActions'];
@@ -101,8 +110,8 @@ export function WrappedEntryCard(props: WrappedEntryCardProps) {
       description={description}
       contentType={contentType?.name}
       size={props.size}
-      status={status}
       isSelected={props.isSelected}
+      status={status}
       icon={
         props.spaceName ? (
           <SpaceName
@@ -115,7 +124,12 @@ export function WrappedEntryCard(props: WrappedEntryCardProps) {
             entityType="Entry"
             entityId={props.entry.sys.id}
           >
-            <EntityStatusBadge entityStatus={status} isScheduled />
+            <ClockIcon
+              className={styles.scheduleIcon}
+              size="small"
+              variant="muted"
+              testId="schedule-icon"
+            />
           </ScheduledIconWithTooltip>
         )
       }


### PR DESCRIPTION
This reverts commit b15911a7e4882d4c6f9765a3022f47b825ab7aab.

Implementing it this way results in a bug where we show 2 badges. We would need to first update the forma component for EntryCard in order for us to pass scheduled state as a prop then we have to get rid of the icon for scheduled status completely