### PR TITLE
feat: support strikethrough

### DIFF
--- a/cypress/component/rich-text/RichTextEditor.Marks.spec.ts
+++ b/cypress/component/rich-text/RichTextEditor.Marks.spec.ts
@@ -21,7 +21,7 @@ describe('Rich Text Editor - Marks', { viewportHeight: 2000, viewportWidth: 1000
   });
 
   const findMarkViaToolbar = (mark: string) => {
-    if (mark === 'code' || mark === 'superscript' || mark === 'subscript') {
+    if (['code', 'superscript', 'subscript', 'strikethrough'].includes(mark)) {
       cy.findByTestId('dropdown-toolbar-button').click();
       return cy.findByTestId(`${mark}-toolbar-button`);
     } else {
@@ -30,7 +30,7 @@ describe('Rich Text Editor - Marks', { viewportHeight: 2000, viewportWidth: 1000
   };
 
   const toggleMarkViaToolbar = (mark: string) => {
-    if (mark === 'code' || mark === 'superscript' || mark === 'subscript') {
+    if (['code', 'superscript', 'subscript', 'strikethrough'].includes(mark)) {
       cy.findByTestId('dropdown-toolbar-button').click();
       cy.findByTestId(`${mark}-toolbar-button`).click();
     } else {
@@ -54,6 +54,7 @@ describe('Rich Text Editor - Marks', { viewportHeight: 2000, viewportWidth: 1000
     [MARKS.CODE, `{${mod}}/`],
     [MARKS.SUPERSCRIPT],
     [MARKS.SUBSCRIPT],
+    [MARKS.STRIKETHROUGH],
   ].forEach(([mark, shortcut]) => {
     describe(`${mark} mark toggle via toolbar`, () => {
       it('allows writing marked text', () => {

--- a/cypress/component/rich-text/RichTextEditor.Pasting.spec.ts
+++ b/cypress/component/rich-text/RichTextEditor.Pasting.spec.ts
@@ -973,6 +973,24 @@ describe(
       });
     });
 
+    describe('Strikethrough mark', () => {
+      it('works when strikethrough from a google doc', () => {
+        // A simple "hello world" text with marks: strikethrough
+        // Copied from a google doc
+        richText.editor.click().paste({
+          'text/html':
+            '<meta charset="utf-8"><meta charset="utf-8"><b style="font-weight:normal;" id="docs-internal-guid-e64bc434-7fff-411f-3a23-35783241e621"><p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;"><span style="font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:line-through;-webkit-text-decoration-skip:none;text-decoration-skip-ink:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Hello world</span></p></b><br class="Apple-interchange-newline">',
+        });
+
+        const expectedValue = doc(
+          block(BLOCKS.PARAGRAPH, {}, text('Hello world', [mark(MARKS.STRIKETHROUGH)])),
+          block(BLOCKS.PARAGRAPH, {}, text('\n'))
+        );
+
+        richText.expectValue(expectedValue);
+      });
+    });
+
     describe('copy from safari (no href in anchors)', () => {
       it('recognizes entry hyperlink', () => {
         richText.editor.click().paste({

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "react": "16.14.0",
     "react-dom": "16.14.0",
     "@contentful/app-sdk": "4.21.1",
-    "@contentful/rich-text-types": "16.3.0"
+    "@contentful/rich-text-types": "16.5.0"
   },
   "browserslist": {
     "production": "extends @contentful/browserslist-config",

--- a/packages/rich-text/package.json
+++ b/packages/rich-text/package.json
@@ -47,7 +47,7 @@
     "@contentful/field-editor-reference": "^5.28.2",
     "@contentful/field-editor-shared": "^1.5.2",
     "@contentful/rich-text-plain-text-renderer": "^16.0.4",
-    "@contentful/rich-text-types": "16.3.0",
+    "@contentful/rich-text-types": "16.5.0",
     "@popperjs/core": "^2.11.5",
     "@udecode/plate-basic-marks": "30.1.2",
     "@udecode/plate-break": "30.1.2",

--- a/packages/rich-text/src/Toolbar/index.tsx
+++ b/packages/rich-text/src/Toolbar/index.tsx
@@ -18,6 +18,10 @@ import { ToolbarListButton } from '../plugins/List';
 import { ToolbarBoldButton } from '../plugins/Marks/Bold';
 import { ToolbarCodeButton, ToolbarDropdownCodeButton } from '../plugins/Marks/Code';
 import { ToolbarItalicButton } from '../plugins/Marks/Italic';
+import {
+  ToolbarDropdownStrikethroughButton,
+  ToolbarStrikethroughButton,
+} from '../plugins/Marks/Strikethrough';
 import { ToolbarDropdownSubscriptButton, ToolbarSubscriptButton } from '../plugins/Marks/Subscript';
 import {
   ToolbarDropdownSuperscriptButton,
@@ -72,13 +76,11 @@ const styles = {
   }),
 };
 
+const dropdownMarks = [MARKS.SUPERSCRIPT, MARKS.SUBSCRIPT, MARKS.CODE, MARKS.STRIKETHROUGH];
+
 const Dropdown = ({ sdk, isDisabled }: { sdk: FieldAppSDK; isDisabled?: boolean }) => {
   const editor = useContentfulEditor();
-  const isActive =
-    editor &&
-    (isMarkActive(editor, MARKS.SUPERSCRIPT) ||
-      isMarkActive(editor, MARKS.SUBSCRIPT) ||
-      isMarkActive(editor, MARKS.CODE));
+  const isActive = editor && dropdownMarks.some((mark) => isMarkActive(editor, mark));
 
   return (
     <Menu>
@@ -101,6 +103,9 @@ const Dropdown = ({ sdk, isDisabled }: { sdk: FieldAppSDK; isDisabled?: boolean 
         )}
         {isMarkEnabled(sdk.field, MARKS.SUBSCRIPT) && (
           <ToolbarDropdownSubscriptButton isDisabled={isDisabled} />
+        )}
+        {isMarkEnabled(sdk.field, MARKS.STRIKETHROUGH) && (
+          <ToolbarDropdownStrikethroughButton isDisabled={isDisabled} />
         )}
         {isMarkEnabled(sdk.field, MARKS.CODE) && (
           <ToolbarDropdownCodeButton isDisabled={isDisabled} />
@@ -126,10 +131,8 @@ const Toolbar = ({ isDisabled }: ToolbarProps) => {
     isMarkEnabled(sdk.field, MARKS.BOLD) ||
     isMarkEnabled(sdk.field, MARKS.ITALIC) ||
     isMarkEnabled(sdk.field, MARKS.UNDERLINE);
-  const dropdownItemsAvailable =
-    isMarkEnabled(sdk.field, MARKS.SUPERSCRIPT) ||
-    isMarkEnabled(sdk.field, MARKS.SUBSCRIPT) ||
-    isMarkEnabled(sdk.field, MARKS.CODE);
+  const dropdownItemsAvailable = dropdownMarks.some((mark) => isMarkEnabled(sdk.field, mark));
+
   const shouldShowDropdown = boldItalicUnderlineAvailable && dropdownItemsAvailable;
 
   return (
@@ -161,6 +164,9 @@ const Toolbar = ({ isDisabled }: ToolbarProps) => {
         )}
         {!boldItalicUnderlineAvailable && isMarkEnabled(sdk.field, MARKS.SUBSCRIPT) && (
           <ToolbarSubscriptButton isDisabled={isDisabled} />
+        )}
+        {!boldItalicUnderlineAvailable && isMarkEnabled(sdk.field, MARKS.STRIKETHROUGH) && (
+          <ToolbarStrikethroughButton isDisabled={isDisabled} />
         )}
         {!boldItalicUnderlineAvailable && isMarkEnabled(sdk.field, MARKS.CODE) && (
           <ToolbarCodeButton isDisabled={isDisabled} />

--- a/packages/rich-text/src/internal/types/editor.ts
+++ b/packages/rich-text/src/internal/types/editor.ts
@@ -20,6 +20,7 @@ export interface Text extends p.TText {
   [MARKS.UNDERLINE]?: boolean;
   [MARKS.SUPERSCRIPT]?: boolean;
   [MARKS.SUBSCRIPT]?: boolean;
+  [MARKS.STRIKETHROUGH]?: boolean;
 }
 
 export interface Element extends p.TElement {

--- a/packages/rich-text/src/plugins/Marks/Strikethrough.tsx
+++ b/packages/rich-text/src/plugins/Marks/Strikethrough.tsx
@@ -1,0 +1,82 @@
+import * as React from 'react';
+
+import { MARKS } from '@contentful/rich-text-types';
+import { createStrikethroughPlugin as createDefaultStrikethroughPlugin } from '@udecode/plate-basic-marks';
+import { css } from 'emotion';
+
+import { PlatePlugin, RenderLeafProps } from '../../internal/types';
+import { createMarkToolbarButton } from './components/MarkToolbarButton';
+import { buildMarkEventHandler } from './helpers';
+
+const styles = {
+  strikethrough: css({
+    textDecoration: 'line-through',
+  }),
+};
+
+export const ToolbarDropdownStrikethroughButton = createMarkToolbarButton({
+  title: 'Strikethrough',
+  mark: MARKS.STRIKETHROUGH,
+});
+
+export const ToolbarStrikethroughButton = createMarkToolbarButton({
+  title: 'Strikethrough',
+  mark: MARKS.STRIKETHROUGH,
+  //@TODO - strikethrough icon should be part of f36-icons
+  icon: (
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" width="18" height="18">
+      <rect width="256" height="256" fill="none" />
+      <line
+        x1="40"
+        y1="128"
+        x2="216"
+        y2="128"
+        fill="none"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="24"
+      />
+      <path
+        d="M72,168c0,22.09,25.07,40,56,40s56-17.91,56-40c0-23.77-21.62-33-45.6-40"
+        fill="none"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="24"
+      />
+      <path
+        d="M75.11,88c0-22.09,22-40,52.89-40,23,0,40.24,9.87,48,24"
+        fill="none"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="24"
+      />
+    </svg>
+  ),
+});
+
+export function Strikethrough(props: RenderLeafProps) {
+  return (
+    <s {...props.attributes} className={styles.strikethrough}>
+      {props.children}
+    </s>
+  );
+}
+
+export const createStrikethroughPlugin = (): PlatePlugin =>
+  createDefaultStrikethroughPlugin({
+    type: MARKS.STRIKETHROUGH,
+    component: Strikethrough,
+    handlers: {
+      onKeyDown: buildMarkEventHandler(MARKS.STRIKETHROUGH),
+    },
+    deserializeHtml: {
+      rules: [
+        {
+          validNodeName: ['S'],
+        },
+      ],
+    },
+  });

--- a/packages/rich-text/src/plugins/Marks/index.ts
+++ b/packages/rich-text/src/plugins/Marks/index.ts
@@ -2,6 +2,7 @@ import { PlatePlugin } from '../../internal/types';
 import { createBoldPlugin } from './Bold';
 import { createCodePlugin } from './Code';
 import { createItalicPlugin } from './Italic';
+import { createStrikethroughPlugin } from './Strikethrough';
 import { createSubscriptPlugin } from './Subscript';
 import { createSuperscriptPlugin } from './Superscript';
 import { createUnderlinePlugin } from './Underline';
@@ -15,5 +16,6 @@ export const createMarksPlugin = (): PlatePlugin => ({
     createUnderlinePlugin(),
     createSuperscriptPlugin(),
     createSubscriptPlugin(),
+    createStrikethroughPlugin(),
   ],
 });


### PR DESCRIPTION
Adding support for strikethrough based on the PR for superscript / subscript https://github.com/contentful/field-editors/pull/1280/files

<img width="1030" alt="Screenshot 2024-05-27 at 09 25 38" src="https://github.com/contentful/field-editors/assets/22968325/bd8b4f6e-b46f-49c1-9d8a-8e36f031d27b">

### Todos
- [x] Update @contentful/rich-text-types after this PR is merged: https://github.com/contentful/rich-text/pull/562