### PR TITLE
feat: localized entity status in rich text [TOL-2454]

### DIFF
--- a/packages/rich-text/src/plugins/shared/FetchingWrappedAssetCard.tsx
+++ b/packages/rich-text/src/plugins/shared/FetchingWrappedAssetCard.tsx
@@ -8,6 +8,10 @@ import {
   MissingEntityCard,
   WrappedAssetCard,
 } from '@contentful/field-editor-reference';
+import {
+  LocalePublishStatusMap,
+  useAsyncLocalePublishStatus,
+} from '@contentful/field-editor-shared';
 import areEqual from 'fast-deep-equal';
 
 interface InternalAssetCardProps {
@@ -19,6 +23,7 @@ interface InternalAssetCardProps {
   onRemove?: () => unknown;
   sdk: FieldAppSDK;
   loadEntityScheduledActions: (entityType: string, entityId: string) => Promise<ScheduledAction[]>;
+  localesStatusMap?: LocalePublishStatusMap;
 }
 
 const InternalAssetCard = React.memo(
@@ -36,6 +41,8 @@ const InternalAssetCard = React.memo(
       isClickable={false}
       useLocalizedEntityStatus={props.sdk.parameters.instance.useLocalizedEntityStatus}
       isLocalized={!!('localized' in props.sdk.field && props.sdk.field.localized)}
+      localesStatusMap={props.localesStatusMap}
+      activeLocales={props.sdk.parameters.instance.activeLocales}
     />
   ),
   areEqual
@@ -61,6 +68,10 @@ export function FetchingWrappedAssetCard(props: FetchingWrappedAssetCardProps) {
   const loadEntityScheduledActions = React.useCallback(
     () => getEntityScheduledActions('Asset', props.assetId),
     [getEntityScheduledActions, props.assetId]
+  );
+  const localesStatusMap = useAsyncLocalePublishStatus(
+    asset,
+    props.sdk.parameters.instance.privateLocales
   );
 
   React.useEffect(() => {
@@ -93,6 +104,7 @@ export function FetchingWrappedAssetCard(props: FetchingWrappedAssetCardProps) {
       locale={props.locale}
       onEdit={props.onEdit}
       onRemove={props.onRemove}
+      localesStatusMap={localesStatusMap}
     />
   );
 }

--- a/packages/rich-text/src/plugins/shared/FetchingWrappedEntryCard.tsx
+++ b/packages/rich-text/src/plugins/shared/FetchingWrappedEntryCard.tsx
@@ -9,6 +9,10 @@ import {
   WrappedEntryCard,
   useEntityLoader,
 } from '@contentful/field-editor-reference';
+import {
+  LocalePublishStatusMap,
+  useAsyncLocalePublishStatus,
+} from '@contentful/field-editor-shared';
 import areEqual from 'fast-deep-equal';
 
 interface InternalEntryCard {
@@ -20,6 +24,7 @@ interface InternalEntryCard {
   entry: Entry;
   onEdit?: VoidFunction;
   onRemove?: VoidFunction;
+  localesStatusMap?: LocalePublishStatusMap;
 }
 
 const InternalEntryCard = React.memo((props: InternalEntryCard) => {
@@ -45,6 +50,8 @@ const InternalEntryCard = React.memo((props: InternalEntryCard) => {
       isClickable={false}
       useLocalizedEntityStatus={sdk.parameters.instance.useLocalizedEntityStatus}
       isLocalized={!!('localized' in props.sdk.field && props.sdk.field.localized)}
+      localesStatusMap={props.localesStatusMap}
+      activeLocales={props.sdk.parameters.instance.activeLocales}
     />
   );
 }, areEqual);
@@ -69,6 +76,10 @@ export const FetchingWrappedEntryCard = (props: FetchingWrappedEntryCardProps) =
   const loadEntityScheduledActions = React.useCallback(
     () => getEntityScheduledActions('Entry', entryId),
     [getEntityScheduledActions, entryId]
+  );
+  const localesStatusMap = useAsyncLocalePublishStatus(
+    entry,
+    props.sdk.parameters.instance.privateLocales
   );
 
   React.useEffect(() => {
@@ -101,6 +112,7 @@ export const FetchingWrappedEntryCard = (props: FetchingWrappedEntryCardProps) =
       onEdit={props.onEdit}
       onRemove={props.onRemove}
       loadEntityScheduledActions={loadEntityScheduledActions}
+      localesStatusMap={localesStatusMap}
     />
   );
 };


### PR DESCRIPTION
Bring localized entity status to the rich text editor (for embedded references)

<img width="983" alt="Screenshot 2024-10-11 at 09 00 53" src="https://github.com/user-attachments/assets/22ef8a86-306b-489e-9bd8-372d05d3bace">
