### PR TITLE
fix(rich-text): changing scroll position with \r [TOL-2365]

### DIFF
--- a/packages/rich-text/src/plugins/Normalizer/baseRules.ts
+++ b/packages/rich-text/src/plugins/Normalizer/baseRules.ts
@@ -3,6 +3,7 @@ import { BLOCKS, TEXT_CONTAINERS } from '@contentful/rich-text-types';
 import { INLINE_TYPES } from '../../helpers/editor';
 import { transformWrapIn } from '../../helpers/transformers';
 import { getParentNode, isText } from '../../internal/queries';
+import { insertText } from '../../internal/transforms';
 import { Element } from '../../internal/types';
 import { NormalizerRule } from './types';
 
@@ -33,5 +34,15 @@ export const baseRules: Required<NormalizerRule>[] = [
       return !!parent && isTextContainer(parent);
     },
     transform: transformWrapIn(BLOCKS.PARAGRAPH),
+  },
+  {
+    // Replaces `\r` as it causes issues with scroll position and focus
+    match: isText,
+    validNode: (_editor, [node]) => typeof node.text === 'string' && !node.text.includes('\r'),
+    transform: (editor, [node, path]) => {
+      if (typeof node.text === 'string') {
+        return insertText(editor, node.text.replace(/\r/g, ''), { at: path });
+      }
+    },
   },
 ];

--- a/packages/rich-text/src/plugins/Normalizer/baseRules.ts
+++ b/packages/rich-text/src/plugins/Normalizer/baseRules.ts
@@ -40,9 +40,7 @@ export const baseRules: Required<NormalizerRule>[] = [
     match: isText,
     validNode: (_editor, [node]) => typeof node.text === 'string' && !node.text.includes('\r'),
     transform: (editor, [node, path]) => {
-      if (typeof node.text === 'string') {
-        return insertText(editor, node.text.replace(/\r/g, ''), { at: path });
-      }
+      return insertText(editor, (node.text as string).replace(/\r/g, ''), { at: path });
     },
   },
 ];


### PR DESCRIPTION
- Normalize the content before rendering it
- This will not trigger a change event for the editor directly
- The next time the content is adjusted and saved, it will be cleaned up internally