### PR TITLE
feat(Rich Text Editor): add sticky offset property

### DIFF
--- a/packages/rich-text/src/RichTextEditor.tsx
+++ b/packages/rich-text/src/RichTextEditor.tsx
@@ -49,6 +49,7 @@ type ConnectedRichTextProps = {
   isDisabled?: boolean;
   isToolbarHidden?: boolean;
   actionsDisabled?: boolean;
+  stickyToolbarOffset?: number;
 };
 
 export const ConnectedRichTextEditor = (props: ConnectedRichTextProps) => {
@@ -94,7 +95,10 @@ export const ConnectedRichTextEditor = (props: ConnectedRichTextProps) => {
               disableCorePlugins={disableCorePlugins}
             >
               {!props.isToolbarHidden && (
-                <StickyToolbarWrapper isDisabled={props.isDisabled}>
+                <StickyToolbarWrapper
+                  isDisabled={props.isDisabled}
+                  offset={props.stickyToolbarOffset}
+                >
                   <Toolbar isDisabled={props.isDisabled} />
                 </StickyToolbarWrapper>
               )}

--- a/packages/rich-text/src/Toolbar/components/StickyToolbarWrapper.tsx
+++ b/packages/rich-text/src/Toolbar/components/StickyToolbarWrapper.tsx
@@ -3,21 +3,22 @@ import React, { ReactNode } from 'react';
 import { css } from 'emotion';
 
 const styles = {
-  nativeSticky: css`
+  nativeSticky: (offset?: number) => css`
     position: -webkit-sticky;
     position: sticky;
-    top: -1px;
+    top: ${offset ? offset : -1}px;
     z-index: 2;
   `,
 };
 
 type StickyToolbarProps = {
   isDisabled?: boolean;
+  offset?: number;
   children: ReactNode;
 };
 
-const StickyToolbarWrapper = ({ isDisabled, children }: StickyToolbarProps) => (
-  <div className={isDisabled ? '' : styles.nativeSticky}>{children}</div>
+const StickyToolbarWrapper = ({ isDisabled, offset, children }: StickyToolbarProps) => (
+  <div className={isDisabled ? '' : styles.nativeSticky(offset)}>{children}</div>
 );
 
 export default StickyToolbarWrapper;


### PR DESCRIPTION
Having the sticky entity editor tabs in the web app requires having a customizable offset for the Rich Text Editor sticky toolbar to ensure it stays visible when scrolling and not hidden behind the tabs.

**Before**

The toolbar is sticky behind the tabs.

https://github.com/user-attachments/assets/0935d43e-8582-42ab-bf84-2e0965126f82

**After**

Adding the offset value matching the tabs' height ensures the toolbar stays visible.

https://github.com/user-attachments/assets/b190189e-bc10-4da7-8b13-30bd5f49eb09