### PR TITLE
fix: remove paragraph tracking [TOL-1865]

### DIFF
--- a/packages/rich-text/src/plugins/Heading/components/ToolbarHeadingButton.tsx
+++ b/packages/rich-text/src/plugins/Heading/components/ToolbarHeadingButton.tsx
@@ -123,8 +123,10 @@ export function ToolbarHeadingButton(props: ToolbarHeadingButtonProps) {
         prevOnChange(...args);
       };
 
-      const isActive = isBlockSelected(editor, type);
-      editor.tracking.onToolbarAction(isActive ? 'remove' : 'insert', { nodeType: type });
+      if (type !== BLOCKS.PARAGRAPH) {
+        const isActive = isBlockSelected(editor, type);
+        editor.tracking.onToolbarAction(isActive ? 'remove' : 'insert', { nodeType: type });
+      }
 
       toggleElement(editor, { activeType: type, inactiveType: type });
     };

--- a/packages/rich-text/src/plugins/Heading/createHeadingPlugin.ts
+++ b/packages/rich-text/src/plugins/Heading/createHeadingPlugin.ts
@@ -13,8 +13,10 @@ const buildHeadingEventHandler =
   (editor, { options: { hotkey } }) =>
   (event) => {
     if (editor.selection && hotkey && isHotkey(hotkey, event)) {
-      const isActive = isBlockSelected(editor, type);
-      editor.tracking.onShortcutAction(isActive ? 'remove' : 'insert', { nodeType: type });
+      if (type !== BLOCKS.PARAGRAPH) {
+        const isActive = isBlockSelected(editor, type);
+        editor.tracking.onShortcutAction(isActive ? 'remove' : 'insert', { nodeType: type });
+      }
 
       toggleElement(editor, { activeType: type, inactiveType: BLOCKS.PARAGRAPH });
     }


### PR DESCRIPTION
We fired tracking events (`removeParagraph` and `insertParagraph`) when the user uses the Toolbar Heading Menu to select or deselect the paragraph element.
However, in user_interface we filtered out these events in the `ALLOWED_EVENTS`, since we do not care about tracking this. This caused errors to show in Sentry.
Removing the tracking at the source will fix the issue :)