### PR TITLE
fix: use proper methods to fetch NER entities

### DIFF
--- a/packages/reference/package.json
+++ b/packages/reference/package.json
@@ -45,7 +45,7 @@
     "@dnd-kit/sortable": "^8.0.0",
     "@tanstack/react-query": "^4.3.9",
     "constate": "^3.3.2",
-    "contentful-management": "^11.30.0",
+    "contentful-management": "^11.35.1",
     "emotion": "^10.0.17",
     "lodash": "^4.17.15",
     "moment": "^2.20.0",

--- a/packages/reference/src/resources/Cards/ResourceCard.spec.tsx
+++ b/packages/reference/src/resources/Cards/ResourceCard.spec.tsx
@@ -58,23 +58,29 @@ const sdk: any = {
         return Promise.reject(new Error());
       }),
     },
-    Http: {
-      get: jest.fn().mockImplementation(({ url, config }) => {
-        if (url === '/spaces/space-id/environments/environment-id/resource_types') {
-          return Promise.resolve({ items: [resourceType], pages: {} });
-        }
+    Locale: {
+      getMany: jest.fn().mockResolvedValue({ items: [{ default: true, code: 'en' }] }),
+    },
+    Resource: {
+      getMany: jest.fn().mockImplementation(({ spaceId, environmentId, resourceTypeId, query }) => {
         if (
-          url ===
-            `/spaces/space-id/environments/environment-id/resource_types/${resolvableExternalResourceType}/resources` &&
-          config.params['sys.urn[in]'] === resolvableExternalEntityUrn
+          spaceId === 'space-id' &&
+          environmentId === 'environment-id' &&
+          resourceTypeId === resolvableExternalResourceType &&
+          query['sys.urn[in]'] === resolvableExternalEntityUrn
         ) {
           return Promise.resolve({ items: [resource] });
         }
         return Promise.resolve({ items: [] });
       }),
     },
-    Locale: {
-      getMany: jest.fn().mockResolvedValue({ items: [{ default: true, code: 'en' }] }),
+    ResourceType: {
+      getForEnvironment: jest.fn().mockImplementation(({ spaceId, environmentId }) => {
+        if (spaceId === 'space-id' && environmentId === 'environment-id') {
+          return Promise.resolve({ items: [resourceType], pages: {} });
+        }
+        return Promise.resolve({ items: [] });
+      }),
     },
     ScheduledAction: {
       getMany: jest.fn().mockResolvedValue({ items: [], total: 0 }),

--- a/packages/reference/src/resources/ExternalResourceCard/ExternalResourceCard.tsx
+++ b/packages/reference/src/resources/ExternalResourceCard/ExternalResourceCard.tsx
@@ -31,12 +31,6 @@ export interface ExternalResourceCardProps {
   hasCardRemoveActions?: boolean;
 }
 
-const defaultProps = {
-  isClickable: true,
-  hasCardMoveActions: true,
-  hasCardRemoveActions: true,
-};
-
 const styles = {
   subtitle: css({
     color: tokens.gray600,
@@ -85,14 +79,14 @@ ExternalResourceCardDescription.displayName = 'ExternalResourceCardDescription';
 
 export function ExternalResourceCard({
   info,
-  isClickable,
+  isClickable = true,
   onEdit,
   onRemove,
   onMoveTop,
   onMoveBottom,
   hasCardEditActions,
-  hasCardMoveActions,
-  hasCardRemoveActions,
+  hasCardMoveActions = true,
+  hasCardRemoveActions = true,
   renderDragHandle,
   onClick,
   isSelected,
@@ -123,8 +117,7 @@ export function ExternalResourceCard({
             testId="edit"
             onClick={() => {
               onEdit && onEdit();
-            }}
-          >
+            }}>
             Edit
           </MenuItem>
         ) : null,
@@ -134,8 +127,7 @@ export function ExternalResourceCard({
             testId="delete"
             onClick={() => {
               onRemove && onRemove();
-            }}
-          >
+            }}>
             Remove
           </MenuItem>
         ) : null,
@@ -151,8 +143,7 @@ export function ExternalResourceCard({
           <MenuItem
             key="move-bottom"
             onClick={() => onMoveBottom && onMoveBottom()}
-            testId="move-bottom"
-          >
+            testId="move-bottom">
             Move to bottom
           </MenuItem>
         ) : null,
@@ -165,8 +156,7 @@ export function ExternalResourceCard({
               onEdit && onEdit();
             }
           : undefined
-      }
-    >
+      }>
       <ExternalResourceCardDescription
         subtitle={entity.fields.subtitle}
         description={entity.fields.description}
@@ -174,5 +164,3 @@ export function ExternalResourceCard({
     </EntryCard>
   );
 }
-
-ExternalResourceCard.defaultProps = defaultProps;

--- a/packages/reference/src/types.ts
+++ b/packages/reference/src/types.ts
@@ -1,5 +1,6 @@
 import { NavigatorSlideInfo, ContentEntityType } from '@contentful/app-sdk';
 import { Entry, Asset } from '@contentful/field-editor-shared';
+import { ResourceProps } from 'contentful-management';
 
 export type {
   BaseAppSDK,
@@ -11,7 +12,12 @@ export type {
   NavigatorSlideInfo,
   ScheduledAction,
 } from '@contentful/app-sdk';
-export type { SpaceProps as Space, ResourceLink } from 'contentful-management';
+export type {
+  SpaceProps as Space,
+  ResourceLink,
+  ResourceProps as ExternalResource,
+  SpaceEnvResourceTypeProps as ResourceType,
+} from 'contentful-management';
 
 export { Entry, File, Asset } from '@contentful/field-editor-shared';
 
@@ -25,43 +31,7 @@ export type AssetLink = { sys: { type: 'Link'; linkType: 'Asset'; id: string } }
 
 export type EntityLink = EntryLink | AssetLink;
 
-type SysExternalResource<T extends string> = {
-  sys: { type: 'Link'; linkType: T; id: string };
-};
-
-export type ResourceType = {
-  sys: {
-    type: 'ResourceType';
-    id: string;
-    resourceProvider: SysExternalResource<'ResourceProvider'>;
-  };
-  name: string;
-};
-
-export interface ExternalResource {
-  sys: {
-    type: 'Resource';
-    urn: string;
-    resourceProvider: SysExternalResource<'ResourceProvider'>;
-    resourceType: SysExternalResource<'ResourceType'>;
-  };
-  fields: {
-    title: string;
-    subtitle?: string;
-    description?: string;
-    externalUrl?: string;
-    badge?: {
-      label: string;
-      variant: 'negative' | 'positive' | 'primary' | 'secondary' | 'warning';
-    };
-    image?: {
-      url: string;
-      altText?: string;
-    };
-  };
-}
-
-export type Resource = Entry | ExternalResource;
+export type Resource = Entry | ResourceProps;
 
 export type EntityType = 'Entry' | 'Asset' | string;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9395,7 +9395,7 @@ contentful-import@^9.0.0:
     p-queue "^6.6.2"
     yargs "^17.7.2"
 
-contentful-management@>=7.30.0, contentful-management@^11.0.0, contentful-management@^11.0.1, contentful-management@^11.15.0, contentful-management@^11.30.0:
+contentful-management@>=7.30.0, contentful-management@^11.0.0, contentful-management@^11.0.1, contentful-management@^11.15.0:
   version "11.33.0"
   resolved "https://registry.yarnpkg.com/contentful-management/-/contentful-management-11.33.0.tgz#3bed7a5154790690218a77d393f55a1616b7523a"
   integrity sha512-QIpKV9BWGQ4M9TTTeyJiIyCElMnQvzMijMpQA31uFAdFxfokRcyA6zyYoVA7tIsyOmpWIAcFbGcDiGROAMR+zA==


### PR DESCRIPTION
Use proper types and methods from contentful-management for fetching [NER](https://www.contentful.com/help/orchestration/native-external-references/) entities.

Removing the default props in 49be1667ebce35dab86b31e46549d50779f5c4a2 is technically unrelated but it made sense to clean up while I was at it.
