### PR TITLE
fix: spaces removed for non english text [ZEND-5011]

### DIFF
--- a/cypress/component/rich-text/RichTextEditor.Pasting.spec.ts
+++ b/cypress/component/rich-text/RichTextEditor.Pasting.spec.ts
@@ -892,6 +892,31 @@ describe(
 
         richText.expectValue(msWordOnline);
       });
+
+      it('does not remove spaces between inline elements', () => {
+        // context: MS Word adds span elements around non english text; we test to see if we preserve the spaces between those spans
+        richText.editor.click().paste({
+          'text/html': `<span lang="KO" style="font-size:11.0pt;line-height:107%;
+            font-family:&quot;Dotum&quot;,sans-serif;mso-ascii-font-family:Calibri;mso-ascii-theme-font:
+            minor-latin;mso-hansi-font-family:Calibri;mso-hansi-theme-font:minor-latin;
+            mso-bidi-font-family:Calibri;mso-bidi-theme-font:minor-latin;mso-ansi-language:
+            EN-US;mso-fareast-language:KO;mso-bidi-language:AR-SA">당사는</span><span lang="KO" style="font-size:11.0pt;line-height:107%;font-family:&quot;Calibri&quot;,sans-serif;
+            mso-ascii-theme-font:minor-latin;mso-fareast-font-family:Dotum;mso-hansi-theme-font:
+            minor-latin;mso-bidi-theme-font:minor-latin;mso-ansi-language:EN-US;mso-fareast-language:
+            KO;mso-bidi-language:AR-SA"> </span><span lang="KO" style="font-size:11.0pt;
+            line-height:107%;font-family:&quot;Dotum&quot;,sans-serif;mso-ascii-font-family:Calibri;
+            mso-ascii-theme-font:minor-latin;mso-hansi-font-family:Calibri;mso-hansi-theme-font:
+            minor-latin;mso-bidi-font-family:Calibri;mso-bidi-theme-font:minor-latin;
+            mso-ansi-language:EN-US;mso-fareast-language:KO;mso-bidi-language:AR-SA">귀하의</span><span lang="KO" style="font-size:11.0pt;line-height:107%;font-family:&quot;Calibri&quot;,sans-serif;
+            mso-ascii-theme-font:minor-latin;mso-fareast-font-family:Dotum;mso-hansi-theme-font:
+            minor-latin;mso-bidi-theme-font:minor-latin;mso-ansi-language:EN-US;mso-fareast-language:
+            KO;mso-bidi-language:AR-SA"></span>`,
+        });
+
+        const expectedValue = doc(block('paragraph', {}, text('당사는 귀하의')));
+
+        richText.expectValue(expectedValue);
+      });
     });
 
     describe('Basic marks', () => {

--- a/packages/rich-text/src/plugins/DeserializeDocx/cleanHtmlEmptyElements.tsx
+++ b/packages/rich-text/src/plugins/DeserializeDocx/cleanHtmlEmptyElements.tsx
@@ -1,0 +1,32 @@
+/*
+ The cleanHtmlEmptyElements from Plate is overly aggressive in removing elements, removing those that are necessary for maintaining proper spacing (span).
+ We are using a slightly adjusted version of the cleanHtmlEmptyElements function to prevent the removal of span elements.
+ */
+import { traverseHtmlElements } from '@udecode/plate-common';
+
+const ALLOWED_EMPTY_ELEMENTS = new Set(['BR', 'IMG', 'TH', 'TD', 'SPAN']);
+
+const isEmpty = (element: Element): boolean => {
+  return !ALLOWED_EMPTY_ELEMENTS.has(element.nodeName) && !element.innerHTML.trim();
+};
+
+const removeIfEmpty = (element: Element): void => {
+  if (isEmpty(element)) {
+    const { parentElement } = element;
+
+    element.remove();
+
+    if (parentElement) {
+      removeIfEmpty(parentElement);
+    }
+  }
+};
+
+/** Remove empty elements from rootNode. Allowed empty elements: BR, IMG. */
+export const cleanHtmlEmptyElements = (rootNode: Node): void => {
+  traverseHtmlElements(rootNode, (element) => {
+    removeIfEmpty(element);
+
+    return true;
+  });
+};

--- a/packages/rich-text/src/plugins/DeserializeDocx/createDeserializeDocxPlugin.tsx
+++ b/packages/rich-text/src/plugins/DeserializeDocx/createDeserializeDocxPlugin.tsx
@@ -1,7 +1,6 @@
 import {
   KEY_DESERIALIZE_HTML,
   cleanHtmlBrElements,
-  cleanHtmlEmptyElements,
   cleanHtmlFontElements,
   cleanHtmlLinkElements,
   cleanHtmlTextNodes,
@@ -22,6 +21,7 @@ import {
 } from '@udecode/plate-serializer-docx';
 
 import { PlatePlugin } from '../../internal';
+import { cleanHtmlEmptyElements } from './cleanHtmlEmptyElements';
 
 export const createDeserializeDocxPlugin: () => PlatePlugin = () =>
   originalCreateDeserializeDocxPlugin({


### PR DESCRIPTION
## Summary
This pull request addresses an issue where spaces were removed from Korean text pasted into the rich text field. The problem was caused by the `cleanHtmlEmptyElements` plugin from Plate, which removes all empty elements, including `<span>` elements used by MS Word to represent spaces in Korean text.
Content support ticket: https://contentful.atlassian.net/browse/ZEND-5011

## Problem
MS Word adds `<span>` elements for each Korean word, and spaces are represented by empty `<span>` elements. The `cleanHtmlEmptyElements` plugin removed these empty `<span>` elements, causing spaces to be removed in Korean text when pasted into the rich text field. 

## Solution
We have customized the plugin to ignore empty `<span>` elements, ensuring that spaces in Korean text are preserved. This change means we no longer rely on the `cleanHtmlEmptyElements` plugin from Plate.

## Additional Changes
Added a test to ensure this behavior is maintained in the future.
