### PR TITLE
feat: add card subtitle and Provider ID to the external card [DANTE-1407]

### DIFF
--- a/packages/reference/src/__fixtures__/resource/resource.json
+++ b/packages/reference/src/__fixtures__/resource/resource.json
@@ -1,6 +1,7 @@
 {
   "fields": {
-    "title": "External Resource"
+    "title": "External Resource",
+    "subtitle": "Product ID: 123456789"
   },
   "sys": {
     "type": "Resource",

--- a/packages/reference/src/resources/Cards/ResourceCard.spec.tsx
+++ b/packages/reference/src/resources/Cards/ResourceCard.spec.tsx
@@ -190,6 +190,8 @@ describe('ResourceCard', () => {
 
     await waitFor(() => expect(getByTestId('cf-ui-entry-card')).toBeDefined());
     expect(getByText(resource.fields.title)).toBeDefined();
-    expect(getByText(resourceType.name)).toBeDefined();
+    expect(
+      getByText(`${resourceType.sys.resourceProvider.sys.id} ${resourceType.name}`)
+    ).toBeDefined();
   });
 });

--- a/packages/reference/src/resources/ExternalResourceCard/ExternalResourceCard.tsx
+++ b/packages/reference/src/resources/ExternalResourceCard/ExternalResourceCard.tsx
@@ -40,7 +40,6 @@ const defaultProps = {
 const styles = {
   subtitle: css({
     color: tokens.gray600,
-    marginBottom: 'none',
   }),
   description: css({
     color: tokens.gray900,
@@ -71,7 +70,7 @@ function ExternalResourceCardDescription({
     );
   }
 
-  const truncatedDescription = truncate(description, 500, {});
+  const truncatedDescription = truncate(description, 180, {});
 
   return (
     <>

--- a/packages/reference/src/resources/ExternalResourceCard/ExternalResourceCard.tsx
+++ b/packages/reference/src/resources/ExternalResourceCard/ExternalResourceCard.tsx
@@ -1,9 +1,20 @@
 import * as React from 'react';
 
-import { Badge, EntryCard, MenuItem, MenuDivider } from '@contentful/f36-components';
+import {
+  Badge,
+  EntryCard,
+  MenuItem,
+  MenuDivider,
+  Paragraph,
+  Caption,
+} from '@contentful/f36-components';
+import tokens from '@contentful/f36-tokens';
+import { css } from 'emotion';
+import truncate from 'truncate';
 
 import { ExternalResourceInfo } from '../../common/EntityStore';
 import { ExternalResource, RenderDragFn } from '../../types';
+
 
 export interface ExternalResourceCardProps {
   info: ExternalResourceInfo;
@@ -27,9 +38,54 @@ const defaultProps = {
   hasCardRemoveActions: true,
 };
 
+const styles = {
+  subtitle: css({
+    color: tokens.gray600,
+    marginBottom: 'none',
+  }),
+  description: css({
+    color: tokens.gray900,
+    marginBottom: 'none',
+    maxWidth: '642px',
+  }),
+};
+
 function ExternalEntityBadge(badge: ExternalResource['fields']['badge']) {
   return badge ? <Badge variant={badge.variant}>{badge.label}</Badge> : null;
 }
+
+function ExternalResourceCardDescription({
+  subtitle,
+  description,
+}: {
+  subtitle?: string;
+  description?: string;
+}) {
+  if (!subtitle) {
+    return null;
+  }
+
+  if (!description) {
+    return (
+      <Paragraph className={styles.description} isWordBreak>
+        {subtitle}
+      </Paragraph>
+    );
+  }
+
+  const truncatedDescription = truncate(description, 500, {});
+
+  return (
+    <>
+      <Caption className={styles.subtitle}>{subtitle}</Caption>
+      <Paragraph className={styles.description} isWordBreak>
+        {truncatedDescription}
+      </Paragraph>
+    </>
+  );
+}
+
+ExternalResourceCardDescription.displayName = 'ExternalResourceCardDescription';
 
 export function ExternalResourceCard({
   info,
@@ -51,8 +107,7 @@ export function ExternalResourceCard({
       as={entity.fields.externalUrl ? 'a' : 'article'}
       href={entity.fields.externalUrl}
       title={entity.fields.title}
-      description={entity.fields.description}
-      contentType={resourceType.name}
+      contentType={`${resourceType.sys.resourceProvider.sys.id} ${resourceType.name}`}
       size={'auto'}
       thumbnailElement={
         entity.fields.image?.url ? (
@@ -69,7 +124,8 @@ export function ExternalResourceCard({
             testId="edit"
             onClick={() => {
               onEdit && onEdit();
-            }}>
+            }}
+          >
             Edit
           </MenuItem>
         ) : null,
@@ -79,7 +135,8 @@ export function ExternalResourceCard({
             testId="delete"
             onClick={() => {
               onRemove && onRemove();
-            }}>
+            }}
+          >
             Remove
           </MenuItem>
         ) : null,
@@ -95,7 +152,8 @@ export function ExternalResourceCard({
           <MenuItem
             key="move-bottom"
             onClick={() => onMoveBottom && onMoveBottom()}
-            testId="move-bottom">
+            testId="move-bottom"
+          >
             Move to bottom
           </MenuItem>
         ) : null,
@@ -109,7 +167,12 @@ export function ExternalResourceCard({
             }
           : undefined
       }
-    />
+    >
+      <ExternalResourceCardDescription
+        subtitle={entity.fields.subtitle || `Product ID: ${entity.sys.id}`}
+        description={entity.fields.description}
+      />
+    </EntryCard>
   );
 }
 

--- a/packages/reference/src/resources/ExternalResourceCard/ExternalResourceCard.tsx
+++ b/packages/reference/src/resources/ExternalResourceCard/ExternalResourceCard.tsx
@@ -15,7 +15,6 @@ import truncate from 'truncate';
 import { ExternalResourceInfo } from '../../common/EntityStore';
 import { ExternalResource, RenderDragFn } from '../../types';
 
-
 export interface ExternalResourceCardProps {
   info: ExternalResourceInfo;
   isDisabled: boolean;
@@ -45,7 +44,6 @@ const styles = {
   }),
   description: css({
     color: tokens.gray900,
-    marginBottom: 'none',
     maxWidth: '642px',
   }),
 };
@@ -67,7 +65,7 @@ function ExternalResourceCardDescription({
 
   if (!description) {
     return (
-      <Paragraph className={styles.description} isWordBreak>
+      <Paragraph className={styles.description} marginBottom="none" isWordBreak>
         {subtitle}
       </Paragraph>
     );
@@ -78,7 +76,7 @@ function ExternalResourceCardDescription({
   return (
     <>
       <Caption className={styles.subtitle}>{subtitle}</Caption>
-      <Paragraph className={styles.description} isWordBreak>
+      <Paragraph className={styles.description} marginBottom="none" isWordBreak>
         {truncatedDescription}
       </Paragraph>
     </>
@@ -169,7 +167,7 @@ export function ExternalResourceCard({
       }
     >
       <ExternalResourceCardDescription
-        subtitle={entity.fields.subtitle || `Product ID: ${entity.sys.id}`}
+        subtitle={entity.fields.subtitle}
         description={entity.fields.description}
       />
     </EntryCard>

--- a/packages/reference/src/resources/ExternalResourceCard/ExternalResourceCard.tsx
+++ b/packages/reference/src/resources/ExternalResourceCard/ExternalResourceCard.tsx
@@ -43,7 +43,6 @@ const styles = {
   }),
   description: css({
     color: tokens.gray900,
-    maxWidth: '642px',
   }),
 };
 
@@ -70,7 +69,7 @@ function ExternalResourceCardDescription({
     );
   }
 
-  const truncatedDescription = truncate(description, 180, {});
+  const truncatedDescription = truncate(description, 95, {});
 
   return (
     <>

--- a/packages/reference/stories/ExternalReferenceCard.stories.tsx
+++ b/packages/reference/stories/ExternalReferenceCard.stories.tsx
@@ -37,7 +37,8 @@ const resource: ExternalResource = {
   },
   fields: {
     title: 'dress',
-    description: 'This is a nice dress',
+    description:
+      'Associate Editor at Popular Science where she explores intersections of technology and art and their impact on human psychology their impact on human psychology their impact on human p...',
     externalUrl: 'https://shopify.com/dress123',
     image: {
       url: 'https://picsum.photos/200/300 ',
@@ -61,7 +62,7 @@ const resourceType: ResourceType = {
       },
     },
   },
-  name: 'Shopify product',
+  name: 'Product',
 };
 
 export const Default: Story = {

--- a/packages/reference/stories/ExternalReferenceCard.stories.tsx
+++ b/packages/reference/stories/ExternalReferenceCard.stories.tsx
@@ -37,6 +37,7 @@ const resource: ExternalResource = {
   },
   fields: {
     title: 'dress',
+    subtitle: 'Product ID: 123456789',
     description:
       'Associate Editor at Popular Science where she explores intersections of technology and art and their impact on human psychology their impact on human psychology their impact on human p...',
     externalUrl: 'https://shopify.com/dress123',

--- a/packages/reference/stories/ExternalReferenceCard.stories.tsx
+++ b/packages/reference/stories/ExternalReferenceCard.stories.tsx
@@ -117,7 +117,7 @@ export const WithMultipleCardsHavingMultipleStatuses: Story = {
     const mitt = newReferenceEditorFakeSdk()[1];
     return (
       <div>
-        <Flex flexDirection="column" gap="spacingS">
+        <Flex flexDirection="column" gap="spacingS" style={{ width: '752px' }}>
           {(['positive', 'negative', 'primary', 'secondary', 'warning'] as const).map((variant) => (
             <ExternalResourceCard
               key={variant}


### PR DESCRIPTION
Before we have the ideal state for the product card we should be able to show some crucial information that doesn’t fit with the ideal card UI. 

In the title section of the card, we need to make sure to show the Provider name (in our case `Shopify`) before the Product type name (`Product`/`Product Variant`/`Collection`).

In the description section of the externalCard we should show the Product ID as a subtitle then show the description if there is any.


 