### PR TITLE
refactor(Slug): remove z-index to prevent overlap [CFISO-1949]

### DIFF
--- a/packages/slug/src/styles.ts
+++ b/packages/slug/src/styles.ts
@@ -21,7 +21,6 @@ export const icon = css({
   position: 'absolute',
   left: '10px',
   top: '8px',
-  zIndex: 2,
   width: '25px',
   height: '25px',
   fill: tokens.gray500,
@@ -29,7 +28,6 @@ export const icon = css({
 
 export const spinnerContainer = css({
   position: 'absolute',
-  zIndex: 2,
   right: '8px',
   top: '8px',
 });


### PR DESCRIPTION
To prevent the overlap with the entity editor tabs stickiness introduced in https://github.com/contentful/user_interface/pull/23688.

![2024-10-10 17 15 01](https://github.com/user-attachments/assets/e4ee3958-71b0-4510-8d66-3777d1dd2d5f)

---

Removing the `z-index` does not have any impact on the icon or spinner loader visibility.