### PR TITLE
feat: permissions check for cross space reference editor [FUS-115]

### DIFF
--- a/packages/reference/src/resources/MultipleResourceReferenceEditor.spec.tsx
+++ b/packages/reference/src/resources/MultipleResourceReferenceEditor.spec.tsx
@@ -95,7 +95,6 @@ describe('Multiple resource editor', () => {
     const sdk: FieldAppSDK = mockSdkForField(fieldDefinition);
     render(
       <MultipleResourceReferenceEditor
-        apiUrl={'test-contentful'}
         getEntryRouteHref={() => ''}
         isInitiallyDisabled={false}
         sdk={sdk}

--- a/packages/reference/src/resources/MultipleResourceReferenceEditor.spec.tsx
+++ b/packages/reference/src/resources/MultipleResourceReferenceEditor.spec.tsx
@@ -1,10 +1,11 @@
-import * as React from 'react';
-
 import { FieldAppSDK } from '@contentful/app-sdk';
 import '@testing-library/jest-dom/extend-expect';
 import { fireEvent, render, screen } from '@testing-library/react';
 
+import * as React from 'react';
+
 import { useResource } from '../common/EntityStore';
+import { useEditorPermissions } from '../common/useEditorPermissions';
 import { MultipleResourceReferenceEditor } from './MultipleResourceReferenceEditor';
 import { createFakeEntryResource, mockSdkForField } from './testHelpers/resourceEditorHelpers';
 
@@ -20,6 +21,12 @@ jest.mock('../common/EntityStore', () => {
       status: 'success',
       apiUrl,
     })),
+  };
+});
+
+jest.mock('../common/useEditorPermissions', () => {
+  return {
+    useEditorPermissions: jest.fn(),
   };
 });
 
@@ -49,6 +56,12 @@ const fieldDefinition = {
   validations: [],
 };
 
+const mockedUseEditorPermissions = useEditorPermissions as jest.Mock;
+
+beforeEach(() => {
+  mockedUseEditorPermissions.mockImplementation(() => ({ canLinkEntity: true }));
+});
+
 describe('Multiple resource editor', () => {
   it('renders the action button when no value is set', async () => {
     const sdk: FieldAppSDK = mockSdkForField(fieldDefinition);
@@ -74,6 +87,27 @@ describe('Multiple resource editor', () => {
     expect(options).toEqual({
       allowedResources: fieldDefinition.allowedResources,
     });
+  });
+
+  it('hides the action button when insufficient permissions', async () => {
+    mockedUseEditorPermissions.mockImplementation(() => ({ canLinkEntity: false }));
+
+    const sdk: FieldAppSDK = mockSdkForField(fieldDefinition);
+    render(
+      <MultipleResourceReferenceEditor
+        apiUrl={'test-contentful'}
+        getEntryRouteHref={() => ''}
+        isInitiallyDisabled={false}
+        sdk={sdk}
+        hasCardEditActions={true}
+        viewType="card"
+        // @ts-expect-error unused...
+        parameters={{}}
+      />
+    );
+
+    const noPermission = await screen.findByText(/You don't have permission to view this content/);
+    expect(noPermission).toBeDefined();
   });
 
   it('renders custom actions when passed', async () => {

--- a/packages/reference/src/resources/MultipleResourceReferenceEditor.tsx
+++ b/packages/reference/src/resources/MultipleResourceReferenceEditor.tsx
@@ -9,6 +9,7 @@ import noop from 'lodash/noop';
 import { EntityProvider } from '../common/EntityStore';
 import { ReferenceEditorProps } from '../common/ReferenceEditor';
 import { SortableLinkList } from '../common/SortableLinkList';
+import { useEditorPermissions } from '../common/useEditorPermissions';
 import { CombinedLinkEntityActions } from '../components/LinkActions/LinkEntityActions';
 import { ResourceLink } from '../types';
 import { EntryRoute } from './Cards/ContentfulEntryCard';
@@ -57,11 +58,18 @@ function ResourceEditor(props: EditorProps) {
     [items, setValue]
   );
 
+  const editorPermissions = useEditorPermissions({
+    ...props,
+    entityType: 'Entry',
+    allContentTypes: [],
+  });
+
   const { dialogs, field } = props.sdk;
   const linkActionsProps = useResourceLinkActions({
     dialogs,
     field,
     apiUrl,
+    editorPermissions,
   });
 
   return (

--- a/packages/reference/src/resources/MultipleResourceReferenceEditor.tsx
+++ b/packages/reference/src/resources/MultipleResourceReferenceEditor.tsx
@@ -9,7 +9,6 @@ import noop from 'lodash/noop';
 import { EntityProvider } from '../common/EntityStore';
 import { ReferenceEditorProps } from '../common/ReferenceEditor';
 import { SortableLinkList } from '../common/SortableLinkList';
-import { useEditorPermissions } from '../common/useEditorPermissions';
 import { CombinedLinkEntityActions } from '../components/LinkActions/LinkEntityActions';
 import { ResourceLink } from '../types';
 import { EntryRoute } from './Cards/ContentfulEntryCard';
@@ -29,11 +28,10 @@ type ChildProps = {
 type EditorProps = ReferenceEditorProps &
   Omit<ChildProps, 'onSortStart' | 'onSortEnd' | 'onMove' | 'onRemoteItemAtIndex'> & {
     children: (props: ReferenceEditorProps & ChildProps) => React.ReactElement;
-    apiUrl: string;
   };
 
 function ResourceEditor(props: EditorProps) {
-  const { setValue, items, apiUrl } = props;
+  const { setValue, items } = props;
 
   const onSortStart = () => noop();
   const onSortEnd = useCallback(
@@ -58,18 +56,9 @@ function ResourceEditor(props: EditorProps) {
     [items, setValue]
   );
 
-  const editorPermissions = useEditorPermissions({
-    ...props,
-    entityType: 'Entry',
-    allContentTypes: [],
-  });
-
-  const { dialogs, field } = props.sdk;
   const linkActionsProps = useResourceLinkActions({
-    dialogs,
-    field,
-    apiUrl,
-    editorPermissions,
+    sdk: props.sdk,
+    parameters: props.parameters,
   });
 
   return (

--- a/packages/reference/src/resources/SingleResourceReferenceEditor.spec.tsx
+++ b/packages/reference/src/resources/SingleResourceReferenceEditor.spec.tsx
@@ -5,6 +5,7 @@ import '@testing-library/jest-dom/extend-expect';
 import { fireEvent, render, screen } from '@testing-library/react';
 
 import { useResource } from '../common/EntityStore';
+import { useEditorPermissions } from '../common/useEditorPermissions';
 import { SingleResourceReferenceEditor } from './SingleResourceReferenceEditor';
 import { createFakeEntryResource, mockSdkForField } from './testHelpers/resourceEditorHelpers';
 
@@ -31,6 +32,12 @@ jest.mock('react-intersection-observer', () => {
   };
 });
 
+jest.mock('../common/useEditorPermissions', () => {
+  return {
+    useEditorPermissions: jest.fn(),
+  };
+});
+
 const fieldDefinition = {
   type: 'ResourceLink',
   id: 'foo',
@@ -44,6 +51,13 @@ const fieldDefinition = {
   required: true,
   validations: [],
 };
+
+const mockedUseEditorPermissions = useEditorPermissions as jest.Mock;
+
+beforeEach(() => {
+  mockedUseEditorPermissions.mockImplementation(() => ({ canLinkEntity: true }));
+});
+
 describe('Single resource editor', () => {
   it('renders the action button when no value is set', async () => {
     const sdk: FieldAppSDK = mockSdkForField(fieldDefinition);
@@ -69,6 +83,25 @@ describe('Single resource editor', () => {
     expect(options).toEqual({
       allowedResources: fieldDefinition.allowedResources,
     });
+  });
+
+  it('renders no the action button when permissions insufficient', async () => {
+    mockedUseEditorPermissions.mockImplementation(() => ({ canLinkEntity: false }));
+
+    const sdk: FieldAppSDK = mockSdkForField(fieldDefinition);
+    render(
+      <SingleResourceReferenceEditor
+        isInitiallyDisabled={false}
+        sdk={sdk}
+        hasCardEditActions={true}
+        viewType="card"
+        // @ts-expect-error unused...
+        parameters={{}}
+      />
+    );
+
+    const noPermission = await screen.findByText(/You don't have permission to view this content/);
+    expect(noPermission).toBeDefined();
   });
 
   it('renders custom actions when passed', async () => {

--- a/packages/reference/src/resources/SingleResourceReferenceEditor.tsx
+++ b/packages/reference/src/resources/SingleResourceReferenceEditor.tsx
@@ -4,6 +4,7 @@ import { FieldConnector } from '@contentful/field-editor-shared';
 
 import { EntityProvider } from '../common/EntityStore';
 import { ReferenceEditorProps } from '../common/ReferenceEditor';
+import { useEditorPermissions } from '../common/useEditorPermissions';
 import { CombinedLinkEntityActions } from '../components/LinkActions/LinkEntityActions';
 import { ResourceLink } from '../types';
 import { EntryRoute } from './Cards/ContentfulEntryCard';
@@ -17,10 +18,18 @@ export function SingleResourceReferenceEditor(
   }
 ) {
   const { dialogs, field } = props.sdk;
+
+  const editorPermissions = useEditorPermissions({
+    ...props,
+    entityType: 'Entry',
+    allContentTypes: [],
+  });
+
   const linkActionsProps = useResourceLinkActions({
     dialogs,
     field,
     apiUrl: props.apiUrl,
+    editorPermissions,
   });
 
   return (

--- a/packages/reference/src/resources/SingleResourceReferenceEditor.tsx
+++ b/packages/reference/src/resources/SingleResourceReferenceEditor.tsx
@@ -4,7 +4,6 @@ import { FieldConnector } from '@contentful/field-editor-shared';
 
 import { EntityProvider } from '../common/EntityStore';
 import { ReferenceEditorProps } from '../common/ReferenceEditor';
-import { useEditorPermissions } from '../common/useEditorPermissions';
 import { CombinedLinkEntityActions } from '../components/LinkActions/LinkEntityActions';
 import { ResourceLink } from '../types';
 import { EntryRoute } from './Cards/ContentfulEntryCard';
@@ -14,22 +13,11 @@ import { useResourceLinkActions } from './useResourceLinkActions';
 export function SingleResourceReferenceEditor(
   props: ReferenceEditorProps & {
     getEntryRouteHref: (entryRoute: EntryRoute) => string;
-    apiUrl: string;
   }
 ) {
-  const { dialogs, field } = props.sdk;
-
-  const editorPermissions = useEditorPermissions({
-    ...props,
-    entityType: 'Entry',
-    allContentTypes: [],
-  });
-
   const linkActionsProps = useResourceLinkActions({
-    dialogs,
-    field,
-    apiUrl: props.apiUrl,
-    editorPermissions,
+    sdk: props.sdk,
+    parameters: props.parameters,
   });
 
   return (

--- a/packages/reference/src/resources/useResourceLinkActions.ts
+++ b/packages/reference/src/resources/useResourceLinkActions.ts
@@ -3,6 +3,7 @@ import { useMemo } from 'react';
 import type { FieldAPI, FieldAppSDK } from '@contentful/app-sdk';
 import type { ResourceLink } from 'contentful-management';
 
+import { EditorPermissions } from '../common/useEditorPermissions';
 import { LinkActionsProps } from '../components';
 
 const getUpdatedValue = (
@@ -18,12 +19,16 @@ const getUpdatedValue = (
   }
 };
 
+type ResourceLinkActionProps = Pick<FieldAppSDK, 'field' | 'dialogs'> & {
+  apiUrl: string;
+  editorPermissions: Pick<EditorPermissions, 'canLinkEntity'>;
+};
+
 export function useResourceLinkActions({
   dialogs,
   field,
-}: Pick<FieldAppSDK, 'field' | 'dialogs'> & {
-  apiUrl: string;
-}): LinkActionsProps {
+  editorPermissions,
+}: ResourceLinkActionProps): LinkActionsProps {
   const onLinkedExisting = useMemo(() => {
     return (
       links: ResourceLink<'Contentful:Entry'>[] | [ResourceLink<'Contentful:Entry'> | null]
@@ -67,7 +72,7 @@ export function useResourceLinkActions({
     contentTypes: [],
     canCreateEntity: false,
     canLinkMultiple: multiple,
-    canLinkEntity: true,
+    canLinkEntity: editorPermissions.canLinkEntity,
     isDisabled: false,
     isEmpty: false,
     isFull: false,

--- a/packages/reference/src/resources/useResourceLinkActions.ts
+++ b/packages/reference/src/resources/useResourceLinkActions.ts
@@ -1,9 +1,9 @@
 import { useMemo } from 'react';
 
-import type { FieldAPI, FieldAppSDK } from '@contentful/app-sdk';
+import type { FieldAPI } from '@contentful/app-sdk';
 import type { ResourceLink } from 'contentful-management';
 
-import { EditorPermissions } from '../common/useEditorPermissions';
+import { EditorPermissionsProps, useEditorPermissions } from '../common/useEditorPermissions';
 import { LinkActionsProps } from '../components';
 
 const getUpdatedValue = (
@@ -19,16 +19,14 @@ const getUpdatedValue = (
   }
 };
 
-type ResourceLinkActionProps = Pick<FieldAppSDK, 'field' | 'dialogs'> & {
-  apiUrl: string;
-  editorPermissions: Pick<EditorPermissions, 'canLinkEntity'>;
-};
+type ResourceLinkActionProps = Pick<EditorPermissionsProps, 'parameters' | 'sdk'>;
 
 export function useResourceLinkActions({
-  dialogs,
-  field,
-  editorPermissions,
+  parameters,
+  sdk,
 }: ResourceLinkActionProps): LinkActionsProps {
+  const { field, dialogs } = sdk;
+
   const onLinkedExisting = useMemo(() => {
     return (
       links: ResourceLink<'Contentful:Entry'>[] | [ResourceLink<'Contentful:Entry'> | null]
@@ -63,6 +61,13 @@ export function useResourceLinkActions({
     // @ts-expect-error wait for update of app-sdk version
   }, [dialogs, field.allowedResources, multiple, onLinkedExisting]);
 
+  const { canLinkEntity } = useEditorPermissions({
+    entityType: 'Entry',
+    allContentTypes: [],
+    sdk,
+    parameters,
+  });
+
   return {
     onLinkExisting,
     // @ts-expect-error
@@ -72,7 +77,7 @@ export function useResourceLinkActions({
     contentTypes: [],
     canCreateEntity: false,
     canLinkMultiple: multiple,
-    canLinkEntity: editorPermissions.canLinkEntity,
+    canLinkEntity,
     isDisabled: false,
     isEmpty: false,
     isFull: false,


### PR DESCRIPTION
# Description
Checks permission when rendering to the Reference Editor. This check exists on the service, but we also want to check for access in the frontend for better UX. The same logic exists for "normal" same space entries.  