### PR TITLE
fix(reference): open function invocation error log in new window

### DIFF
--- a/packages/reference/src/components/ResourceEntityErrorCard/FunctionInvocationErrorCard.tsx
+++ b/packages/reference/src/components/ResourceEntityErrorCard/FunctionInvocationErrorCard.tsx
@@ -49,6 +49,7 @@ export function FunctionInvocationErrorCard({
             <TextLink
               testId="cf-ui-function-invocation-log-link"
               icon={<ExternalLinkIcon />}
+              target="_blank"
               alignIcon="end"
               href={functionLink}
             >


### PR DESCRIPTION
I forgot to add `target="_blank"` to the function invocation error log link in the previous PR. This addresses that oversight.