### PR TITLE
fix: show dropdown datepicker [ZEND-5711, ZEND-5710]

### DIFF
--- a/packages/date/src/DatepickerInput.tsx
+++ b/packages/date/src/DatepickerInput.tsx
@@ -1,9 +1,12 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 
 import { Datepicker } from '@contentful/f36-components';
 import { css } from 'emotion';
 // eslint-disable-next-line -- TODO: move to date-fns
 import moment from 'moment';
+
+const YEARS_INTO_FUTURE = 100;
+const MIN_YEAR = '1000';
 
 const styles = {
   root: css({
@@ -18,6 +21,13 @@ export type DatePickerProps = {
 };
 
 export const DatepickerInput = (props: DatePickerProps) => {
+  const [fromDate, toDate] = useMemo(() => {
+    const fromDate = new Date(MIN_YEAR);
+    const toDate = new Date();
+    toDate.setFullYear(toDate.getFullYear() + YEARS_INTO_FUTURE);
+
+    return [fromDate, toDate];
+  }, []);
   // The DatepickerInput should be time and timezone agnostic,
   // thats why we don't use moment().toDate() to get Date object.
   // moment().toDate() takes into account time and timezone and converts it
@@ -36,6 +46,11 @@ export const DatepickerInput = (props: DatePickerProps) => {
         props.onChange(momentDay);
       }}
       inputProps={{ isDisabled: props.disabled, placeholder: '' }}
+      //fromDate and toDate are necessary to show the year dropdown
+      // there is a customer need to go back more than 100 years
+      // when the underlying library react-day-picker gets updated to v9, we should make sure to set fromYear to a greater value
+      fromDate={fromDate}
+      toDate={toDate}
     />
   );
 };


### PR DESCRIPTION
Show the year dropdown picker again. from and to values are necessary to render it. increase the value to be able to go back to the year 1000