### PR TITLE
fix(rich-text): add status differentiation props []

### DIFF
--- a/packages/rich-text/src/plugins/shared/FetchingWrappedAssetCard.tsx
+++ b/packages/rich-text/src/plugins/shared/FetchingWrappedAssetCard.tsx
@@ -35,6 +35,7 @@ const InternalAssetCard = React.memo(
       onRemove={props.isDisabled ? undefined : props.onRemove}
       isClickable={false}
       useLocalizedEntityStatus={props.sdk.parameters.instance.useLocalizedEntityStatus}
+      isLocalized={!!('localized' in props.sdk.field && props.sdk.field.localized)}
     />
   ),
   areEqual

--- a/packages/rich-text/src/plugins/shared/FetchingWrappedEntryCard.tsx
+++ b/packages/rich-text/src/plugins/shared/FetchingWrappedEntryCard.tsx
@@ -43,6 +43,8 @@ const InternalEntryCard = React.memo((props: InternalEntryCard) => {
       onEdit={props.onEdit}
       onRemove={props.isDisabled ? undefined : props.onRemove}
       isClickable={false}
+      useLocalizedEntityStatus={sdk.parameters.instance.useLocalizedEntityStatus}
+      isLocalized={!!('localized' in props.sdk.field && props.sdk.field.localized)}
     />
   );
 }, areEqual);

--- a/packages/rich-text/src/plugins/shared/FetchingWrappedResourceCard.tsx
+++ b/packages/rich-text/src/plugins/shared/FetchingWrappedResourceCard.tsx
@@ -43,6 +43,8 @@ const InternalEntryCard = React.memo((props: InternalEntryCard) => {
       onRemove={props.isDisabled ? undefined : props.onRemove}
       isClickable={false}
       getEntityScheduledActions={() => Promise.resolve([])}
+      useLocalizedEntityStatus={props.sdk.parameters.instance.useLocalizedEntityStatus}
+      isLocalized={!!('localized' in props.sdk.field && props.sdk.field.localized)}
     />
   );
 }, areEqual);

--- a/packages/rich-text/src/plugins/shared/__tests__/FetchingWrappedAssetCard.test.tsx
+++ b/packages/rich-text/src/plugins/shared/__tests__/FetchingWrappedAssetCard.test.tsx
@@ -38,6 +38,7 @@ beforeEach(() => {
     parameters: {
       instance: {},
     },
+    field: { localized: false },
   };
 });
 

--- a/packages/rich-text/src/plugins/shared/__tests__/FetchingWrappedEntryCard.test.tsx
+++ b/packages/rich-text/src/plugins/shared/__tests__/FetchingWrappedEntryCard.test.tsx
@@ -37,6 +37,8 @@ beforeEach(() => {
       space: 'space-id',
       environment: 'environment-id',
     },
+    parameters: { instance: {} },
+    field: { localized: false },
   };
 });
 

--- a/packages/rich-text/src/plugins/shared/__tests__/FetchingWrappedResourceCard.test.tsx
+++ b/packages/rich-text/src/plugins/shared/__tests__/FetchingWrappedResourceCard.test.tsx
@@ -48,6 +48,8 @@ beforeEach(() => {
       space: 'space-id',
       environment: 'environment-id',
     },
+    parameters: { instance: {} },
+    field: { localized: false },
   };
 });
 


### PR DESCRIPTION
For rich-text the necessary properties were not provided to differentiate the entry status by locale