### PR TITLE
fix: rerender rich text when active locales change [TOL-2606]

### DIFF
--- a/packages/rich-text/src/SdkProvider.tsx
+++ b/packages/rich-text/src/SdkProvider.tsx
@@ -8,7 +8,7 @@ interface SdkProviderProps {
 }
 
 function useSdk({ sdk }: SdkProviderProps) {
-  const sdkMemo = React.useMemo<FieldAppSDK>(() => sdk, []); // eslint-disable-line -- TODO: explain this disable
+  const sdkMemo = React.useMemo<FieldAppSDK>(() => sdk, [sdk.parameters.instance.activeLocales]); // eslint-disable-line -- TODO: explain this disable
 
   return sdkMemo;
 }

--- a/packages/rich-text/src/Toolbar/_tests_/toolbar.test.tsx
+++ b/packages/rich-text/src/Toolbar/_tests_/toolbar.test.tsx
@@ -33,6 +33,11 @@ const mockSdk = (marks?: MARKS[]): any => {
     access: {
       can: jest.fn().mockResolvedValue(true),
     },
+    parameters: {
+      instance: {
+        activeLocales: [],
+      },
+    },
   };
 };
 
@@ -48,7 +53,7 @@ describe('Toolbar', () => {
             <Toolbar isDisabled />
           </ContentfulEditorIdProvider>
         </SdkProvider>
-      </Plate>,
+      </Plate>
     );
     await waitFor(() => {
       expect(getByTestId('toolbar-heading-toggle')).toBeDisabled();
@@ -79,7 +84,7 @@ describe('Toolbar', () => {
               <Toolbar isDisabled />
             </ContentfulEditorIdProvider>
           </SdkProvider>
-        </Plate>,
+        </Plate>
       );
       expect(queryByTestId('dropdown-toolbar-button')).toBeVisible();
     });
@@ -94,7 +99,7 @@ describe('Toolbar', () => {
               <Toolbar isDisabled />
             </ContentfulEditorIdProvider>
           </SdkProvider>
-        </Plate>,
+        </Plate>
       );
       expect(queryByTestId('dropdown-toolbar-button')).not.toBeInTheDocument();
     });


### PR DESCRIPTION
Rerender rich text editor when active locales change