### PR TITLE
fix: editor focus [ZEND-4737]

### DIFF
--- a/packages/rich-text/src/internal/hooks.ts
+++ b/packages/rich-text/src/internal/hooks.ts
@@ -16,7 +16,3 @@ export const usePlateEditorState = (id?: string) => {
 export const usePlateSelectors = (id?: string) => {
   return p.usePlateSelectors(id);
 };
-
-export const useFocused = () => {
-  return sr.useFocused();
-};

--- a/packages/rich-text/src/plugins/Hyperlink/components/EntityHyperlink.tsx
+++ b/packages/rich-text/src/plugins/Hyperlink/components/EntityHyperlink.tsx
@@ -30,7 +30,9 @@ export type HyperlinkElementProps = {
 };
 
 export function EntityHyperlink(props: HyperlinkElementProps) {
-  const { editor, sdk, isLinkFocused, pathToElement } = useHyperlinkCommon(props.element);
+  const { editor, sdk, isLinkFocused, pathToElement, isEditorFocused } = useHyperlinkCommon(
+    props.element
+  );
   const { onEntityFetchComplete } = useLinkTracking();
   const { target } = props.element.data;
 
@@ -56,6 +58,7 @@ export function EntityHyperlink(props: HyperlinkElementProps) {
       handleEditLink={() => handleEditLink(editor, sdk, pathToElement)}
       handleRemoveLink={() => handleRemoveLink(editor)}
       popoverText={popoverText}
+      isEditorFocused={isEditorFocused}
     >
       <Text
         testId="cf-ui-text-link"

--- a/packages/rich-text/src/plugins/Hyperlink/components/LinkPopover.tsx
+++ b/packages/rich-text/src/plugins/Hyperlink/components/LinkPopover.tsx
@@ -3,7 +3,6 @@ import * as React from 'react';
 import { Popover, IconButton, Tooltip, Flex } from '@contentful/f36-components';
 import { EditIcon, CopyIcon } from '@contentful/f36-icons';
 
-import { useFocused } from '../../../internal/hooks';
 import { styles } from './styles';
 
 type LinkPopoverProps = {
@@ -13,6 +12,7 @@ type LinkPopoverProps = {
   handleRemoveLink: () => void;
   children: React.ReactNode;
   handleCopyLink?: () => void;
+  isEditorFocused: boolean;
 };
 
 export const LinkPopover = ({
@@ -22,8 +22,8 @@ export const LinkPopover = ({
   handleRemoveLink,
   children,
   handleCopyLink,
+  isEditorFocused,
 }: LinkPopoverProps) => {
-  const isEditorFocused = useFocused();
   const popoverContent = React.useRef<HTMLDivElement | null>(null);
   const [isPopoverContentClicked, setIsPopoverContentClicked] = React.useState(false);
 

--- a/packages/rich-text/src/plugins/Hyperlink/components/ResourceHyperlink.tsx
+++ b/packages/rich-text/src/plugins/Hyperlink/components/ResourceHyperlink.tsx
@@ -29,7 +29,9 @@ export type ResourceHyperlinkProps = {
 };
 
 export function ResourceHyperlink(props: ResourceHyperlinkProps) {
-  const { editor, sdk, isLinkFocused, pathToElement } = useHyperlinkCommon(props.element);
+  const { editor, sdk, isLinkFocused, pathToElement, isEditorFocused } = useHyperlinkCommon(
+    props.element
+  );
   const { onEntityFetchComplete } = useLinkTracking();
   const { target } = props.element.data;
 
@@ -51,6 +53,7 @@ export function ResourceHyperlink(props: ResourceHyperlinkProps) {
       handleEditLink={() => handleEditLink(editor, sdk, pathToElement)}
       handleRemoveLink={() => handleRemoveLink(editor)}
       popoverText={popoverText}
+      isEditorFocused={isEditorFocused}
     >
       <Text
         testId="cf-ui-text-link"

--- a/packages/rich-text/src/plugins/Hyperlink/components/UrlHyperlink.tsx
+++ b/packages/rich-text/src/plugins/Hyperlink/components/UrlHyperlink.tsx
@@ -28,7 +28,9 @@ type UrlHyperlinkProps = {
 };
 
 export function UrlHyperlink(props: UrlHyperlinkProps) {
-  const { editor, sdk, isLinkFocused, pathToElement } = useHyperlinkCommon(props.element);
+  const { editor, sdk, isLinkFocused, pathToElement, isEditorFocused } = useHyperlinkCommon(
+    props.element
+  );
   const uri = props.element.data?.uri;
 
   const popoverText = (
@@ -44,6 +46,7 @@ export function UrlHyperlink(props: UrlHyperlinkProps) {
       handleRemoveLink={() => handleRemoveLink(editor)}
       handleCopyLink={() => handleCopyLink(uri)}
       popoverText={popoverText}
+      isEditorFocused={isEditorFocused}
     >
       <TextLink
         testId="cf-ui-text-link"

--- a/packages/rich-text/src/plugins/Hyperlink/components/useHyperlinkCommon.tsx
+++ b/packages/rich-text/src/plugins/Hyperlink/components/useHyperlinkCommon.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useState } from 'react';
+
 import { FieldAppSDK } from '@contentful/app-sdk';
 
 import { useContentfulEditor } from '../../../ContentfulEditorProvider';
@@ -10,6 +12,29 @@ export function useHyperlinkCommon(element) {
   const focus = editor.selection?.focus;
   const pathToElement = findNodePath(editor, element);
   const isLinkFocused = pathToElement && focus && isChildPath(focus.path, pathToElement);
+  const [isEditorFocused, setIsEditorFocused] = useState(false);
 
-  return { editor, sdk, isLinkFocused, pathToElement };
+  useEffect(() => {
+    const handleFocus = () => setIsEditorFocused(true);
+    const handleBlur = () => setIsEditorFocused(false);
+
+    const editorElement = document.getElementById(editor.id);
+
+    if (editorElement) {
+      // Initially check if the editor is focused
+      setIsEditorFocused(document.activeElement === editorElement);
+
+      editorElement.addEventListener('focus', handleFocus);
+      editorElement.addEventListener('blur', handleBlur);
+    }
+
+    return () => {
+      if (editorElement) {
+        editorElement.removeEventListener('focus', handleFocus);
+        editorElement.removeEventListener('blur', handleBlur);
+      }
+    };
+  }, [editor]);
+
+  return { editor, sdk, isLinkFocused, pathToElement, isEditorFocused };
 }


### PR DESCRIPTION
For some unknown reason (probably an internal slate bug), the provided `useFocused();` from slate-react is always false.
Instead of relying on this hook to determine if the editor is in focus, we check it ourselves.
I removed the hook for now since we only used it for the hyperlink modal