### PR TITLE
feat(shared): show stacked badge when status diff [TOL-2502]

### DIFF
--- a/packages/_shared/src/utils/entityHelpers.test.ts
+++ b/packages/_shared/src/utils/entityHelpers.test.ts
@@ -1,4 +1,6 @@
-import { getEntityStatus, type EntitySys } from './entityHelpers';
+import { LocalePublishStatus } from 'hooks/useLocalePublishStatus';
+
+import { getEntityStatus, hasDifferentLocaleStatuses, type EntitySys } from './entityHelpers';
 
 describe('getEntityStatus', () => {
   function createEntity(
@@ -173,6 +175,28 @@ describe('getEntityStatus', () => {
           expect(result).toEqual('draft');
         });
       });
+    });
+  });
+
+  describe('hasDifferentLocaleStatuses', () => {
+    test('returns false if all locales have the same status', () => {
+      const statusMap = new Map<string, LocalePublishStatus>([
+        ['en-US', { status: 'published', locale: { code: 'en-US' } as any }],
+        ['fr-FR', { status: 'published', locale: { code: 'fr-FR' } as any }],
+        ['de-DE', { status: 'published', locale: { code: 'de-DE' } as any }],
+      ]);
+
+      expect(hasDifferentLocaleStatuses(statusMap)).toBeFalsy();
+    });
+
+    test('returns true if locales have different statuses', () => {
+      const statusMap = new Map<string, LocalePublishStatus>([
+        ['en-US', { status: 'published', locale: { code: 'en-US' } as any }],
+        ['fr-FR', { status: 'draft', locale: { code: 'fr-FR' } as any }],
+        ['de-DE', { status: 'published', locale: { code: 'de-DE' } as any }],
+      ]);
+
+      expect(hasDifferentLocaleStatuses(statusMap)).toBeTruthy();
     });
   });
 });

--- a/packages/_shared/src/utils/entityHelpers.ts
+++ b/packages/_shared/src/utils/entityHelpers.ts
@@ -1,3 +1,4 @@
+import { LocalePublishStatusMap } from 'hooks/useLocalePublishStatus';
 import get from 'lodash/get';
 import isObject from 'lodash/isObject';
 
@@ -313,3 +314,32 @@ export const getEntryImage = async (
     return null;
   }
 };
+
+/**
+ * Checks if a locale status map contains different statuses across its locales
+ * Returns true if there are at least two different statuses (e.g. published and draft)
+ * @param localesStatusMap
+ * @returns boolean indicating if there are different statuses
+ */
+export function hasDifferentLocaleStatuses(
+  localesStatusMap: LocalePublishStatusMap | null
+): boolean {
+  if (!localesStatusMap) return false;
+
+  let firstStatus: string | undefined;
+
+  for (const localeStatus of localesStatusMap.values()) {
+    if (!localeStatus) continue;
+
+    if (firstStatus === undefined) {
+      firstStatus = localeStatus.status;
+      continue;
+    }
+
+    if (localeStatus.status !== firstStatus) {
+      return true;
+    }
+  }
+
+  return false;
+}

--- a/packages/reference/src/assets/WrappedAssetCard/FetchingWrappedAssetCard.tsx
+++ b/packages/reference/src/assets/WrappedAssetCard/FetchingWrappedAssetCard.tsx
@@ -98,6 +98,7 @@ export function FetchingWrappedAssetCard(props: FetchingWrappedAssetCardProps) {
       localesStatusMap,
       activeLocales: props.sdk.parameters.instance.activeLocales,
       isLocalized: !!('localized' in props.sdk.field && props.sdk.field.localized), // missing in types :(
+      shouldRetainLocaleHistory: props.sdk.parameters.instance.shouldRetainLocaleHistory,
     };
 
     if (props.viewType === 'link') {

--- a/packages/reference/src/assets/WrappedAssetCard/WrappedAssetCard.tsx
+++ b/packages/reference/src/assets/WrappedAssetCard/WrappedAssetCard.tsx
@@ -43,6 +43,7 @@ export interface WrappedAssetCardProps {
   isLocalized?: boolean;
   localesStatusMap?: LocalePublishStatusMap;
   activeLocales?: Pick<LocaleProps, 'code'>[];
+  shouldRetainLocaleHistory?: boolean;
 }
 
 const defaultProps = {
@@ -106,6 +107,7 @@ export const WrappedAssetCard = (props: WrappedAssetCardProps) => {
           entity={props.asset}
           localesStatusMap={props.localesStatusMap}
           activeLocales={props.activeLocales}
+          shouldRetainLocaleHistory={props.shouldRetainLocaleHistory}
         />
       }
       src={

--- a/packages/reference/src/assets/WrappedAssetCard/WrappedAssetLink.tsx
+++ b/packages/reference/src/assets/WrappedAssetCard/WrappedAssetLink.tsx
@@ -27,6 +27,7 @@ export interface WrappedAssetLinkProps {
   useLocalizedEntityStatus?: boolean;
   localesStatusMap?: LocalePublishStatusMap;
   activeLocales?: Pick<LocaleProps, 'code'>[];
+  shouldRetainLocaleHistory?: boolean;
 }
 
 export const WrappedAssetLink = (props: WrappedAssetLinkProps) => {
@@ -69,6 +70,7 @@ export const WrappedAssetLink = (props: WrappedAssetLinkProps) => {
           entity={props.asset}
           localesStatusMap={props.localesStatusMap}
           activeLocales={props.activeLocales}
+          shouldRetainLocaleHistory={props.shouldRetainLocaleHistory}
         />
       }
       thumbnailElement={

--- a/packages/reference/src/common/customCardTypes.ts
+++ b/packages/reference/src/common/customCardTypes.ts
@@ -47,4 +47,5 @@ export type CustomEntityCardProps = {
   useLocalizedEntityStatus?: boolean;
   localesStatusMap?: LocalePublishStatusMap;
   activeLocales?: Pick<LocaleProps, 'code'>[];
+  shouldRetainLocaleHistory?: boolean;
 };

--- a/packages/reference/src/components/EntityStatusBadge/EntityStatusBadge.tsx
+++ b/packages/reference/src/components/EntityStatusBadge/EntityStatusBadge.tsx
@@ -1,7 +1,11 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 
 import { EntityStatusBadge as StatusBadge, type EntityStatus } from '@contentful/f36-components';
-import { LocalePublishingPopover, LocalePublishStatusMap } from '@contentful/field-editor-shared';
+import {
+  LocalePublishingPopover,
+  LocalePublishStatusMap,
+  entityHelpers,
+} from '@contentful/field-editor-shared';
 import { EntryProps, LocaleProps, AssetProps } from 'contentful-management';
 
 import {
@@ -16,6 +20,7 @@ type EntityStatusBadgeProps = Omit<UseScheduledActionsProps, 'entityId'> & {
   useLocalizedEntityStatus?: boolean;
   localesStatusMap?: LocalePublishStatusMap;
   activeLocales?: Pick<LocaleProps, 'code'>[];
+  shouldRetainLocaleHistory?: boolean;
 };
 
 export function EntityStatusBadge({
@@ -26,6 +31,7 @@ export function EntityStatusBadge({
   localesStatusMap,
   activeLocales,
   entity,
+  shouldRetainLocaleHistory,
   ...props
 }: EntityStatusBadgeProps) {
   const { isError, isLoading, jobs } = useScheduledActions({
@@ -34,7 +40,12 @@ export function EntityStatusBadge({
     getEntityScheduledActions,
   });
 
-  if (useLocalizedEntityStatus && activeLocales && localesStatusMap) {
+  const hasMultipleStatuses = useMemo(
+    () => shouldRetainLocaleHistory && entityHelpers.hasDifferentLocaleStatuses(localesStatusMap),
+    [localesStatusMap, shouldRetainLocaleHistory]
+  );
+
+  if (useLocalizedEntityStatus || hasMultipleStatuses) {
     return (
       <LocalePublishingPopover
         entity={entity}

--- a/packages/reference/src/entries/WrappedEntryCard/FetchingWrappedEntryCard.tsx
+++ b/packages/reference/src/entries/WrappedEntryCard/FetchingWrappedEntryCard.tsx
@@ -148,6 +148,7 @@ export function FetchingWrappedEntryCard(props: EntryCardReferenceEditorProps) {
       localesStatusMap,
       activeLocales: props.sdk.parameters.instance.activeLocales,
       isLocalized: !!('localized' in props.sdk.field && props.sdk.field.localized), // missing in types :(
+      shouldRetainLocaleHistory: props.sdk.parameters.instance.shouldRetainLocaleHistory,
     };
 
     const { hasCardEditActions, hasCardMoveActions, hasCardRemoveActions } = props;

--- a/packages/reference/src/entries/WrappedEntryCard/WrappedEntryCard.tsx
+++ b/packages/reference/src/entries/WrappedEntryCard/WrappedEntryCard.tsx
@@ -42,6 +42,7 @@ export interface WrappedEntryCardProps {
   useLocalizedEntityStatus?: boolean;
   localesStatusMap?: LocalePublishStatusMap;
   activeLocales?: Pick<LocaleProps, 'code'>[];
+  shouldRetainLocaleHistory?: boolean;
 }
 
 const defaultProps = {
@@ -134,6 +135,7 @@ export function WrappedEntryCard(props: WrappedEntryCardProps) {
           entity={props.entry}
           localesStatusMap={props.localesStatusMap}
           activeLocales={props.activeLocales}
+          shouldRetainLocaleHistory={props.shouldRetainLocaleHistory}
         />
       }
       icon={

--- a/packages/rich-text/src/plugins/shared/FetchingWrappedAssetCard.tsx
+++ b/packages/rich-text/src/plugins/shared/FetchingWrappedAssetCard.tsx
@@ -40,6 +40,7 @@ const InternalAssetCard = React.memo(
       isLocalized={!!('localized' in props.sdk.field && props.sdk.field.localized)}
       localesStatusMap={props.localesStatusMap}
       activeLocales={props.sdk.parameters.instance.activeLocales}
+      shouldRetainLocaleHistory={props.sdk.parameters.instance.shouldRetainLocaleHistory}
     />
   ),
   areEqual

--- a/packages/rich-text/src/plugins/shared/FetchingWrappedEntryCard.tsx
+++ b/packages/rich-text/src/plugins/shared/FetchingWrappedEntryCard.tsx
@@ -49,6 +49,7 @@ const InternalEntryCard = React.memo((props: InternalEntryCard) => {
       isLocalized={!!('localized' in props.sdk.field && props.sdk.field.localized)}
       localesStatusMap={props.localesStatusMap}
       activeLocales={props.sdk.parameters.instance.activeLocales}
+      shouldRetainLocaleHistory={props.sdk.parameters.instance.shouldRetainLocaleHistory}
     />
   );
 }, areEqual);


### PR DESCRIPTION
Exports a util function to calculate if the statuses differ. Controlled by `shouldRetainLocaleHistory`