### PR TITLE
fix: add the isDisabled check to MissingEntityCard

### DIFF
--- a/cypress/component/reference/SingleResourceReferenceEditor.spec.tsx
+++ b/cypress/component/reference/SingleResourceReferenceEditor.spec.tsx
@@ -92,6 +92,24 @@ describe('Single resource editor', () => {
     findMissingCards().should('have.length', 0);
   });
 
+  it('cannot remove missing cards when it is disabled', () => {
+    const sdk = createReferenceEditorTestSdk({
+      initialValue: asLink(fixtures.entries.invalid),
+    });
+    mount(
+      <SingleResourceReferenceEditor
+        {...commonProps}
+        isInitiallyDisabled={true}
+        viewType="card"
+        sdk={sdk}
+      />
+    );
+
+    findMissingCards().should('have.length', 1);
+
+    findMissingCards().first().get('#cf-ui-icon-button').should('not.exist');
+  });
+
   // TODO: Enable this test after navigation is moved into sdk.navigator
 
   // it.only('opens entry when clicking on it', () => {

--- a/packages/reference/src/components/MissingEntityCard/MissingEntityCard.tsx
+++ b/packages/reference/src/components/MissingEntityCard/MissingEntityCard.tsx
@@ -16,6 +16,8 @@ export function MissingEntityCard(props: MissingEntityCardProps) {
   const description = props.customMessage ?? 'Content missing or inaccessible';
 
   function CustomActionButton() {
+    if (props.isDisabled || !props.onRemove) return null;
+
     return (
       <IconButton
         aria-label="Actions"


### PR DESCRIPTION
To fix the issue [here](https://contentful.atlassian.net/browse/ZEND-4949) where customers with no delete rights can delete references in an entry, this PR adds the correct check on `MissingEntityCard` to disable this bug.