### PR TITLE
fix(richtext-editor): handle failed inline entries [ZEND-4919,ZEND-4913]

### DIFF
--- a/packages/reference/src/common/EntityStore.tsx
+++ b/packages/reference/src/common/EntityStore.tsx
@@ -73,6 +73,8 @@ type UseEntityResult<E> =
   | { status: 'error'; data: never }
   | { status: 'success'; data: E };
 
+export type UseEntityStatus = 'idle' | 'loading' | 'error' | 'success';
+
 type FetchFunction<TQueryData> = (context: { cmaClient: PlainClientAPI }) => Promise<TQueryData>;
 type FetchServiceOptions<
   TQueryFnData = unknown,
@@ -511,7 +513,7 @@ export function useEntity<E extends FetchableEntity>(
   const { status, data } = useQuery(queryKey, () => getEntity(entityType, entityId, options), {
     enabled: options?.enabled,
   });
-  return { status, data: status === 'error' ? 'failed' : data } as UseEntityResult<E>;
+  return { status, data } as UseEntityResult<E>;
 }
 
 export function useResource<R extends Resource = Resource>(

--- a/packages/reference/src/index.tsx
+++ b/packages/reference/src/index.tsx
@@ -24,7 +24,7 @@ export type {
 export { SortableLinkList } from './common/SortableLinkList';
 export { EntityProvider, useEntityLoader, useEntity, useResource } from './common/EntityStore';
 export { SharedQueryClientProvider as EntityCacheProvider } from './common/queryClient';
-export type { ResourceInfo } from './common/EntityStore';
+export type { ResourceInfo, UseEntityStatus } from './common/EntityStore';
 export {
   SingleResourceReferenceEditor,
   MultipleResourceReferenceEditor,

--- a/packages/rich-text/src/plugins/EmbeddedEntityInline/FetchingWrappedInlineEntryCard.tsx
+++ b/packages/rich-text/src/plugins/EmbeddedEntityInline/FetchingWrappedInlineEntryCard.tsx
@@ -39,12 +39,14 @@ export function FetchingWrappedInlineEntryCard(props: FetchingWrappedInlineEntry
   const allContentTypes = props.sdk.space.getCachedContentTypes();
   const { onEntityFetchComplete } = props;
   const contentType = React.useMemo(() => {
-    if (!entry || !allContentTypes) return undefined;
+    if (requestStatus !== 'success' || !entry || !allContentTypes) {
+      return undefined;
+    }
 
     return allContentTypes.find(
       (contentType) => contentType.sys.id === entry.sys.contentType.sys.id
     );
-  }, [allContentTypes, entry]);
+  }, [allContentTypes, entry, requestStatus]);
 
   React.useEffect(() => {
     if (requestStatus !== 'success') {
@@ -57,6 +59,7 @@ export function FetchingWrappedInlineEntryCard(props: FetchingWrappedInlineEntry
 
   const title = React.useMemo(
     () =>
+      requestStatus === 'success' &&
       getEntryTitle({
         entry,
         contentType,
@@ -64,7 +67,7 @@ export function FetchingWrappedInlineEntryCard(props: FetchingWrappedInlineEntry
         defaultLocaleCode: props.sdk.locales.default,
         defaultTitle: 'Untitled',
       }),
-    [entry, contentType, props.sdk.field.locale, props.sdk.locales.default]
+    [entry, requestStatus, contentType, props.sdk.field.locale, props.sdk.locales.default]
   );
 
   if (requestStatus === 'error') {

--- a/packages/rich-text/src/plugins/shared/FetchingWrappedAssetCard.tsx
+++ b/packages/rich-text/src/plugins/shared/FetchingWrappedAssetCard.tsx
@@ -7,11 +7,13 @@ import {
   useEntityLoader,
   MissingEntityCard,
   WrappedAssetCard,
+  type UseEntityStatus,
 } from '@contentful/field-editor-reference';
 import areEqual from 'fast-deep-equal';
 
 interface InternalAssetCardProps {
-  asset?: Asset | 'failed';
+  status: UseEntityStatus;
+  asset?: Asset;
   isDisabled: boolean;
   isSelected: boolean;
   locale: string;
@@ -22,11 +24,7 @@ interface InternalAssetCardProps {
 }
 
 const InternalAssetCard = React.memo((props: InternalAssetCardProps) => {
-  if (props.asset === undefined) {
-    return <AssetCard size="default" isLoading />;
-  }
-
-  if (props.asset === 'failed') {
+  if (props.status === 'error') {
     return (
       <MissingEntityCard
         isDisabled={props.isDisabled}
@@ -34,6 +32,10 @@ const InternalAssetCard = React.memo((props: InternalAssetCardProps) => {
         providerName="Contentful"
       />
     );
+  }
+
+  if (!props.asset) {
+    return <AssetCard size="default" isLoading />;
   }
 
   return (
@@ -83,6 +85,7 @@ export function FetchingWrappedAssetCard(props: FetchingWrappedAssetCardProps) {
   return (
     <InternalAssetCard
       asset={asset as Asset | undefined}
+      status={status}
       sdk={props.sdk}
       isDisabled={props.isDisabled}
       isSelected={props.isSelected}

--- a/packages/rich-text/src/plugins/shared/FetchingWrappedEntryCard.tsx
+++ b/packages/rich-text/src/plugins/shared/FetchingWrappedEntryCard.tsx
@@ -8,28 +8,26 @@ import {
   MissingEntityCard,
   WrappedEntryCard,
   useEntityLoader,
+  type UseEntityStatus,
 } from '@contentful/field-editor-reference';
 import areEqual from 'fast-deep-equal';
 
 interface InternalEntryCard {
+  status: UseEntityStatus;
   isDisabled: boolean;
   isSelected: boolean;
   locale: string;
   sdk: FieldAppSDK;
   loadEntityScheduledActions: (entityType: string, entityId: string) => Promise<ScheduledAction[]>;
-  entry?: Entry | 'failed';
+  entry?: Entry;
   onEdit?: VoidFunction;
   onRemove?: VoidFunction;
 }
 
 const InternalEntryCard = React.memo((props: InternalEntryCard) => {
-  const { entry, sdk, loadEntityScheduledActions } = props;
+  const { entry, sdk, loadEntityScheduledActions, status } = props;
 
-  if (entry === undefined) {
-    return <EntryCard isLoading />;
-  }
-
-  if (entry === 'failed') {
+  if (status === 'error') {
     return (
       <MissingEntityCard
         isDisabled={props.isDisabled}
@@ -37,6 +35,10 @@ const InternalEntryCard = React.memo((props: InternalEntryCard) => {
         providerName="Contentful"
       />
     );
+  }
+
+  if (entry === undefined) {
+    return <EntryCard isLoading />;
   }
 
   const contentType = sdk.space
@@ -91,6 +93,7 @@ export const FetchingWrappedEntryCard = (props: FetchingWrappedEntryCardProps) =
 
   return (
     <InternalEntryCard
+      status={status}
       entry={entry}
       sdk={props.sdk}
       locale={props.locale}


### PR DESCRIPTION
follow up on https://github.com/contentful/field-editors/pull/1639

Currently, the rich text editor fails as we try to read 'contentType' from 'failed'.sys.
Instead patching the entry to 'failed', it uses now the status to check for errors