### PR TITLE
fix: [] Consider text direction when positioning cell actions inside of Rich Text Editor

### DIFF
--- a/packages/rich-text/src/plugins/Table/components/TableActions.tsx
+++ b/packages/rich-text/src/plugins/Table/components/TableActions.tsx
@@ -19,8 +19,8 @@ import { isTableHeaderEnabled } from '../helpers';
 export const styles = {
   topRight: css({
     position: 'absolute',
-    top: '6px',
-    right: '5px',
+    insetBlockStart: '6px',
+    insetInlineEnd: '5px',
   }),
 };
 


### PR DESCRIPTION
With LTR text actions dropdown goes to the right:
![image](https://github.com/contentful/field-editors/assets/8289447/a0fae5ae-6611-4215-a940-3292a9351d93)

With RTL text actions dropdown goes to the left:
![image](https://github.com/contentful/field-editors/assets/8289447/81401bb8-c4bd-4f50-84ab-44740400f01c)
