### PR TITLE
fix: re-introduce apiUrl prop [FUS-115]

### DIFF
--- a/packages/reference/src/resources/SingleResourceReferenceEditor.tsx
+++ b/packages/reference/src/resources/SingleResourceReferenceEditor.tsx
@@ -13,6 +13,7 @@ import { useResourceLinkActions } from './useResourceLinkActions';
 export function SingleResourceReferenceEditor(
   props: ReferenceEditorProps & {
     getEntryRouteHref: (entryRoute: EntryRoute) => string;
+    apiUrl: string;
   }
 ) {
   const linkActionsProps = useResourceLinkActions({


### PR DESCRIPTION
[Removing](https://github.com/contentful/field-editors/pull/1818) the `apiUrl` prop caused a downstream consumer to break as it's expected by the general widget renderer of the web app. even though we don't use it here in the specific component, we have to allow it in the props. 