### PR TITLE
fix: adding line breaks to rich text anchor styles []

### DIFF
--- a/packages/rich-text/src/plugins/Hyperlink/components/styles.ts
+++ b/packages/rich-text/src/plugins/Hyperlink/components/styles.ts
@@ -25,6 +25,9 @@ export const styles = {
     zIndex: tokens.zIndexModal,
   }),
   hyperlink: css({
+    position: 'relative',
+    whiteSpace: 'pre-wrap',
+    overflowWrap: 'break-word',
     fontSize: 'inherit !important',
     display: 'inline !important',
     direction: 'inherit',


### PR DESCRIPTION
When creating spaces with "shift + enter" it breaks the line for normal text but doesn't for anchor tags. When rendered the rich text field is then render in apps it can contain the line break, safest to mimic the behaviour of normal text.

**Before**

![Screenshot 2024-07-23 at 12 32 04](https://github.com/user-attachments/assets/04b0a9e5-12f7-4aff-841c-f3bfecc9d257)

**After**

![Screenshot 2024-07-23 at 12 32 51](https://github.com/user-attachments/assets/f89721df-096a-42e8-b68e-3aa351ae79fd)
