### PR TITLE
feat: enable isSelected option on the external resource cards [DANTE-1329]

### DIFF
--- a/packages/reference/src/resources/ExternalResourceCard/ExternalResourceCard.tsx
+++ b/packages/reference/src/resources/ExternalResourceCard/ExternalResourceCard.tsx
@@ -95,6 +95,7 @@ export function ExternalResourceCard({
   hasCardRemoveActions,
   renderDragHandle,
   onClick,
+  isSelected,
 }: ExternalResourceCardProps) {
   const { resource: entity, resourceType } = info;
   const badge = ExternalEntityBadge(entity.fields.badge);
@@ -113,6 +114,7 @@ export function ExternalResourceCard({
       dragHandleRender={renderDragHandle}
       withDragHandle={!!renderDragHandle}
       badge={badge}
+      isSelected={isSelected}
       actions={[
         hasCardEditActions && onEdit ? (
           <MenuItem

--- a/packages/reference/stories/ExternalReferenceCard.stories.tsx
+++ b/packages/reference/stories/ExternalReferenceCard.stories.tsx
@@ -108,6 +108,33 @@ export const WithEditActions: Story = {
   },
 };
 
+export const WithSelectedState: Story = {
+  parameters: {
+    controls: { hideNoControlsWarning: true },
+  },
+  render: () => {
+    const isInitiallyDisabled = !!window.localStorage.getItem('initialDisabled');
+    const mitt = newReferenceEditorFakeSdk()[1];
+    return (
+      <div>
+        <ExternalResourceCard
+          info={{ resource, resourceType }}
+          isDisabled={isInitiallyDisabled}
+          onRemove={() => {
+            console.log('Removed');
+          }}
+          onEdit={() => {
+            console.log('edited');
+          }}
+          hasCardEditActions={true}
+          isSelected={true}
+        />
+        <ActionsPlayground mitt={mitt} />
+      </div>
+    );
+  },
+};
+
 export const WithMultipleCardsHavingMultipleStatuses: Story = {
   parameters: {
     controls: { hideNoControlsWarning: true },


### PR DESCRIPTION
We want to enable selecting the external resource cards in the entity picker so we have to pass the `isSelected` option to the EntryCard.