### PR TITLE
fix: do new status calculation only conditionally [TOL-2143]

### DIFF
--- a/cypress/component/reference/MultipleEntryReferenceEditor.spec.tsx
+++ b/cypress/component/reference/MultipleEntryReferenceEditor.spec.tsx
@@ -152,9 +152,7 @@ describe('Multiple Reference Editor', () => {
     findLinkExistingBtn().should('not.exist'); // limit reached, button hidden.
   });
 
-  // FIXME: re-enable
-  // eslint-disable-next-line
-  it.skip(`shows status of entries`, () => {
+  it(`shows status of entries`, () => {
     const sdk = createReferenceEditorTestSdk({
       initialValue: [
         asLink(fixtures.entries.empty),
@@ -163,6 +161,7 @@ describe('Multiple Reference Editor', () => {
         asLink(fixtures.entries.publishedAndChanged),
       ],
     });
+    sdk.parameters.instance.useLocalizedEntityStatus = true;
     mount(<MultipleEntryReferenceEditor {...commonProps} sdk={sdk} />);
 
     cy.findAllByTestId('cf-ui-entry-card').should('have.length', 4);

--- a/cypress/fixtures/FakeSdk.ts
+++ b/cypress/fixtures/FakeSdk.ts
@@ -161,6 +161,11 @@ export function createReferenceEditorTestSdk(props?: ReferenceEditorFakeSdkProps
       space: 'space-id',
       environment: 'environment-id',
     },
+    parameters: {
+      installation: {},
+      instance: {},
+      invocation: {},
+    },
   } as unknown as FieldAppSDK;
   const sdk = props?.modifier?.(localSdk) ?? localSdk;
 

--- a/cypress/fixtures/createRichTextFakeSdk.tsx
+++ b/cypress/fixtures/createRichTextFakeSdk.tsx
@@ -234,6 +234,11 @@ export function createRichTextFakeSdk(props?: RichTextFakeSdkProps): FieldAppSDK
       space: 'space-id',
       environment: 'environment-id',
     },
+    parameters: {
+      installation: {},
+      instance: {},
+      invocation: {},
+    },
   } as unknown as FieldAppSDK;
   const sdk = props?.modifier?.(localSdk) ?? localSdk;
 

--- a/packages/_shared/src/utils/entityHelpers.ts
+++ b/packages/_shared/src/utils/entityHelpers.ts
@@ -205,11 +205,18 @@ type FieldStatus = {
   '*': Record<string, AsyncPublishStatus>;
 };
 
-export function getEntryStatus(
-  //TODO: remove union after fieldStatus is added to App SDK
-  sys: Entry['sys'] & { fieldStatus?: FieldStatus },
-  // @ts-expect-error
-  localeCodes?: string | string[] // eslint-disable-line @typescript-eslint/no-unused-vars -- temporary disabled
+/**
+ * Returns the status of the entry/asset
+ * If a locale code(s) is provided it will pick up the most advanced state for these locale(s)
+ * - deleted
+ * - archived
+ * - changed
+ * - published
+ * - draft
+ */
+export function getEntityStatus(
+  sys: (Entry['sys'] | Asset['sys']) & { fieldStatus?: FieldStatus },
+  localeCodes?: string | string[]
 ) {
   if (!sys || (sys.type !== 'Entry' && sys.type !== 'Asset')) {
     throw new TypeError('Invalid entity metadata object');
@@ -223,31 +230,33 @@ export function getEntryStatus(
     return 'archived';
   }
 
-  // if (sys.fieldStatus && localeCodes) {
-  //   let status: AsyncPublishStatus = 'draft';
+  // TODO: remove the condition, once locale based publishing is GA
+  // Then we don't need the publishedVersion calculation anymore
+  if (sys.fieldStatus && localeCodes) {
+    let status: AsyncPublishStatus = 'draft';
 
-  //   const condition = (locale: string) => {
-  //     if (Array.isArray(localeCodes)) {
-  //       return localeCodes.includes(locale);
-  //     }
+    const isMatchingLocale = (locale: string) => {
+      if (Array.isArray(localeCodes)) {
+        return localeCodes.includes(locale);
+      }
 
-  //     return localeCodes ? localeCodes === locale : true;
-  //   };
+      return localeCodes ? localeCodes === locale : true;
+    };
 
-  //   Object.entries(sys.fieldStatus['*']).forEach(([localeCode, fieldStatus]) => {
-  //     if (condition(localeCode)) {
-  //       if (fieldStatus === 'changed') {
-  //         status = fieldStatus;
-  //         return;
-  //       }
-  //       if (fieldStatus === 'published') {
-  //         status = fieldStatus;
-  //       }
-  //     }
-  //   });
+    Object.entries(sys.fieldStatus['*']).forEach(([localeCode, fieldStatus]) => {
+      if (isMatchingLocale(localeCode)) {
+        if (fieldStatus === 'changed') {
+          status = fieldStatus;
+          return;
+        }
+        if (fieldStatus === 'published') {
+          status = fieldStatus;
+        }
+      }
+    });
 
-  //   return status;
-  // }
+    return status;
+  }
 
   if (sys.publishedVersion) {
     if (sys.version > sys.publishedVersion + 1) {
@@ -258,6 +267,15 @@ export function getEntryStatus(
   }
 
   return 'draft';
+}
+
+/**@deprecated use `getEntityStatus` */
+export function getEntryStatus(
+  //TODO: remove union after fieldStatus is added to App SDK
+  sys: Entry['sys'] & { fieldStatus?: FieldStatus },
+  localeCodes?: string | string[]
+) {
+  return getEntityStatus(sys, localeCodes);
 }
 
 /**

--- a/packages/reference/src/__fixtures__/FakeSdk.ts
+++ b/packages/reference/src/__fixtures__/FakeSdk.ts
@@ -181,6 +181,11 @@ export function newReferenceEditorFakeSdk(props?: ReferenceEditorSdkProps): [Fie
       space: 'space-id',
       environment: 'environment-id',
     },
+    parameters: {
+      installation: {},
+      instance: {},
+      invocation: {},
+    },
   } as unknown as FieldAppSDK;
   return [sdk, mitt];
 }

--- a/packages/reference/src/assets/WrappedAssetCard/FetchingWrappedAssetCard.tsx
+++ b/packages/reference/src/assets/WrappedAssetCard/FetchingWrappedAssetCard.tsx
@@ -92,6 +92,7 @@ export function FetchingWrappedAssetCard(props: FetchingWrappedAssetCardProps) {
       renderDragHandle: props.renderDragHandle,
       onEdit,
       onRemove,
+      useLocalizedEntityStatus: props.sdk.parameters.instance.useLocalizedEntityStatus,
     };
 
     if (props.viewType === 'link') {

--- a/packages/reference/src/assets/WrappedAssetCard/WrappedAssetCard.tsx
+++ b/packages/reference/src/assets/WrappedAssetCard/WrappedAssetCard.tsx
@@ -47,6 +47,7 @@ export interface WrappedAssetCardProps {
   size: 'default' | 'small';
   renderDragHandle?: RenderDragFn;
   isClickable: boolean;
+  useLocalizedEntityStatus: boolean;
 }
 
 const defaultProps = {
@@ -71,8 +72,10 @@ export const WrappedAssetCard = (props: WrappedAssetCardProps) => {
   const { className, onEdit, getAssetUrl, onRemove, size, isDisabled, isSelected, isClickable } =
     props;
 
-  // @ts-expect-error
-  const status = entityHelpers.getEntryStatus(props.asset.sys, props.localeCode);
+  const status = entityHelpers.getEntityStatus(
+    props.asset.sys,
+    props.useLocalizedEntityStatus ? props.localeCode : undefined
+  );
 
   if (status === 'deleted') {
     return <MissingAssetCard asSquare isDisabled={props.isDisabled} onRemove={props.onRemove} />;

--- a/packages/reference/src/assets/WrappedAssetCard/WrappedAssetLink.tsx
+++ b/packages/reference/src/assets/WrappedAssetCard/WrappedAssetLink.tsx
@@ -27,13 +27,16 @@ export interface WrappedAssetLinkProps {
   onEdit: () => void;
   onRemove: () => void;
   renderDragHandle?: RenderDragFn;
+  useLocalizedEntityStatus?: boolean;
 }
 
 export const WrappedAssetLink = (props: WrappedAssetLinkProps) => {
   const { className, href, onEdit, onRemove, isDisabled } = props;
 
-  // @ts-expect-error
-  const status = entityHelpers.getEntryStatus(props.asset.sys, props.localeCode);
+  const status = entityHelpers.getEntityStatus(
+    props.asset.sys,
+    props.useLocalizedEntityStatus ? props.localeCode : undefined
+  );
 
   if (status === 'deleted') {
     return <MissingAssetCard isDisabled={props.isDisabled} onRemove={props.onRemove} />;

--- a/packages/reference/src/common/customCardTypes.ts
+++ b/packages/reference/src/common/customCardTypes.ts
@@ -39,4 +39,6 @@ export type CustomEntityCardProps = {
   onMoveTop?: () => void;
   onMoveBottom?: () => void;
   isBeingDragged?: boolean;
+
+  useLocalizedEntityStatus?: boolean;
 };

--- a/packages/reference/src/entries/WrappedEntryCard/FetchingWrappedEntryCard.tsx
+++ b/packages/reference/src/entries/WrappedEntryCard/FetchingWrappedEntryCard.tsx
@@ -141,6 +141,7 @@ export function FetchingWrappedEntryCard(props: EntryCardReferenceEditorProps) {
       onMoveTop: props.onMoveTop,
       onMoveBottom: props.onMoveBottom,
       isBeingDragged: props.isBeingDragged,
+      useLocalizedEntityStatus: props.sdk.parameters.instance.useLocalizedEntityStatus,
     };
 
     const { hasCardEditActions, hasCardMoveActions, hasCardRemoveActions } = props;

--- a/packages/reference/src/entries/WrappedEntryCard/WrappedEntryCard.tsx
+++ b/packages/reference/src/entries/WrappedEntryCard/WrappedEntryCard.tsx
@@ -11,7 +11,7 @@ import { AssetThumbnail, MissingEntityCard, ScheduledIconWithTooltip } from '../
 import { SpaceName } from '../../components/SpaceName/SpaceName';
 import { ContentType, Entry, File, RenderDragFn } from '../../types';
 
-const { getEntryTitle, getEntityDescription, getEntryStatus, getEntryImage } = entityHelpers;
+const { getEntryTitle, getEntityDescription, getEntityStatus, getEntryImage } = entityHelpers;
 
 const styles = {
   scheduleIcon: css({
@@ -41,6 +41,7 @@ export interface WrappedEntryCardProps {
   hasCardEditActions: boolean;
   hasCardMoveActions?: boolean;
   hasCardRemoveActions?: boolean;
+  useLocalizedEntityStatus?: boolean;
 }
 
 const defaultProps = {
@@ -75,7 +76,10 @@ export function WrappedEntryCard(props: WrappedEntryCardProps) {
     }
   }, [props.entry, props.getAsset, contentType, props.localeCode, props.defaultLocaleCode]);
 
-  const status = getEntryStatus(props.entry?.sys, props.localeCode);
+  const status = getEntityStatus(
+    props.entry?.sys,
+    props.useLocalizedEntityStatus ? props.localeCode : undefined
+  );
 
   if (status === 'deleted') {
     return (

--- a/packages/rich-text/src/plugins/EmbeddedEntityInline/FetchingWrappedInlineEntryCard.tsx
+++ b/packages/rich-text/src/plugins/EmbeddedEntityInline/FetchingWrappedInlineEntryCard.tsx
@@ -12,7 +12,7 @@ import { Entry, FieldAppSDK, entityHelpers } from '@contentful/field-editor-shar
 import { INLINES } from '@contentful/rich-text-types';
 import { css } from 'emotion';
 
-const { getEntryTitle, getEntryStatus } = entityHelpers;
+const { getEntryTitle, getEntityStatus } = entityHelpers;
 
 const styles = {
   scheduledIcon: css({
@@ -32,7 +32,7 @@ type InternalFetchingWrappedInlineEntryCardProps = Pick<
   getEntityScheduledActions: React.ComponentProps<
     typeof ScheduledIconWithTooltip
   >['getEntityScheduledActions'];
-  entryStatus: ReturnType<typeof getEntryStatus>;
+  entryStatus: ReturnType<typeof getEntityStatus>;
 };
 
 function InternalFetchingWrappedInlineEntryCard({
@@ -133,7 +133,11 @@ export function FetchingWrappedInlineEntryCard(props: FetchingWrappedInlineEntry
     );
   }
 
-  const entryStatus = getEntryStatus(entry.sys, props.sdk.field.locale);
+  const entryStatus = getEntityStatus(
+    entry.sys,
+    props.sdk.parameters.instance.useLocalizedEntityStatus ? props.sdk.field.locale : undefined
+  );
+
   if (entryStatus === 'deleted') {
     return (
       <InlineEntryCard

--- a/packages/rich-text/src/plugins/EmbeddedResourceInline/FetchingWrappedResourceInlineCard.tsx
+++ b/packages/rich-text/src/plugins/EmbeddedResourceInline/FetchingWrappedResourceInlineCard.tsx
@@ -9,7 +9,7 @@ import { INLINES } from '@contentful/rich-text-types';
 
 import { truncateTitle } from '../../plugins/shared/utils';
 
-const { getEntryTitle, getEntryStatus } = entityHelpers;
+const { getEntryTitle, getEntityStatus } = entityHelpers;
 
 interface FetchingWrappedResourceInlineCardProps {
   link: ResourceLink<'Contentful:Entry'>['sys'];
@@ -54,7 +54,10 @@ export function FetchingWrappedResourceInlineCard(props: FetchingWrappedResource
     defaultTitle: 'Untitled',
   });
   const truncatedTitle = truncateTitle(title, 40);
-  const status = getEntryStatus(entry.sys, props.sdk.field.locale);
+  const status = getEntityStatus(
+    entry.sys,
+    props.sdk.parameters.instance.useLocalizedEntityStatus ? props.sdk.field.locale : undefined
+  );
 
   return (
     <InlineEntryCard

--- a/packages/rich-text/src/plugins/Hyperlink/useEntityInfo.ts
+++ b/packages/rich-text/src/plugins/Hyperlink/useEntityInfo.ts
@@ -17,7 +17,7 @@ export type FetchedEntityData = {
   entity: Entry | Asset;
   entityTitle: string;
   entityDescription: string;
-  entityStatus: ReturnType<typeof entityHelpers.getEntryStatus>;
+  entityStatus: ReturnType<typeof entityHelpers.getEntityStatus>;
   contentTypeName: string;
 };
 
@@ -70,8 +70,10 @@ async function fetchAllData({
 
   const jobs = await sdk.space.getEntityScheduledActions(entityType, entityId);
 
-  // @ts-expect-error
-  const entityStatus = entityHelpers.getEntryStatus(entity.sys, sdk.field.locale);
+  const entityStatus = entityHelpers.getEntityStatus(
+    entity.sys,
+    sdk.parameters.instance.useLocalizedEntityStatus ? sdk.field.locale : undefined
+  );
 
   return {
     jobs,

--- a/packages/rich-text/src/plugins/shared/FetchingWrappedAssetCard.tsx
+++ b/packages/rich-text/src/plugins/shared/FetchingWrappedAssetCard.tsx
@@ -34,6 +34,7 @@ const InternalAssetCard = React.memo(
       onEdit={props.onEdit}
       onRemove={props.isDisabled ? undefined : props.onRemove}
       isClickable={false}
+      useLocalizedEntityStatus={props.sdk.parameters.instance.useLocalizedEntityStatus}
     />
   ),
   areEqual

--- a/packages/rich-text/src/plugins/shared/__tests__/FetchingWrappedAssetCard.test.tsx
+++ b/packages/rich-text/src/plugins/shared/__tests__/FetchingWrappedAssetCard.test.tsx
@@ -35,6 +35,9 @@ beforeEach(() => {
       space: 'space-id',
       environment: 'environment-id',
     },
+    parameters: {
+      instance: {},
+    },
   };
 });
 


### PR DESCRIPTION
Restores the commented status calculation by locale, but only do it if the feature is enabled.
For the beta that comes as an instance parameter.

disabled here: https://github.com/contentful/field-editors/pull/1666/files