### PR TITLE
feat: update external resource entity format

### DIFF
--- a/packages/reference/src/types.ts
+++ b/packages/reference/src/types.ts
@@ -41,7 +41,7 @@ export type ResourceType = {
 export interface ExternalResource {
   sys: {
     type: 'Resource';
-    id: string;
+    urn: string;
     resourceProvider: SysExternalResource<'ResourceProvider'>;
     resourceType: SysExternalResource<'ResourceType'>;
   };


### PR DESCRIPTION
Going forward we will use `urn` instead of `id` in external resources. The property is not used anywhere yet so changing the type now won’t break anything.