### PR TITLE
fix: add an ERL component to handle URLs in the editor [DANTE-1757]

### DIFF
--- a/packages/reference/src/resources/Cards/ExternalEntryCard.tsx
+++ b/packages/reference/src/resources/Cards/ExternalEntryCard.tsx
@@ -1,0 +1,16 @@
+import * as React from 'react';
+
+import {
+  ExternalResourceCard,
+  type ExternalResourceCardProps,
+} from '../ExternalResourceCard/ExternalResourceCard';
+
+type ExternalEntryCardProps = ExternalResourceCardProps;
+
+export function ExternalEntryCard(props: ExternalEntryCardProps) {
+  const openEntryDetail = () => {
+    window.open(props.info.resource.fields.externalUrl, '_blank', 'noopener,noreferrer');
+  };
+
+  return <ExternalResourceCard {...props} onEdit={openEntryDetail} />;
+}

--- a/packages/reference/src/resources/Cards/ResourceCard.tsx
+++ b/packages/reference/src/resources/Cards/ResourceCard.tsx
@@ -7,8 +7,8 @@ import { SetRequired } from 'type-fest';
 import { isContentfulResourceInfo, useResource } from '../../common/EntityStore';
 import { ResourceEntityErrorCard } from '../../components';
 import { RenderDragFn, ResourceLink } from '../../types';
-import { ExternalResourceCard } from '../ExternalResourceCard/ExternalResourceCard';
 import { CardActionsHandlers, ContentfulEntryCard, EntryRoute } from './ContentfulEntryCard';
+import { ExternalEntryCard } from './ExternalEntryCard';
 
 type ResourceCardProps = {
   index?: number;
@@ -57,7 +57,7 @@ function ExistingResourceCard(
     return <ContentfulEntryCard info={info} {...props} />;
   }
 
-  return <ExternalResourceCard info={info} {...props} />;
+  return <ExternalEntryCard info={info} {...props} />;
 }
 
 function ResourceCardWrapper(props: ResourceCardProps & { inView: boolean }) {

--- a/packages/reference/src/resources/ExternalResourceCard/ExternalResourceCard.tsx
+++ b/packages/reference/src/resources/ExternalResourceCard/ExternalResourceCard.tsx
@@ -20,6 +20,7 @@ export interface ExternalResourceCardProps {
   isDisabled: boolean;
   isSelected?: boolean;
   onRemove?: () => void;
+  onEdit?: () => void;
   onClick?: (e: React.MouseEvent<HTMLElement>) => void;
   renderDragHandle?: RenderDragFn;
   isClickable?: boolean;
@@ -85,6 +86,7 @@ ExternalResourceCardDescription.displayName = 'ExternalResourceCardDescription';
 export function ExternalResourceCard({
   info,
   isClickable,
+  onEdit,
   onRemove,
   onMoveTop,
   onMoveBottom,
@@ -97,12 +99,6 @@ export function ExternalResourceCard({
 }: ExternalResourceCardProps) {
   const { resource: entity, resourceType } = info;
   const badge = ExternalEntityBadge(entity.fields.badge);
-
-  const onEdit = () => {
-    if (entity.fields.externalUrl) {
-      window.open(entity.fields.externalUrl, '_blank', 'noopener,noreferrer');
-    }
-  };
 
   return (
     <EntryCard
@@ -166,7 +162,7 @@ export function ExternalResourceCard({
           ? (e: React.MouseEvent<HTMLElement>) => {
               e.preventDefault();
               if (onClick) return onClick(e);
-              onEdit();
+              onEdit && onEdit();
             }
           : undefined
       }


### PR DESCRIPTION
In [this PR](https://github.com/contentful/field-editors/pull/1717) we have addressed the bug where clicking on an ERL card did not open the external resource. This, however, has introduced a bug where entity picker also started opening the links when selecting the cards.

This was caused by the fact that `ExternalResourceCard` component, used both by editor and entity picker, had the logic of opening a new tab.

Solution:
I lifted the logic of opening the URLs to a new parent component to be used only in the context of `field-editors` (entry editor). For context of entity picker (`experience-packages`), this logic is not there and click does not trigger opening a new tab.