### PR TITLE
fix: passing failed to fetched entry card when inaccessible []

### DIFF
--- a/packages/reference/src/common/EntityStore.tsx
+++ b/packages/reference/src/common/EntityStore.tsx
@@ -511,7 +511,7 @@ export function useEntity<E extends FetchableEntity>(
   const { status, data } = useQuery(queryKey, () => getEntity(entityType, entityId, options), {
     enabled: options?.enabled,
   });
-  return { status, data } as UseEntityResult<E>;
+  return { status, data: status === 'error' ? 'failed' : data } as UseEntityResult<E>;
 }
 
 export function useResource<R extends Resource = Resource>(

--- a/packages/rich-text/src/plugins/shared/FetchingWrappedEntryCard.tsx
+++ b/packages/rich-text/src/plugins/shared/FetchingWrappedEntryCard.tsx
@@ -91,7 +91,7 @@ export const FetchingWrappedEntryCard = (props: FetchingWrappedEntryCardProps) =
 
   return (
     <InternalEntryCard
-      entry={status === 'error' ? 'failed' : entry}
+      entry={entry}
       sdk={props.sdk}
       locale={props.locale}
       isDisabled={props.isDisabled}

--- a/packages/rich-text/src/plugins/shared/FetchingWrappedEntryCard.tsx
+++ b/packages/rich-text/src/plugins/shared/FetchingWrappedEntryCard.tsx
@@ -91,7 +91,7 @@ export const FetchingWrappedEntryCard = (props: FetchingWrappedEntryCardProps) =
 
   return (
     <InternalEntryCard
-      entry={entry}
+      entry={status === 'error' ? 'failed' : entry}
       sdk={props.sdk}
       locale={props.locale}
       isDisabled={props.isDisabled}


### PR DESCRIPTION
Previously we were seeing an infinite loader when the entries are deleted. Now showing the missing entry card instead

**before**

<img width="620" alt="Screenshot 2024-04-16 at 14 59 56" src="https://github.com/contentful/field-editors/assets/109096340/be429697-a798-4a6a-bffc-f822c7e2d051">

**after**

<img width="709" alt="Screenshot 2024-04-16 at 15 00 06" src="https://github.com/contentful/field-editors/assets/109096340/9ca3a49d-b431-42ab-8634-482508f5203c">
