### PR TITLE
feat: implement localized entity status badge in references [TOL-2454]

### DIFF
--- a/packages/reference/src/assets/WrappedAssetCard/FetchingWrappedAssetCard.tsx
+++ b/packages/reference/src/assets/WrappedAssetCard/FetchingWrappedAssetCard.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
 import { AssetCard, EntryCard } from '@contentful/f36-components';
+import { useAsyncLocalePublishStatus } from '@contentful/field-editor-shared';
 
 import {
   CustomEntityCardProps,
@@ -32,6 +33,10 @@ export function FetchingWrappedAssetCard(props: FetchingWrappedAssetCardProps) {
   const loadEntityScheduledActions = React.useCallback(
     () => getEntityScheduledActions('Asset', props.assetId),
     [getEntityScheduledActions, props.assetId]
+  );
+  const localesStatusMap = useAsyncLocalePublishStatus(
+    asset,
+    props.sdk.parameters.instance.privateLocales
   );
 
   React.useEffect(() => {
@@ -93,6 +98,8 @@ export function FetchingWrappedAssetCard(props: FetchingWrappedAssetCardProps) {
       onEdit,
       onRemove,
       useLocalizedEntityStatus: props.sdk.parameters.instance.useLocalizedEntityStatus,
+      localesStatusMap,
+      activeLocales: props.sdk.parameters.instance.activeLocales,
       isLocalized: !!('localized' in props.sdk.field && props.sdk.field.localized), // missing in types :(
     };
 

--- a/packages/reference/src/assets/WrappedAssetCard/WrappedAssetCard.tsx
+++ b/packages/reference/src/assets/WrappedAssetCard/WrappedAssetCard.tsx
@@ -101,7 +101,6 @@ export const WrappedAssetCard = (props: WrappedAssetCardProps) => {
         <EntityStatusBadge
           getEntityScheduledActions={props.getEntityScheduledActions}
           entityType="Asset"
-          entityId={props.asset.sys.id}
           status={status}
           useLocalizedEntityStatus={props.useLocalizedEntityStatus}
           entity={props.asset}

--- a/packages/reference/src/assets/WrappedAssetCard/WrappedAssetCard.tsx
+++ b/packages/reference/src/assets/WrappedAssetCard/WrappedAssetCard.tsx
@@ -1,10 +1,11 @@
 import * as React from 'react';
 
 import { SpaceAPI } from '@contentful/app-sdk';
-import { AssetCard, Badge } from '@contentful/f36-components';
-import { entityHelpers } from '@contentful/field-editor-shared';
+import { AssetCard } from '@contentful/f36-components';
+import { entityHelpers, LocalePublishStatusMap } from '@contentful/field-editor-shared';
 // @ts-expect-error
 import mimetype from '@contentful/mimetype';
+import { LocaleProps } from 'contentful-management';
 
 import { EntityStatusBadge, MissingAssetCard } from '../../components';
 import { Asset, File, RenderDragFn } from '../../types';
@@ -40,6 +41,8 @@ export interface WrappedAssetCardProps {
   isClickable: boolean;
   useLocalizedEntityStatus?: boolean;
   isLocalized?: boolean;
+  localesStatusMap?: LocalePublishStatusMap;
+  activeLocales?: LocaleProps[];
 }
 
 const defaultProps = {
@@ -100,12 +103,11 @@ export const WrappedAssetCard = (props: WrappedAssetCardProps) => {
           entityType="Asset"
           entityId={props.asset.sys.id}
           status={status}
+          useLocalizedEntityStatus={props.useLocalizedEntityStatus}
+          entity={props.asset}
+          localesStatusMap={props.localesStatusMap}
+          activeLocales={props.activeLocales}
         />
-      }
-      icon={
-        !props.isLocalized && props.useLocalizedEntityStatus ? (
-          <Badge variant="secondary">Default</Badge>
-        ) : null
       }
       src={
         entityFile && entityFile.url

--- a/packages/reference/src/assets/WrappedAssetCard/WrappedAssetLink.tsx
+++ b/packages/reference/src/assets/WrappedAssetCard/WrappedAssetLink.tsx
@@ -1,7 +1,13 @@
 import * as React from 'react';
 
 import { EntryCard } from '@contentful/f36-components';
-import { entityHelpers, isValidImage, SpaceAPI } from '@contentful/field-editor-shared';
+import {
+  entityHelpers,
+  isValidImage,
+  LocalePublishStatusMap,
+  SpaceAPI,
+} from '@contentful/field-editor-shared';
+import { LocaleProps } from 'contentful-management';
 
 import { AssetThumbnail, EntityStatusBadge, MissingAssetCard } from '../../components';
 import { Asset, RenderDragFn } from '../../types';
@@ -19,6 +25,8 @@ export interface WrappedAssetLinkProps {
   onRemove: () => void;
   renderDragHandle?: RenderDragFn;
   useLocalizedEntityStatus?: boolean;
+  localesStatusMap?: LocalePublishStatusMap;
+  activeLocales?: LocaleProps[];
 }
 
 export const WrappedAssetLink = (props: WrappedAssetLinkProps) => {
@@ -58,6 +66,10 @@ export const WrappedAssetLink = (props: WrappedAssetLinkProps) => {
           entityType="Asset"
           entityId={props.asset.sys.id}
           status={status}
+          useLocalizedEntityStatus={props.useLocalizedEntityStatus}
+          entity={props.asset}
+          localesStatusMap={props.localesStatusMap}
+          activeLocales={props.activeLocales}
         />
       }
       thumbnailElement={

--- a/packages/reference/src/assets/WrappedAssetCard/WrappedAssetLink.tsx
+++ b/packages/reference/src/assets/WrappedAssetCard/WrappedAssetLink.tsx
@@ -64,7 +64,6 @@ export const WrappedAssetLink = (props: WrappedAssetLinkProps) => {
         <EntityStatusBadge
           getEntityScheduledActions={props.getEntityScheduledActions}
           entityType="Asset"
-          entityId={props.asset.sys.id}
           status={status}
           useLocalizedEntityStatus={props.useLocalizedEntityStatus}
           entity={props.asset}

--- a/packages/reference/src/common/customCardTypes.ts
+++ b/packages/reference/src/common/customCardTypes.ts
@@ -1,5 +1,8 @@
 import * as React from 'react';
 
+import { LocalePublishStatusMap } from '@contentful/field-editor-shared';
+import { LocaleProps } from 'contentful-management';
+
 import { Asset, ContentType, Entry, RenderDragFn } from '../types';
 import { CustomActionProps } from './ReferenceEditor';
 
@@ -42,4 +45,6 @@ export type CustomEntityCardProps = {
 
   isLocalized?: boolean;
   useLocalizedEntityStatus?: boolean;
+  localesStatusMap?: LocalePublishStatusMap;
+  activeLocales?: LocaleProps[];
 };

--- a/packages/reference/src/components/EntityStatusBadge/EntityStatusBadge.tsx
+++ b/packages/reference/src/components/EntityStatusBadge/EntityStatusBadge.tsx
@@ -10,7 +10,7 @@ import {
 } from '../ScheduledIconWithTooltip/ScheduledIconWithTooltip';
 import { ScheduleTooltip } from '../ScheduledIconWithTooltip/ScheduleTooltip';
 
-type EntityStatusBadgeProps = UseScheduledActionsProps & {
+type EntityStatusBadgeProps = Omit<UseScheduledActionsProps, 'entityId'> & {
   status: EntityStatus;
   entity: EntryProps | AssetProps;
   useLocalizedEntityStatus?: boolean;
@@ -19,7 +19,6 @@ type EntityStatusBadgeProps = UseScheduledActionsProps & {
 };
 
 export function EntityStatusBadge({
-  entityId,
   entityType,
   getEntityScheduledActions,
   status,
@@ -30,7 +29,7 @@ export function EntityStatusBadge({
   ...props
 }: EntityStatusBadgeProps) {
   const { isError, isLoading, jobs } = useScheduledActions({
-    entityId,
+    entityId: entity.sys.id,
     entityType,
     getEntityScheduledActions,
   });

--- a/packages/reference/src/components/EntityStatusBadge/EntityStatusBadge.tsx
+++ b/packages/reference/src/components/EntityStatusBadge/EntityStatusBadge.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 
 import { EntityStatusBadge as StatusBadge, type EntityStatus } from '@contentful/f36-components';
+import { LocalePublishingPopover, LocalePublishStatusMap } from '@contentful/field-editor-shared';
+import { EntryProps, LocaleProps, AssetProps } from 'contentful-management';
 
 import {
   useScheduledActions,
@@ -10,6 +12,10 @@ import { ScheduleTooltip } from '../ScheduledIconWithTooltip/ScheduleTooltip';
 
 type EntityStatusBadgeProps = UseScheduledActionsProps & {
   status: EntityStatus;
+  entity: EntryProps | AssetProps;
+  useLocalizedEntityStatus?: boolean;
+  localesStatusMap?: LocalePublishStatusMap;
+  activeLocales?: LocaleProps[];
 };
 
 export function EntityStatusBadge({
@@ -17,6 +23,10 @@ export function EntityStatusBadge({
   entityType,
   getEntityScheduledActions,
   status,
+  useLocalizedEntityStatus,
+  localesStatusMap,
+  activeLocales,
+  entity,
   ...props
 }: EntityStatusBadgeProps) {
   const { isError, isLoading, jobs } = useScheduledActions({
@@ -24,6 +34,18 @@ export function EntityStatusBadge({
     entityType,
     getEntityScheduledActions,
   });
+
+  if (useLocalizedEntityStatus && activeLocales && localesStatusMap) {
+    return (
+      <LocalePublishingPopover
+        entity={entity}
+        jobs={jobs}
+        isScheduled={jobs.length !== 0}
+        localesStatusMap={localesStatusMap}
+        activeLocales={activeLocales}
+      />
+    );
+  }
 
   if (isError || isLoading || jobs.length === 0) {
     return <StatusBadge {...props} entityStatus={status} />;

--- a/packages/reference/src/entries/WrappedEntryCard/FetchingWrappedEntryCard.tsx
+++ b/packages/reference/src/entries/WrappedEntryCard/FetchingWrappedEntryCard.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
 import { EntryCard } from '@contentful/f36-components';
+import { useAsyncLocalePublishStatus } from '@contentful/field-editor-shared';
 import { EntryProps } from 'contentful-management';
 import get from 'lodash/get';
 
@@ -62,6 +63,10 @@ export function FetchingWrappedEntryCard(props: EntryCardReferenceEditorProps) {
   const loadEntityScheduledActions = React.useCallback(
     () => getEntityScheduledActions('Entry', props.entryId),
     [getEntityScheduledActions, props.entryId]
+  );
+  const localesStatusMap = useAsyncLocalePublishStatus(
+    entry,
+    props.sdk.parameters.instance.privateLocales
   );
 
   const size = props.viewType === 'link' ? 'small' : 'default';
@@ -143,6 +148,8 @@ export function FetchingWrappedEntryCard(props: EntryCardReferenceEditorProps) {
       onMoveBottom: props.onMoveBottom,
       isBeingDragged: props.isBeingDragged,
       useLocalizedEntityStatus: props.sdk.parameters.instance.useLocalizedEntityStatus,
+      localesStatusMap,
+      activeLocales: props.sdk.parameters.instance.activeLocales,
       isLocalized: !!('localized' in props.sdk.field && props.sdk.field.localized), // missing in types :(
     };
 

--- a/packages/reference/src/entries/WrappedEntryCard/WrappedEntryCard.tsx
+++ b/packages/reference/src/entries/WrappedEntryCard/WrappedEntryCard.tsx
@@ -1,8 +1,13 @@
 import * as React from 'react';
 
 import { SpaceAPI } from '@contentful/app-sdk';
-import { EntryCard, MenuItem, MenuDivider, Badge } from '@contentful/f36-components';
-import { entityHelpers, isValidImage } from '@contentful/field-editor-shared';
+import { EntryCard, MenuItem, MenuDivider } from '@contentful/f36-components';
+import {
+  entityHelpers,
+  isValidImage,
+  LocalePublishStatusMap,
+} from '@contentful/field-editor-shared';
+import { LocaleProps } from 'contentful-management';
 
 import { AssetThumbnail, MissingEntityCard, EntityStatusBadge } from '../../components';
 import { SpaceName } from '../../components/SpaceName/SpaceName';
@@ -35,6 +40,8 @@ export interface WrappedEntryCardProps {
 
   isLocalized?: boolean;
   useLocalizedEntityStatus?: boolean;
+  localesStatusMap?: LocalePublishStatusMap;
+  activeLocales?: LocaleProps[];
 }
 
 const defaultProps = {
@@ -124,6 +131,10 @@ export function WrappedEntryCard(props: WrappedEntryCardProps) {
           entityId={props.entry.sys.id}
           entityType="Entry"
           getEntityScheduledActions={props.getEntityScheduledActions}
+          useLocalizedEntityStatus={props.useLocalizedEntityStatus}
+          entity={props.entry}
+          localesStatusMap={props.localesStatusMap}
+          activeLocales={props.activeLocales}
         />
       }
       icon={
@@ -132,8 +143,6 @@ export function WrappedEntryCard(props: WrappedEntryCardProps) {
             spaceName={props.spaceName}
             environmentName={props.entry.sys.environment.sys.id}
           />
-        ) : !props.isLocalized && props.useLocalizedEntityStatus ? (
-          <Badge variant="secondary">Default</Badge>
         ) : null
       }
       thumbnailElement={file && isValidImage(file) ? <AssetThumbnail file={file} /> : undefined}

--- a/packages/reference/src/entries/WrappedEntryCard/WrappedEntryCard.tsx
+++ b/packages/reference/src/entries/WrappedEntryCard/WrappedEntryCard.tsx
@@ -128,7 +128,6 @@ export function WrappedEntryCard(props: WrappedEntryCardProps) {
       badge={
         <EntityStatusBadge
           status={status}
-          entityId={props.entry.sys.id}
           entityType="Entry"
           getEntityScheduledActions={props.getEntityScheduledActions}
           useLocalizedEntityStatus={props.useLocalizedEntityStatus}


### PR DESCRIPTION
## Description
- localised entity status popover badge for reference cards (asset and entry)
- remove 'default' badge for references that are not localised. We don't need this anymore since here we will also show the stacked badge

## Approach

- We pass `privateLocales` and `activeLocales` to the widget renderer using the widget API sdk props (internal).
- We also moved the `useAsyncLocalePublishStatus` fn to the `shared` package, so we can use it in the webapp and in the `reference` package to determine the locale status for each reference


### Demo

#### Single reference
<img width="945" alt="Screenshot 2024-10-10 at 14 13 17" src="https://github.com/user-attachments/assets/f78a7a1c-f03f-49b8-8341-b9f7cc097a6c">

#### Multi reference
<img width="934" alt="Screenshot 2024-10-10 at 14 13 58" src="https://github.com/user-attachments/assets/4b224ff5-2f1a-4360-b982-02b699964f79">

#### Asset link
<img width="932" alt="Screenshot 2024-10-10 at 14 46 12" src="https://github.com/user-attachments/assets/6b65cbd2-5baf-4be0-9b61-0755989d16f4">

#### Asset Gallery
<img width="439" alt="Screenshot 2024-10-10 at 14 46 20" src="https://github.com/user-attachments/assets/9964de4b-faa5-4ae6-8445-516fa8152596">