### PR TITLE
fix: add a missing handler for ERL click [DANTE-1735]

### DIFF
--- a/packages/reference/src/resources/ExternalResourceCard/ExternalResourceCard.tsx
+++ b/packages/reference/src/resources/ExternalResourceCard/ExternalResourceCard.tsx
@@ -86,7 +86,6 @@ ExternalResourceCardDescription.displayName = 'ExternalResourceCardDescription';
 export function ExternalResourceCard({
   info,
   isClickable,
-  onEdit,
   onRemove,
   onMoveTop,
   onMoveBottom,
@@ -99,6 +98,13 @@ export function ExternalResourceCard({
 }: ExternalResourceCardProps) {
   const { resource: entity, resourceType } = info;
   const badge = ExternalEntityBadge(entity.fields.badge);
+
+  const onEdit = () => {
+    if (entity.fields.externalUrl) {
+      window.open(entity.fields.externalUrl, '_blank', 'noopener,noreferrer');
+    }
+  };
+
   return (
     <EntryCard
       as={entity.fields.externalUrl ? 'a' : 'article'}
@@ -161,7 +167,7 @@ export function ExternalResourceCard({
           ? (e: React.MouseEvent<HTMLElement>) => {
               e.preventDefault();
               if (onClick) return onClick(e);
-              onEdit && onEdit();
+              onEdit();
             }
           : undefined
       }

--- a/packages/reference/src/resources/ExternalResourceCard/ExternalResourceCard.tsx
+++ b/packages/reference/src/resources/ExternalResourceCard/ExternalResourceCard.tsx
@@ -20,7 +20,6 @@ export interface ExternalResourceCardProps {
   isDisabled: boolean;
   isSelected?: boolean;
   onRemove?: () => void;
-  onEdit?: () => void;
   onClick?: (e: React.MouseEvent<HTMLElement>) => void;
   renderDragHandle?: RenderDragFn;
   isClickable?: boolean;


### PR DESCRIPTION
External Resource Cards had no `onEdit` handler provided in the parent component, therefore clicking on the card had no effect. This PR fixes this issue and opens the URL provided in `externalUrl` (if existing).

https://contentful.atlassian.net/browse/DANTE-1734