### PR TITLE
fix: reference-error by defining enum without declare [TOL-2454]

### DIFF
--- a/packages/_shared/src/LocalePublishingEntityStatusBadge/ScheduledBanner.tsx
+++ b/packages/_shared/src/LocalePublishingEntityStatusBadge/ScheduledBanner.tsx
@@ -11,7 +11,7 @@ type ScheduledBannerProps = {
   jobs: ScheduledActionProps[];
 };
 
-declare enum ScheduledActionTypes {
+enum ScheduledActionTypes {
   publish = 'publish',
   unpublish = 'unpublish',
   'patch+publish' = 'patch+publish',


### PR DESCRIPTION
Fixed a ReferenceError caused by ScheduledActionTypes enum not being defined at runtime by removing the declare keyword from its definition.