### PR TITLE
fix(rich-text): respect sdk.field.locale text direction in text nodes [ZEND-4773]

### DIFF
--- a/packages/rich-text/src/RichTextEditor.styles.ts
+++ b/packages/rich-text/src/RichTextEditor.styles.ts
@@ -52,4 +52,10 @@ export const styles = {
     background: tokens.gray100,
     cursor: 'not-allowed',
   }),
+  rtl: css({
+    direction: 'rtl',
+  }),
+  ltr: css({
+    direction: 'ltr',
+  }),
 };

--- a/packages/rich-text/src/RichTextEditor.tsx
+++ b/packages/rich-text/src/RichTextEditor.tsx
@@ -52,12 +52,16 @@ export const ConnectedRichTextEditor = (props: ConnectedProps) => {
     );
   }, [props.value, plugins]);
 
+  // Force text direction based on editor locale
+  const direction = sdk.locales.direction[sdk.field.locale] ?? 'ltr';
+
   const classNames = cx(
     styles.editor,
     props.minHeight !== undefined ? css({ minHeight: props.minHeight }) : undefined,
     props.maxHeight !== undefined ? css({ maxHeight: props.maxHeight }) : undefined,
     props.isDisabled ? styles.disabled : styles.enabled,
-    props.isToolbarHidden && styles.hiddenToolbar
+    props.isToolbarHidden && styles.hiddenToolbar,
+    direction === 'rtl' ? styles.rtl : styles.ltr
   );
 
   return (

--- a/packages/rich-text/src/plugins/Heading/components/Heading.tsx
+++ b/packages/rich-text/src/plugins/Heading/components/Heading.tsx
@@ -37,6 +37,7 @@ const styles = {
       font-weight: ${tokens.fontWeightMedium};
       line-height: 1.3;
       margin: 0 0 ${tokens.spacingS};
+      direction: inherit;
     `,
     [BLOCKS.HEADING_1]: css`
       font-size: 1.875rem;

--- a/packages/rich-text/src/plugins/Hyperlink/components/styles.ts
+++ b/packages/rich-text/src/plugins/Hyperlink/components/styles.ts
@@ -27,6 +27,7 @@ export const styles = {
   hyperlink: css({
     fontSize: 'inherit !important',
     display: 'inline !important',
+    direction: 'inherit',
     '&:hover': {
       fill: tokens.gray900,
       textDecoration: 'none',

--- a/packages/rich-text/src/plugins/List/components/List.tsx
+++ b/packages/rich-text/src/plugins/List/components/List.tsx
@@ -8,6 +8,7 @@ import * as Slate from 'slate-react';
 const baseStyle = css`
   padding: 0;
   margin: 0 0 1.25rem 1.25rem;
+  direction: inherit;
 
   div:first-child {
     margin: 0;

--- a/packages/rich-text/src/plugins/List/components/ListItem.tsx
+++ b/packages/rich-text/src/plugins/List/components/ListItem.tsx
@@ -8,6 +8,7 @@ const style = css`
   margin: 0;
   list-style: inherit;
   margin-top: ${tokens.spacingXs};
+  direction: inherit;
 
   ol,
   ul {

--- a/packages/rich-text/src/plugins/Paragraph/Paragraph.tsx
+++ b/packages/rich-text/src/plugins/Paragraph/Paragraph.tsx
@@ -10,6 +10,7 @@ const styles = {
   [BLOCKS.PARAGRAPH]: css`
     line-height: ${tokens.lineHeightDefault};
     margin-bottom: 1.5em;
+    direction: inherit;
   `,
 };
 


### PR DESCRIPTION
Slate detects text direction on a block level e.g. paragraph which is fine in most cases but its implementation is naive. For example, if you have an English word at the beginning of a paragraph written mostly in Arabic the whole paragraph would be marked as `ltr` instead of `rtl`. 

At Contentful, we don't need to guess the direction, we already have the locale information exposed in the Field SDK which is respected in other field editors e.g. SingleLineEditor. This brings some of that to RT but it's no where near complete. To fully support RTL we have to adjust the styling of some the elements e.g. blockquotes, tables ..etc.

This fixes the problem at hand and serves as a first step in the right direction.  