### PR TITLE
feat: bring useAsyncLocalePublishStatus function [TOL-2454]

### DIFF
--- a/packages/_shared/package.json
+++ b/packages/_shared/package.json
@@ -36,7 +36,8 @@
   },
   "devDependencies": {
     "@contentful/app-sdk": "^4.29.0",
-    "@contentful/field-editor-test-utils": "^1.5.2"
+    "@contentful/field-editor-test-utils": "^1.5.2",
+    "@testing-library/react": "16.0.1"
   },
   "dependencies": {
     "@contentful/f36-components": "^4.70.0",

--- a/packages/_shared/src/FieldConnector.test.tsx
+++ b/packages/_shared/src/FieldConnector.test.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 import { createFakeFieldAPI } from '@contentful/field-editor-test-utils';
-import { render } from '@testing-library/react';
+import { act, render } from '@testing-library/react';
 import noop from 'lodash/noop';
 
 import { FieldConnector, FieldConnectorChildProps } from './FieldConnector';
 
-it('does not rerender with outdated value after calling setValue', () => {
+it('does not rerender with outdated value after calling setValue', async () => {
   function getChild(): FieldConnectorChildProps<any> {
     return props.children.mock.calls[props.children.mock.calls.length - 1][0];
   }
@@ -34,7 +34,9 @@ it('does not rerender with outdated value after calling setValue', () => {
   expect(child.value).toBe('initial value');
   const initialRenderCount = props.children.mock.calls.length;
 
-  child.setValue('new value');
+  await act(async () => {
+    child.setValue('new value');
+  });
 
   onSchemaErrorsChanged.mock.calls.forEach(([cb]) => cb([]));
 

--- a/packages/_shared/src/LocalePublishingEntityStatusBadge/LocalePublishingPopover.tsx
+++ b/packages/_shared/src/LocalePublishingEntityStatusBadge/LocalePublishingPopover.tsx
@@ -16,6 +16,7 @@ import type {
 } from 'contentful-management';
 import { cx, css } from 'emotion';
 
+import { LocalePublishStatusMap } from '../hooks/useAsyncLocalePublishStatus';
 import * as entityHelpers from '../utils/entityHelpers';
 import { LocalePublishingStatusList } from './LocalePublishingStatusList';
 import { ScheduledBanner } from './ScheduledBanner';
@@ -159,12 +160,6 @@ const determineBadgeStatus = (
       return { primary: 'draft', secondary: 'draft' };
   }
 };
-
-export type LocalePublishStatus = {
-  status: 'draft' | 'published' | 'changed';
-  locale: LocaleProps;
-};
-export type LocalePublishStatusMap = Map<string, LocalePublishStatus>;
 
 type LocalePublishingPopoverProps = {
   entity: EntryProps | AssetProps;

--- a/packages/_shared/src/LocalePublishingEntityStatusBadge/LocalePublishingStatusList.tsx
+++ b/packages/_shared/src/LocalePublishingEntityStatusBadge/LocalePublishingStatusList.tsx
@@ -4,13 +4,12 @@ import { MenuSectionTitle } from '@contentful/f36-components';
 import type { LocaleProps } from 'contentful-management';
 import { sortBy } from 'lodash';
 
-import { Banner } from './Banner';
 import type {
   LocalePublishStatusMap,
   LocalePublishStatus as LocalePublishStatusType,
-} from './LocalePublishingPopover';
+} from '../hooks/useAsyncLocalePublishStatus';
+import { Banner } from './Banner';
 import { LocalePublishingStatus } from './LocalePublishingStatus';
-
 
 function groupAndSortLocales(
   entries: [string, LocalePublishStatusType][],

--- a/packages/_shared/src/hooks/useAsyncLocalePublishStatus.spec.tsx
+++ b/packages/_shared/src/hooks/useAsyncLocalePublishStatus.spec.tsx
@@ -1,0 +1,182 @@
+import { renderHook } from '@testing-library/react-hooks';
+
+import { useAsyncLocalePublishStatus } from './useAsyncLocalePublishStatus';
+
+describe('useAsyncLocalePublishStatus', () => {
+  const enUS = {
+    code: 'en-US',
+    name: 'en-US',
+    internal_code: 'en-US',
+    fallbackCode: null,
+    default: false,
+    contentManagementApi: true,
+    contentDeliveryApi: true,
+    optional: false,
+    sys: {
+      type: 'Locale',
+      id: 'en-US',
+      version: 1,
+      space: { sys: { type: 'Link', linkType: 'Space', id: 'test-xokbvvklfw' } },
+      environment: { sys: { type: 'Link', linkType: 'Environment', id: 'test-ak19mszr76' } },
+      createdBy: { sys: { type: 'Link', linkType: 'User', id: 'test-0olok52c12' } },
+      createdAt: '2017-01-23T10:17:55Z',
+      updatedBy: { sys: { type: 'Link', linkType: 'User', id: 'test-0olok52c12' } },
+      updatedAt: '2017-01-23T10:17:55Z',
+    },
+  };
+  const deDE = {
+    code: 'de-DE',
+    name: 'de-DE',
+    internal_code: 'de-DE',
+    fallbackCode: null,
+    default: false,
+    contentManagementApi: true,
+    contentDeliveryApi: true,
+    optional: false,
+    sys: {
+      type: 'Locale',
+      id: 'de-DE',
+      version: 1,
+      space: { sys: { type: 'Link', linkType: 'Space', id: 'test-tnw0g6rujf' } },
+      environment: { sys: { type: 'Link', linkType: 'Environment', id: 'test-wisyjo6pk4' } },
+      createdBy: { sys: { type: 'Link', linkType: 'User', id: 'test-j63uqcmqlx' } },
+      createdAt: '2017-01-23T10:17:55Z',
+      updatedBy: { sys: { type: 'Link', linkType: 'User', id: 'test-j63uqcmqlx' } },
+      updatedAt: '2017-01-23T10:17:55Z',
+    },
+  };
+  const esES = {
+    code: 'es-ES',
+    name: 'es-ES',
+    internal_code: 'es-ES',
+    fallbackCode: null,
+    default: false,
+    contentManagementApi: true,
+    contentDeliveryApi: true,
+    optional: false,
+    sys: {
+      type: 'Locale',
+      id: 'es-ES',
+      version: 1,
+      space: { sys: { type: 'Link', linkType: 'Space', id: 'test-h0e5p83kvo' } },
+      environment: { sys: { type: 'Link', linkType: 'Environment', id: 'test-extqkvjiub' } },
+      createdBy: { sys: { type: 'Link', linkType: 'User', id: 'test-1xpsnz99fa' } },
+      createdAt: '2017-01-23T10:17:55Z',
+      updatedBy: { sys: { type: 'Link', linkType: 'User', id: 'test-1xpsnz99fa' } },
+      updatedAt: '2017-01-23T10:17:55Z',
+    },
+  };
+
+  describe('status from entity', () => {
+    it('returns the status from an entry', () => {
+      const entity = {
+        metadata: { tags: [] },
+        sys: {
+          id: '1',
+          type: 'Entry',
+          createdAt: '2017-12-07T10:48:41Z',
+          createdBy: { sys: { type: 'Link', linkType: 'User', id: 'test-u1dc0g7uzh' } },
+          updatedAt: '2017-12-07T10:48:41Z',
+          updatedBy: { sys: { type: 'Link', linkType: 'User', id: 'test-u1dc0g7uzh' } },
+          space: { sys: { type: 'Link', linkType: 'Space', id: 'test-vllzslv98d' } },
+          environment: { sys: { type: 'Link', linkType: 'Environment', id: 'test-y0ftcnn4eq' } },
+          publishedCounter: 0,
+          version: 1,
+          fieldStatus: { '*': { 'en-US': 'published', 'de-DE': 'changed', 'es-ES': 'draft' } },
+          contentType: { sys: { type: 'Link', linkType: 'ContentType', id: 'content-type' } },
+          automationTags: [],
+        },
+        fields: {},
+      };
+
+      const { result } = renderHook(() => useAsyncLocalePublishStatus(entity, [enUS, deDE, esES]));
+
+      expect(result.current).toEqual(
+        new Map([
+          ['en-US', { status: 'published', locale: enUS }],
+          ['de-DE', { status: 'changed', locale: deDE }],
+          ['es-ES', { status: 'draft', locale: esES }],
+        ])
+      );
+    });
+
+    it('returns the status from an asset', () => {
+      const entity = {
+        sys: {
+          id: '2',
+          type: 'Asset',
+          version: 1,
+          createdAt: '2017-12-07T10:48:41Z',
+          createdBy: { sys: { type: 'Link', linkType: 'User', id: 'test-5im75v0tq3' } },
+          updatedAt: '2017-12-07T10:48:41Z',
+          updatedBy: { sys: { type: 'Link', linkType: 'User', id: 'test-5im75v0tq3' } },
+          space: { sys: { type: 'Link', linkType: 'Space', id: 'test-xjlsyao0to' } },
+          environment: { sys: { type: 'Link', linkType: 'Environment', id: 'test-cyscfldxt8' } },
+          contentType: {
+            sys: {
+              type: 'Link',
+              linkType: 'ContentType',
+              id: 'contentful-builtin-asset-content-type',
+            },
+          },
+          fieldStatus: { '*': { 'en-US': 'changed', 'de-DE': 'draft', 'es-ES': 'published' } },
+        },
+        fields: {
+          title: { 'en-US': 'Title for id 2' },
+          description: { 'en-US': 'Description for id 2' },
+          file: { 'en-US': { fileName: '2.txt', contentType: 'text/plain' } },
+        },
+      };
+
+      const { result } = renderHook(() => useAsyncLocalePublishStatus(entity, [enUS, deDE, esES]));
+
+      expect(result.current).toEqual(
+        new Map([
+          ['en-US', { status: 'changed', locale: enUS }],
+          ['de-DE', { status: 'draft', locale: deDE }],
+          ['es-ES', { status: 'published', locale: esES }],
+        ])
+      );
+    });
+
+    it('falls back to the entity status for entries if no fieldStatus is present', () => {
+      const entity = {
+        metadata: { tags: [] },
+        sys: {
+          id: '1',
+          type: 'Entry',
+          createdAt: '2017-12-07T10:48:41Z',
+          createdBy: { sys: { type: 'Link', linkType: 'User', id: 'test-jm5uw542jo' } },
+          updatedAt: '2017-12-07T10:48:41Z',
+          updatedBy: { sys: { type: 'Link', linkType: 'User', id: 'test-jm5uw542jo' } },
+          space: { sys: { type: 'Link', linkType: 'Space', id: 'test-tyjchr7iyp' } },
+          environment: { sys: { type: 'Link', linkType: 'Environment', id: 'test-01ovjmre16' } },
+          publishedCounter: 0,
+          version: 1,
+          contentType: { sys: { type: 'Link', linkType: 'ContentType', id: 'content-type' } },
+          automationTags: [],
+          publishedVersion: 1,
+        },
+        fields: {},
+      };
+
+      const { result } = renderHook(() => useAsyncLocalePublishStatus(entity, [enUS, deDE, esES]));
+
+      expect(result.current).toEqual(
+        new Map([
+          ['en-US', { status: 'published', locale: enUS }],
+          ['de-DE', { status: 'published', locale: deDE }],
+          ['es-ES', { status: 'published', locale: esES }],
+        ])
+      );
+    });
+
+    it('returns undefined as publishStatus if there is no entity provided', () => {
+      const { result } = renderHook(() =>
+        useAsyncLocalePublishStatus(undefined, [enUS, deDE, esES])
+      );
+
+      expect(result.current).toBeUndefined();
+    });
+  });
+});

--- a/packages/_shared/src/hooks/useAsyncLocalePublishStatus.ts
+++ b/packages/_shared/src/hooks/useAsyncLocalePublishStatus.ts
@@ -1,0 +1,51 @@
+import { useMemo } from 'react';
+
+import type { AssetProps, EntryProps, LocaleProps } from 'contentful-management/types';
+
+import * as entityHelpers from '../utils/entityHelpers';
+
+export type LocalePublishStatus = {
+  status: 'draft' | 'published' | 'changed';
+  locale: LocaleProps;
+};
+export type LocalePublishStatusMap = Map<string, LocalePublishStatus>;
+
+function getLocalePublishStatusMap(entity: AssetProps | EntryProps, locales: LocaleProps[]) {
+  const entityStatus = entityHelpers.getEntityStatus(entity.sys);
+
+  if (['archived', 'deleted'].includes(entityStatus)) {
+    return;
+  }
+
+  const statusMap: LocalePublishStatusMap = new Map(
+    locales.map((locale) => [
+      locale.code,
+      {
+        // save to cast as archived and deleted are already handled before
+        status: entityHelpers.getEntityStatus(entity.sys, locale.code) as
+          | 'draft'
+          | 'published'
+          | 'changed',
+        locale,
+      },
+    ])
+  );
+
+  return statusMap;
+}
+
+/**
+ * Get the publish status for each locale
+ */
+export function useAsyncLocalePublishStatus(
+  entity?: AssetProps | EntryProps,
+  privateLocales?: LocaleProps[] | null
+): LocalePublishStatusMap | undefined {
+  return useMemo(() => {
+    if (entity && privateLocales) {
+      return getLocalePublishStatusMap(entity, privateLocales);
+    }
+
+    return undefined;
+  }, [entity, privateLocales]);
+}

--- a/packages/_shared/src/index.tsx
+++ b/packages/_shared/src/index.tsx
@@ -26,6 +26,7 @@ export { PredefinedValuesError } from './PredefinedValuesError';
 export { Asset, Entry, File } from './typesEntity';
 export { isValidImage } from './utils/isValidImage';
 export { shortenStorageUnit, toLocaleString } from './utils/shortenStorageUnit';
+export * from './hooks/useAsyncLocalePublishStatus';
 export { ModalDialogLauncher };
 export { entityHelpers };
 export { ConstraintsUtils };

--- a/yarn.lock
+++ b/yarn.lock
@@ -5984,6 +5984,13 @@
     "@testing-library/dom" "^8.0.0"
     "@types/react-dom" "<18.0.0"
 
+"@testing-library/react@16.0.1":
+  version "16.0.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-16.0.1.tgz#29c0ee878d672703f5e7579f239005e4e0faa875"
+  integrity sha512-dSmwJVtJXmku+iocRhWOUFbrERC76TX2Mnf0ATODz8brzAZrMBbzLwQixlBSanZxR6LddK3eiwpSFZgDET1URg==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+
 "@testing-library/user-event@^13.1.9":
   version "13.5.0"
   resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-13.5.0.tgz#69d77007f1e124d55314a2b73fd204b333b13295"


### PR DESCRIPTION
Bring in `useAsyncLocalePublishStatus` that can calculate the locale publishing status map for an entity. We will use this hook in the webapp and in other packages in field editors. Later on we might also use it in the entity search package.

⚠️ This is mostly copy-paste code from webapp