### PR TITLE
fix: use filter by id instead of filter by urn in fetchExternalResource function [DANTE-1329]

### DIFF
--- a/packages/reference/src/common/EntityStore.tsx
+++ b/packages/reference/src/common/EntityStore.tsx
@@ -200,7 +200,7 @@ async function fetchExternalResource({
         cmaClient.raw
           .get<CollectionResponse<ExternalResource>>(
             `/spaces/${spaceId}/environments/${environmentId}/resource_types/${resourceType}/resources`,
-            { params: { 'sys.urn[in]': urn } }
+            { params: { 'sys.id[in]': urn } }
           )
           .then(({ items }) => items[0] ?? null),
       options

--- a/packages/reference/src/resources/Cards/ResourceCard.spec.tsx
+++ b/packages/reference/src/resources/Cards/ResourceCard.spec.tsx
@@ -66,7 +66,7 @@ const sdk: any = {
         if (
           url ===
             `/spaces/space-id/environments/environment-id/resource_types/${resolvableExternalResourceType}/resources` &&
-          config.params['sys.urn[in]'] === resolvableExternalEntityUrn
+          config.params['sys.id[in]'] === resolvableExternalEntityUrn
         ) {
           return Promise.resolve({ items: [resource] });
         }


### PR DESCRIPTION
The filter by urn is no longer valid on the backend for external resources so we need to change it to the filter that is working which is by id.