### PR TITLE
feat: support external resources in resource links

### DIFF
--- a/packages/reference/src/__fixtures__/resource-type/resource-type.json
+++ b/packages/reference/src/__fixtures__/resource-type/resource-type.json
@@ -1,0 +1,14 @@
+{
+  "sys": {
+    "type": "ResourceType",
+    "id": "External:ResourceType",
+    "resourceProvider": {
+      "sys": {
+        "type": "Link",
+        "linkType": "ResourceProvider",
+        "id": "Resource Provider"
+      }
+    }
+  },
+  "name": "Resource Type"
+}

--- a/packages/reference/src/__fixtures__/resource/resource.json
+++ b/packages/reference/src/__fixtures__/resource/resource.json
@@ -1,0 +1,23 @@
+{
+  "fields": {
+    "title": "External Resource"
+  },
+  "sys": {
+    "type": "Resource",
+    "id": "external:entity-urn",
+    "resourceProvider": {
+      "sys": {
+        "id": "External Provider",
+        "type": "Link",
+        "linkType": "ResourceProvider"
+      }
+    },
+    "resourceType": {
+      "sys": {
+        "id": "External:ResourceType",
+        "type": "Link",
+        "linkType": "ResourceType"
+      }
+    }
+  }
+}

--- a/packages/reference/src/common/EntityStore.tsx
+++ b/packages/reference/src/common/EntityStore.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 
-import { BaseAppSDK } from '@contentful/app-sdk';
+import { BaseAppSDK, CollectionResponse } from '@contentful/app-sdk';
 import { FetchQueryOptions, Query, QueryKey } from '@tanstack/react-query';
 import constate from 'constate';
 import { PlainClientAPI, createClient } from 'contentful-management';
@@ -10,6 +10,7 @@ import {
   Asset,
   ContentType,
   Entry,
+  ExternalResource,
   Resource,
   ResourceType,
   ScheduledAction,
@@ -17,12 +18,24 @@ import {
 } from '../types';
 import { SharedQueryClientProvider, useQuery, useQueryClient } from './queryClient';
 
-export type ResourceInfo<R extends Resource = Resource> = {
-  resource: R;
+export type ContentfulResourceInfo = {
+  resource: Entry;
   defaultLocaleCode: string;
   contentType: ContentType;
   space: Space;
 };
+export type ExternalResourceInfo = {
+  resource: ExternalResource;
+  resourceType: ResourceType;
+};
+
+export type ResourceInfo<R extends Resource = Resource> = R extends Entry
+  ? ContentfulResourceInfo
+  : ExternalResourceInfo;
+
+export function isContentfulResourceInfo(info: ResourceInfo): info is ContentfulResourceInfo {
+  return info.resource.sys.type === 'Entry';
+}
 
 // global queue for all requests, the actual number is picked without scientific research
 const globalQueue = new PQueue({ concurrency: 50 });
@@ -47,7 +60,7 @@ type UseEntityOptions = GetEntityOptions & { enabled?: boolean };
 
 type QueryEntityResult<E> = Promise<E>;
 
-type GetResourceOptions = GetOptions;
+type GetResourceOptions = GetOptions & { allowExternal?: boolean };
 
 type QueryResourceResult<R extends Resource = Resource> = QueryEntityResult<ResourceInfo<R>>;
 
@@ -103,10 +116,13 @@ const isEntityQueryKey = (queryKey: QueryKey): queryKey is EntityQueryKey => {
   );
 };
 
-type ResourceQueryKey = [ident: 'Resource', resourceType: ResourceType, urn: string];
+type ResourceQueryKey = [ident: 'Resource', resourceType: string, urn: string];
 
-async function fetchContentfulEntry(params: FetchParams): Promise<ResourceInfo<Entry>> {
-  const { urn, fetch, options } = params;
+async function fetchContentfulEntry({
+  urn,
+  fetch,
+  options,
+}: FetchParams): Promise<ResourceInfo<Entry>> {
   // TODO use resource-names package EntryResourceName `fromString` method instead when the package becomes public
   const resourceId = urn.split(':', 6)[5];
   const ENTITY_RESOURCE_ID_REGEX =
@@ -164,6 +180,53 @@ async function fetchContentfulEntry(params: FetchParams): Promise<ResourceInfo<E
     resource: entry,
     space: space,
     contentType: contentType,
+  };
+}
+
+async function fetchExternalResource({
+  urn,
+  fetch,
+  options,
+  spaceId,
+  environmentId,
+  resourceType,
+}: FetchParams & { spaceId: string; environmentId: string; resourceType: string }): Promise<
+  ResourceInfo<ExternalResource>
+> {
+  const [resource, resourceTypes] = await Promise.all([
+    fetch(
+      ['resource', spaceId, environmentId, resourceType, urn],
+      ({ cmaClient }): Promise<ExternalResource | null> =>
+        cmaClient.raw
+          .get<CollectionResponse<ExternalResource>>(
+            `/spaces/${spaceId}/environments/${environmentId}/resource_types/${resourceType}/resources`,
+            { params: { 'sys.urn[in]': urn } }
+          )
+          .then(({ items }) => items[0] ?? null),
+      options
+    ),
+    fetch(['resource-types', spaceId, environmentId], ({ cmaClient }) =>
+      cmaClient.raw
+        .get<CollectionResponse<ResourceType>>(
+          `/spaces/${spaceId}/environments/${environmentId}/resource_types`
+        )
+        .then(({ items }) => items)
+    ),
+  ]);
+
+  const resourceTypeEntity = resourceTypes.find((rt) => rt.sys.id === resourceType);
+
+  if (!resourceTypeEntity) {
+    throw new UnsupportedError('Unsupported resource type');
+  }
+
+  if (!resource) {
+    throw new Error('Missing resource');
+  }
+
+  return {
+    resource,
+    resourceType: resourceTypeEntity,
   };
 }
 
@@ -295,14 +358,14 @@ const [InternalServiceProvider, useFetch, useEntityLoader, useCurrentIds] = cons
 
     const getResource = useCallback(
       function getResource<R extends Resource = Resource>(
-        resourceType: ResourceType,
+        resourceType: string,
         urn: string,
         options?: GetResourceOptions
       ): QueryResourceResult<R> {
         const queryKey: ResourceQueryKey = ['Resource', resourceType, urn];
         return fetch(
           queryKey,
-          () => {
+          (): Promise<ResourceInfo> => {
             if (resourceType === 'Contentful:Entry') {
               return fetchContentfulEntry({
                 fetch,
@@ -311,12 +374,23 @@ const [InternalServiceProvider, useFetch, useEntityLoader, useCurrentIds] = cons
               });
             }
 
-            throw new UnsupportedError('Unsupported resource type');
+            if (!options?.allowExternal) {
+              throw new UnsupportedError('Unsupported resource type');
+            }
+
+            return fetchExternalResource({
+              fetch,
+              urn,
+              options,
+              resourceType,
+              spaceId: currentSpaceId,
+              environmentId: currentEnvironmentId,
+            });
           },
           options
         );
       },
-      [fetch]
+      [currentEnvironmentId, currentSpaceId, fetch]
     );
 
     const isSameSpaceEntityQueryKey = useCallback(
@@ -440,16 +514,21 @@ export function useEntity<E extends FetchableEntity>(
   return { status, data } as UseEntityResult<E>;
 }
 
-export function useResource(resourceType: ResourceType, urn: string, options?: UseResourceOptions) {
+export function useResource<R extends Resource = Resource>(
+  resourceType: string,
+  urn: string,
+  options?: UseResourceOptions
+) {
   const queryKey: ResourceQueryKey = ['Resource', resourceType, urn];
   const { getResource } = useEntityLoader();
   const { status, data, error } = useQuery(
     queryKey,
-    () => getResource(resourceType, urn, options),
+    () => getResource<R>(resourceType, urn, options),
     {
       enabled: options?.enabled,
     }
   );
+
   return { status, data, error };
 }
 

--- a/packages/reference/src/resources/ExternalResourceCard/ExternalResourceCard.tsx
+++ b/packages/reference/src/resources/ExternalResourceCard/ExternalResourceCard.tsx
@@ -2,35 +2,12 @@ import * as React from 'react';
 
 import { Badge, EntryCard, MenuItem, MenuDivider } from '@contentful/f36-components';
 
-import { RenderDragFn } from '../../types';
-type SysExternalResource<T extends string> = {
-  sys: { type: 'Link'; linkType: T; id: string };
-};
-
-interface ExternalResource {
-  sys: {
-    type: string;
-    id: string;
-    resourceProvider: SysExternalResource<'ResourceProvider'>;
-    resourceType: SysExternalResource<'ResourceType'>;
-  };
-  fields: {
-    title: string;
-    description?: string;
-    externalUrl?: string;
-    image?: {
-      url?: string;
-      description?: string;
-    };
-    additionalData: any;
-  };
-}
+import { ExternalResourceInfo } from '../../common/EntityStore';
+import { ExternalResource, RenderDragFn } from '../../types';
 
 export interface ExternalResourceCardProps {
-  entity: ExternalResource;
-  resourceType: string;
+  info: ExternalResourceInfo;
   isDisabled: boolean;
-  size: 'small' | 'default' | 'auto';
   isSelected?: boolean;
   onRemove?: () => void;
   onEdit?: () => void;
@@ -39,38 +16,23 @@ export interface ExternalResourceCardProps {
   isClickable?: boolean;
   onMoveTop?: () => void;
   onMoveBottom?: () => void;
-  hasCardEditActions: boolean;
+  hasCardEditActions?: boolean;
   hasCardMoveActions?: boolean;
   hasCardRemoveActions?: boolean;
 }
 
 const defaultProps = {
   isClickable: true,
-  hasCardEditActions: true,
   hasCardMoveActions: true,
   hasCardRemoveActions: true,
 };
 
-type ExternalEntityStatus = 'active' | 'archived' | 'suspended' | 'draft';
-type BadgeVariant = 'negative' | 'positive' | 'warning';
-
-const statusMap: { [key in ExternalEntityStatus]: BadgeVariant } = {
-  active: 'positive',
-  draft: 'warning',
-  archived: 'negative',
-  suspended: 'negative',
-};
-
-function ExternalEntityBadge(entityStatus: ExternalEntityStatus) {
-  const variant = statusMap[entityStatus];
-
-  return <Badge variant={variant}>{entityStatus}</Badge>;
+function ExternalEntityBadge(badge: ExternalResource['fields']['badge']) {
+  return badge ? <Badge variant={badge.variant}>{badge.label}</Badge> : null;
 }
 
 export function ExternalResourceCard({
-  entity,
-  resourceType,
-  size,
+  info,
   isClickable,
   onEdit,
   onRemove,
@@ -82,69 +44,62 @@ export function ExternalResourceCard({
   renderDragHandle,
   onClick,
 }: ExternalResourceCardProps) {
-  const status = entity.fields.additionalData.status;
-  const badge = status ? ExternalEntityBadge(status) : null;
+  const { resource: entity, resourceType } = info;
+  const badge = ExternalEntityBadge(entity.fields.badge);
   return (
     <EntryCard
       as={entity.fields.externalUrl ? 'a' : 'article'}
       href={entity.fields.externalUrl}
       title={entity.fields.title}
       description={entity.fields.description}
-      contentType={resourceType}
-      size={size}
+      contentType={resourceType.name}
+      size={'auto'}
       thumbnailElement={
-        entity.fields.image && entity.fields.image.url ? (
-          <img alt={entity.fields.image.description} src={entity.fields.image.url} />
+        entity.fields.image?.url ? (
+          <img alt={entity.fields.image.altText} src={entity.fields.image.url} />
         ) : undefined
       }
       dragHandleRender={renderDragHandle}
       withDragHandle={!!renderDragHandle}
       badge={badge}
-      actions={
-        onEdit || onRemove
-          ? [
-              hasCardEditActions && onEdit ? (
-                <MenuItem
-                  key="edit"
-                  testId="edit"
-                  onClick={() => {
-                    onEdit && onEdit();
-                  }}
-                >
-                  Edit
-                </MenuItem>
-              ) : null,
-              hasCardRemoveActions && onRemove ? (
-                <MenuItem
-                  key="delete"
-                  testId="delete"
-                  onClick={() => {
-                    onRemove && onRemove();
-                  }}
-                >
-                  Remove
-                </MenuItem>
-              ) : null,
-              hasCardMoveActions && (onMoveTop || onMoveBottom) ? (
-                <MenuDivider key="divider" />
-              ) : null,
-              hasCardMoveActions && onMoveTop ? (
-                <MenuItem key="move-top" onClick={() => onMoveTop && onMoveTop()} testId="move-top">
-                  Move to top
-                </MenuItem>
-              ) : null,
-              hasCardMoveActions && onMoveBottom ? (
-                <MenuItem
-                  key="move-bottom"
-                  onClick={() => onMoveBottom && onMoveBottom()}
-                  testId="move-bottom"
-                >
-                  Move to bottom
-                </MenuItem>
-              ) : null,
-            ].filter((item) => item)
-          : []
-      }
+      actions={[
+        hasCardEditActions && onEdit ? (
+          <MenuItem
+            key="edit"
+            testId="edit"
+            onClick={() => {
+              onEdit && onEdit();
+            }}>
+            Edit
+          </MenuItem>
+        ) : null,
+        hasCardRemoveActions && onRemove ? (
+          <MenuItem
+            key="delete"
+            testId="delete"
+            onClick={() => {
+              onRemove && onRemove();
+            }}>
+            Remove
+          </MenuItem>
+        ) : null,
+        hasCardMoveActions && (onEdit || onRemove) && (onMoveTop || onMoveBottom) ? (
+          <MenuDivider key="divider" />
+        ) : null,
+        hasCardMoveActions && onMoveTop ? (
+          <MenuItem key="move-top" onClick={() => onMoveTop && onMoveTop()} testId="move-top">
+            Move to top
+          </MenuItem>
+        ) : null,
+        hasCardMoveActions && onMoveBottom ? (
+          <MenuItem
+            key="move-bottom"
+            onClick={() => onMoveBottom && onMoveBottom()}
+            testId="move-bottom">
+            Move to bottom
+          </MenuItem>
+        ) : null,
+      ].filter((item) => item)}
       onClick={
         isClickable
           ? (e: React.MouseEvent<HTMLElement>) => {

--- a/packages/reference/src/resources/MultipleResourceReferenceEditor.tsx
+++ b/packages/reference/src/resources/MultipleResourceReferenceEditor.tsx
@@ -17,9 +17,9 @@ import { ResourceCard } from './Cards/ResourceCard';
 import { useResourceLinkActions } from './useResourceLinkActions';
 
 type ChildProps = {
-  items: ResourceLink[];
+  items: ResourceLink<string>[];
   isDisabled: boolean;
-  setValue: (value: ResourceLink[]) => void;
+  setValue: (value: ResourceLink<string>[]) => void;
   onSortStart: (event: DragStartEvent) => void;
   onSortEnd: ({ oldIndex, newIndex }: { oldIndex: number; newIndex: number }) => void;
   onMove: (oldIndex: number, newIndex: number) => void;
@@ -121,7 +121,7 @@ function WithPerItemCallbacks({
   );
 }
 
-const EMPTY_ARRAY: ResourceLink[] = [];
+const EMPTY_ARRAY: ResourceLink<string>[] = [];
 
 export function MultipleResourceReferenceEditor(
   props: ReferenceEditorProps & {
@@ -131,12 +131,11 @@ export function MultipleResourceReferenceEditor(
 ) {
   return (
     <EntityProvider sdk={props.sdk}>
-      <FieldConnector<ResourceLink[]>
+      <FieldConnector<ResourceLink<string>[]>
         debounce={0}
         field={props.sdk.field}
         isInitiallyDisabled={props.isInitiallyDisabled}
-        isEqualValues={deepEqual}
-      >
+        isEqualValues={deepEqual}>
         {({ value, disabled, setValue, externalReset }) => {
           return (
             <ResourceEditor
@@ -145,18 +144,16 @@ export function MultipleResourceReferenceEditor(
               isDisabled={disabled}
               setValue={setValue}
               renderCustomActions={props.renderCustomActions}
-              key={`${externalReset}-list`}
-            >
+              key={`${externalReset}-list`}>
               {(editorProps) => (
-                <SortableLinkList<ResourceLink> {...editorProps}>
+                <SortableLinkList<ResourceLink<string>> {...editorProps}>
                   {({ item, isDisabled, DragHandle, index }) => (
                     <WithPerItemCallbacks
                       key={index}
                       index={index}
                       onMove={editorProps.onMove}
                       onRemoteItemAtIndex={editorProps.onRemoteItemAtIndex}
-                      listLength={value?.length || 0}
-                    >
+                      listLength={value?.length || 0}>
                       {({ onMoveBottom, onMoveTop, onRemove }) => (
                         <ResourceCard
                           key={index}

--- a/packages/reference/src/resources/SingleResourceReferenceEditor.tsx
+++ b/packages/reference/src/resources/SingleResourceReferenceEditor.tsx
@@ -26,12 +26,11 @@ export function SingleResourceReferenceEditor(
 
   return (
     <EntityProvider sdk={props.sdk}>
-      <FieldConnector<ResourceLink>
+      <FieldConnector<ResourceLink<string>>
         debounce={0}
         field={props.sdk.field}
         isInitiallyDisabled={props.isInitiallyDisabled}
-        isEqualValues={deepEqual}
-      >
+        isEqualValues={deepEqual}>
         {({ value, disabled }) => {
           return value ? (
             <ResourceCard

--- a/packages/reference/src/types.ts
+++ b/packages/reference/src/types.ts
@@ -11,7 +11,7 @@ export type {
   NavigatorSlideInfo,
   ScheduledAction,
 } from '@contentful/app-sdk';
-export type { SpaceProps as Space } from 'contentful-management';
+export type { SpaceProps as Space, ResourceLink } from 'contentful-management';
 
 export { Entry, File, Asset } from '@contentful/field-editor-shared';
 
@@ -25,17 +25,50 @@ export type AssetLink = { sys: { type: 'Link'; linkType: 'Asset'; id: string } }
 
 export type EntityLink = EntryLink | AssetLink;
 
-export type ResourceType = 'Contentful:Entry';
+type SysExternalResource<T extends string> = {
+  sys: { type: 'Link'; linkType: T; id: string };
+};
 
-export type Resource = Entry | Asset;
+export type ResourceType = {
+  sys: {
+    type: 'ResourceType';
+    id: string;
+    resourceProvider: SysExternalResource<'ResourceProvider'>;
+  };
+  name: string;
+};
 
-export type EntityType = 'Entry' | 'Asset' | ResourceType;
+export interface ExternalResource {
+  sys: {
+    type: 'Resource';
+    id: string;
+    resourceProvider: SysExternalResource<'ResourceProvider'>;
+    resourceType: SysExternalResource<'ResourceType'>;
+  };
+  fields: {
+    title: string;
+    subtitle?: string;
+    description?: string;
+    externalUrl?: string;
+    badge?: {
+      label: string;
+      variant: 'negative' | 'positive' | 'primary' | 'secondary' | 'warning';
+    };
+    image?: {
+      url: string;
+      altText?: string;
+    };
+  };
+}
+
+export type Resource = Entry | ExternalResource;
+
+export type EntityType = 'Entry' | 'Asset' | string;
 
 export type SysResourceLink<T extends string> = {
   sys: { type: 'ResourceLink'; linkType: T; urn: string };
 };
 export type ContentfulEntryLink = SysResourceLink<'Contentful:Entry'>;
-export type ResourceLink = ContentfulEntryLink;
 
 /**
  * @deprecated use `EntityLink` type

--- a/packages/reference/src/utils/useSortIDs.ts
+++ b/packages/reference/src/utils/useSortIDs.ts
@@ -4,7 +4,7 @@ import { arrayMove } from '@dnd-kit/sortable';
 
 import { ReferenceValue, ResourceLink } from '../types';
 
-type Items = (ResourceLink | ReferenceValue)[];
+type Items = (ResourceLink<string> | ReferenceValue)[];
 
 export const useSortIDs = (items: Items) => {
   const ids = (items || []).map((item, index) => {

--- a/packages/reference/stories/ExternalReferenceCard.stories.tsx
+++ b/packages/reference/stories/ExternalReferenceCard.stories.tsx
@@ -4,7 +4,7 @@ import { Flex } from '@contentful/f36-components';
 import { ActionsPlayground } from '@contentful/field-editor-test-utils';
 import type { Meta, StoryObj } from '@storybook/react';
 
-import { ExternalResourceCard } from '../src';
+import { ExternalResource, ExternalResourceCard, ResourceType } from '../src';
 import { newReferenceEditorFakeSdk } from '../src/__fixtures__/FakeSdk';
 
 const meta: Meta<typeof ExternalResourceCard> = {
@@ -16,7 +16,7 @@ export default meta;
 
 type Story = StoryObj<typeof ExternalResourceCard>;
 
-const activeEntity = {
+const resource: ExternalResource = {
   sys: {
     type: 'Resource',
     id: 'RandomId',
@@ -42,17 +42,17 @@ const activeEntity = {
     image: {
       url: 'https://picsum.photos/200/300 ',
     },
-    additionalData: {
-      sku: 123,
-      status: 'active',
+    badge: {
+      label: 'primary',
+      variant: 'primary',
     },
   },
 };
 
-const draftEntity = {
+const resourceType: ResourceType = {
   sys: {
-    type: 'Resource',
-    id: 'RandomId',
+    type: 'ResourceType',
+    id: 'Shopify:Product',
     resourceProvider: {
       sys: {
         id: 'Shopify',
@@ -60,94 +60,9 @@ const draftEntity = {
         linkType: 'ResourceProvider',
       },
     },
-    resourceType: {
-      sys: {
-        id: 'Shopify:ProductVariant',
-        type: 'Link',
-        linkType: 'ResourceType',
-      },
-    },
   },
-  fields: {
-    title: 'dress',
-    description: 'This is a nice dress',
-    externalUrl: 'https://shopify.com/dress123',
-    image: {
-      url: 'https://picsum.photos/200/300 ',
-    },
-    additionalData: {
-      sku: 123,
-      status: 'draft',
-    },
-  },
+  name: 'Shopify product',
 };
-
-const archivedEntity = {
-  sys: {
-    type: 'Resource',
-    id: 'RandomId',
-    resourceProvider: {
-      sys: {
-        id: 'Shopify',
-        type: 'Link',
-        linkType: 'ResourceProvider',
-      },
-    },
-    resourceType: {
-      sys: {
-        id: 'Shopify:Collection',
-        type: 'Link',
-        linkType: 'ResourceType',
-      },
-    },
-  },
-  fields: {
-    title: 'dress',
-    description: 'This is a nice dress',
-    externalUrl: 'https://shopify.com/dress123',
-    image: {
-      url: 'https://picsum.photos/200/300 ',
-    },
-    additionalData: {
-      sku: 123,
-      status: 'archived',
-    },
-  },
-};
-
-const suspendedEntity = {
-  sys: {
-    type: 'Resource',
-    id: 'RandomId',
-    resourceProvider: {
-      sys: {
-        id: 'Shopify',
-        type: 'Link',
-        linkType: 'ResourceProvider',
-      },
-    },
-    resourceType: {
-      sys: {
-        id: 'Shopify:Product',
-        type: 'Link',
-        linkType: 'ResourceType',
-      },
-    },
-  },
-  fields: {
-    title: 'dress',
-    description: 'This is a nice dress',
-    externalUrl: 'https://shopify.com/dress123',
-    image: {
-      url: 'https://picsum.photos/200/300 ',
-    },
-    additionalData: {
-      sku: 123,
-      status: 'suspended',
-    },
-  },
-};
-const resourceType = 'Shopify product';
 
 export const Default: Story = {
   parameters: {
@@ -158,12 +73,7 @@ export const Default: Story = {
     const mitt = newReferenceEditorFakeSdk()[1];
     return (
       <div>
-        <ExternalResourceCard
-          entity={activeEntity}
-          resourceType={resourceType}
-          isDisabled={isInitiallyDisabled}
-          size={'auto'}
-        />
+        <ExternalResourceCard info={{ resource, resourceType }} isDisabled={isInitiallyDisabled} />
         <ActionsPlayground mitt={mitt} />
       </div>
     );
@@ -180,8 +90,7 @@ export const WithEditActions: Story = {
     return (
       <div>
         <ExternalResourceCard
-          entity={activeEntity}
-          resourceType={resourceType}
+          info={{ resource, resourceType }}
           isDisabled={isInitiallyDisabled}
           onRemove={() => {
             console.log('Removed');
@@ -190,7 +99,6 @@ export const WithEditActions: Story = {
             console.log('edited');
           }}
           hasCardEditActions={true}
-          size={'auto'}
         />
         <ActionsPlayground mitt={mitt} />
       </div>
@@ -208,58 +116,26 @@ export const WithMultipleCardsHavingMultipleStatuses: Story = {
     return (
       <div>
         <Flex flexDirection="column" gap="spacingS">
-          <ExternalResourceCard
-            entity={activeEntity}
-            resourceType={resourceType}
-            isDisabled={isInitiallyDisabled}
-            onRemove={() => {
-              console.log('Removed');
-            }}
-            onEdit={() => {
-              console.log('edited');
-            }}
-            hasCardEditActions={true}
-            size={'auto'}
-          />
-          <ExternalResourceCard
-            entity={draftEntity}
-            resourceType={'Shopify product variant'}
-            isDisabled={isInitiallyDisabled}
-            onRemove={() => {
-              console.log('Removed');
-            }}
-            onEdit={() => {
-              console.log('edited');
-            }}
-            hasCardEditActions={true}
-            size={'auto'}
-          />
-          <ExternalResourceCard
-            entity={archivedEntity}
-            resourceType={'Shopify collection'}
-            isDisabled={isInitiallyDisabled}
-            onRemove={() => {
-              console.log('Removed');
-            }}
-            onEdit={() => {
-              console.log('edited');
-            }}
-            hasCardEditActions={true}
-            size={'auto'}
-          />
-          <ExternalResourceCard
-            entity={suspendedEntity}
-            resourceType={resourceType}
-            isDisabled={isInitiallyDisabled}
-            onRemove={() => {
-              console.log('Removed');
-            }}
-            onEdit={() => {
-              console.log('edited');
-            }}
-            hasCardEditActions={true}
-            size={'auto'}
-          />
+          {(['positive', 'negative', 'primary', 'secondary', 'warning'] as const).map((variant) => (
+            <ExternalResourceCard
+              key={variant}
+              info={{
+                resource: {
+                  ...resource,
+                  fields: { ...resource.fields, badge: { variant, label: variant } },
+                },
+                resourceType,
+              }}
+              isDisabled={isInitiallyDisabled}
+              onRemove={() => {
+                console.log('Removed');
+              }}
+              onEdit={() => {
+                console.log('edited');
+              }}
+              hasCardEditActions={true}
+            />
+          ))}
         </Flex>
         <ActionsPlayground mitt={mitt} />
       </div>

--- a/packages/rich-text/src/plugins/EmbeddedResourceInline/FetchingWrappedResourceInlineCard.tsx
+++ b/packages/rich-text/src/plugins/EmbeddedResourceInline/FetchingWrappedResourceInlineCard.tsx
@@ -12,7 +12,7 @@ import { truncateTitle } from '../../plugins/shared/utils';
 const { getEntryTitle, getEntryStatus } = entityHelpers;
 
 interface FetchingWrappedResourceInlineCardProps {
-  link: ResourceLink['sys'];
+  link: ResourceLink<'Contentful:Entry'>['sys'];
   sdk: FieldAppSDK;
   isSelected: boolean;
   isDisabled: boolean;
@@ -66,8 +66,7 @@ export function FetchingWrappedResourceInlineCard(props: FetchingWrappedResource
         <MenuItem key="remove" onClick={props.onRemove} disabled={props.isDisabled} testId="delete">
           Remove
         </MenuItem>,
-      ]}
-    >
+      ]}>
       <Text>{title}</Text>
     </InlineEntryCard>
   );

--- a/packages/rich-text/src/plugins/EmbeddedResourceInline/LinkedResourceInline.tsx
+++ b/packages/rich-text/src/plugins/EmbeddedResourceInline/LinkedResourceInline.tsx
@@ -13,7 +13,7 @@ import { FetchingWrappedResourceInlineCard } from './FetchingWrappedResourceInli
 export type LinkedResourceInlineProps = {
   element: Element & {
     data: {
-      target: ResourceLink;
+      target: ResourceLink<'Contentful:Entry'>;
     };
   };
   attributes: Pick<RenderElementProps, 'attributes'>;
@@ -48,8 +48,7 @@ export function LinkedResourceInline(props: LinkedResourceInlineProps) {
           onRemove={handleRemoveClick}
           onEntityFetchComplete={onEntityFetchComplete}
         />
-      }
-    >
+      }>
       {children}
     </LinkedInlineWrapper>
   );

--- a/packages/rich-text/src/plugins/Hyperlink/useResourceEntityInfo.ts
+++ b/packages/rich-text/src/plugins/Hyperlink/useResourceEntityInfo.ts
@@ -1,8 +1,7 @@
 import * as React from 'react';
 
-import { useResource } from '@contentful/field-editor-reference';
+import { Entry, useResource } from '@contentful/field-editor-reference';
 import { ResourceLink } from '@contentful/rich-text-types';
-
 import { truncateTitle } from '../../plugins/shared/utils';
 
 type ResourceEntityInfoProps = {
@@ -11,7 +10,7 @@ type ResourceEntityInfoProps = {
 };
 
 export function useResourceEntityInfo({ onEntityFetchComplete, target }: ResourceEntityInfoProps) {
-  const { data, error, status } = useResource(target.sys.linkType, target.sys.urn);
+  const { data, error, status } = useResource<Entry>(target.sys.linkType, target.sys.urn);
 
   React.useEffect(() => {
     if (status === 'success') {

--- a/packages/rich-text/src/plugins/shared/LinkedBlockWrapper.tsx
+++ b/packages/rich-text/src/plugins/shared/LinkedBlockWrapper.tsx
@@ -24,7 +24,7 @@ const styles = {
 type LinkedBlockWrapperProps = React.PropsWithChildren<{
   attributes: Pick<RenderElementProps, 'attributes'>;
   card: JSX.Element;
-  link: ResourceLink | EntityLink;
+  link: ResourceLink<'Contentful:Entry'> | EntityLink;
 }>;
 
 export function LinkedBlockWrapper({ attributes, card, children, link }: LinkedBlockWrapperProps) {
@@ -36,14 +36,12 @@ export function LinkedBlockWrapper({ attributes, card, children, link }: LinkedB
       data-entity-id={getLinkEntityId(link)}
       // COMPAT: This makes copy & paste work for Firefox
       contentEditable={IS_CHROME ? undefined : false}
-      draggable={IS_CHROME ? true : undefined}
-    >
+      draggable={IS_CHROME ? true : undefined}>
       <div
         // COMPAT: This makes copy & paste work for Chromium/Blink browsers and Safari
         contentEditable={IS_CHROME ? false : undefined}
         draggable={IS_CHROME ? true : undefined}
-        className={styles.container}
-      >
+        className={styles.container}>
         {card}
       </div>
       {children}

--- a/packages/rich-text/src/plugins/shared/LinkedInlineWrapper.tsx
+++ b/packages/rich-text/src/plugins/shared/LinkedInlineWrapper.tsx
@@ -26,7 +26,7 @@ const styles = {
 type LinkedInlineWrapperProps = React.PropsWithChildren<{
   attributes: Pick<RenderElementProps, 'attributes'>;
   card: JSX.Element;
-  link: ResourceLink | EntryLink;
+  link: ResourceLink<'Contentful:Entry'> | EntryLink;
 }>;
 
 export function LinkedInlineWrapper({
@@ -43,13 +43,11 @@ export function LinkedInlineWrapper({
       data-entity-id={getLinkEntityId(link)}
       // COMPAT: This makes copy & paste work for Firefox
       contentEditable={IS_CHROME ? undefined : false}
-      draggable={IS_CHROME ? true : undefined}
-    >
+      draggable={IS_CHROME ? true : undefined}>
       <span
         // COMPAT: This makes copy & paste work for Chromium/Blink browsers and Safari
         contentEditable={IS_CHROME ? false : undefined}
-        draggable={IS_CHROME ? true : undefined}
-      >
+        draggable={IS_CHROME ? true : undefined}>
         {card}
       </span>
       {children}

--- a/packages/rich-text/src/plugins/shared/utils.ts
+++ b/packages/rich-text/src/plugins/shared/utils.ts
@@ -1,9 +1,10 @@
 import { EntityLink, EntryLink, ResourceLink } from '@contentful/field-editor-reference';
 
-const isResourceLink = (link: EntityLink | EntryLink | ResourceLink): link is ResourceLink =>
-  !!(link as ResourceLink).sys.urn;
+const isResourceLink = (
+  link: EntityLink | EntryLink | ResourceLink<'Contentful:Entry'>
+): link is ResourceLink<'Contentful:Entry'> => !!(link as ResourceLink<'Contentful:Entry'>).sys.urn;
 
-export const getLinkEntityId = (link: EntityLink | ResourceLink): string =>
+export const getLinkEntityId = (link: EntityLink | ResourceLink<'Contentful:Entry'>): string =>
   isResourceLink(link) ? link.sys.urn : link.sys.id;
 
 export function truncateTitle(str: string, length: number) {


### PR DESCRIPTION
Add support for external resources to the reference field editor.

## Details
* The biggest change is fetching _resource_ and _resource type_ entities as we’re extending the existing resource link logic and have already introduced the external resource card component in https://github.com/contentful/field-editors/pull/1602.
* Rich text doesn’t support external reference yet so the support is explicitly disabled. The changes here are only due to updated types.