### PR TITLE
fix: instance params as strings [TOL-2887]

### DIFF
--- a/packages/reference/src/assets/WrappedAssetCard/FetchingWrappedAssetCard.tsx
+++ b/packages/reference/src/assets/WrappedAssetCard/FetchingWrappedAssetCard.tsx
@@ -84,6 +84,10 @@ export function FetchingWrappedAssetCard(props: FetchingWrappedAssetCardProps) {
 
     const { getEntityUrl } = props;
     const size = props.viewType === 'big_card' ? 'default' : 'small';
+    const activeLocalesValue = props.sdk.parameters.instance.activeLocales || '[]';
+    const activeLocales =
+      typeof activeLocalesValue === 'string' ? JSON.parse(activeLocalesValue) : activeLocalesValue;
+
     const commonProps = {
       asset,
       entityUrl: getEntityUrl && getEntityUrl(props.assetId),
@@ -96,7 +100,7 @@ export function FetchingWrappedAssetCard(props: FetchingWrappedAssetCardProps) {
       onRemove,
       useLocalizedEntityStatus: props.sdk.parameters.instance.useLocalizedEntityStatus,
       localesStatusMap,
-      activeLocales: props.sdk.parameters.instance.activeLocales,
+      activeLocales,
     };
 
     if (props.viewType === 'link') {

--- a/packages/reference/src/entries/WrappedEntryCard/FetchingWrappedEntryCard.tsx
+++ b/packages/reference/src/entries/WrappedEntryCard/FetchingWrappedEntryCard.tsx
@@ -127,6 +127,10 @@ export function FetchingWrappedEntryCard(props: EntryCardReferenceEditorProps) {
       return <EntryCard size={size} isLoading />;
     }
 
+    const activeLocalesValue = props.sdk.parameters.instance.activeLocales || '[]';
+    const activeLocales =
+      typeof activeLocalesValue === 'string' ? JSON.parse(activeLocalesValue) : activeLocalesValue;
+
     const sharedCardProps: CustomEntityCardProps = {
       index: props.index,
       entity: entry,
@@ -146,7 +150,7 @@ export function FetchingWrappedEntryCard(props: EntryCardReferenceEditorProps) {
       isBeingDragged: props.isBeingDragged,
       useLocalizedEntityStatus: props.sdk.parameters.instance.useLocalizedEntityStatus,
       localesStatusMap,
-      activeLocales: props.sdk.parameters.instance.activeLocales,
+      activeLocales,
     };
 
     const { hasCardEditActions, hasCardMoveActions, hasCardRemoveActions } = props;

--- a/packages/rich-text/src/plugins/shared/FetchingWrappedAssetCard.tsx
+++ b/packages/rich-text/src/plugins/shared/FetchingWrappedAssetCard.tsx
@@ -23,8 +23,12 @@ interface InternalAssetCardProps {
   localesStatusMap?: LocalePublishStatusMap;
 }
 
-const InternalAssetCard = React.memo(
-  (props: InternalAssetCardProps) => (
+const InternalAssetCard = React.memo((props: InternalAssetCardProps) => {
+  const activeLocalesValue = props.sdk.parameters.instance.activeLocales || '[]';
+  const activeLocales =
+    typeof activeLocalesValue === 'string' ? JSON.parse(activeLocalesValue) : activeLocalesValue;
+
+  return (
     <WrappedAssetCard
       getEntityScheduledActions={props.loadEntityScheduledActions}
       size="small"
@@ -38,11 +42,10 @@ const InternalAssetCard = React.memo(
       isClickable={false}
       useLocalizedEntityStatus={props.sdk.parameters.instance.useLocalizedEntityStatus}
       localesStatusMap={props.localesStatusMap}
-      activeLocales={props.sdk.parameters.instance.activeLocales}
+      activeLocales={activeLocales}
     />
-  ),
-  areEqual
-);
+  );
+}, areEqual);
 
 InternalAssetCard.displayName = 'InternalAssetCard';
 

--- a/packages/rich-text/src/plugins/shared/FetchingWrappedEntryCard.tsx
+++ b/packages/rich-text/src/plugins/shared/FetchingWrappedEntryCard.tsx
@@ -26,6 +26,9 @@ interface InternalEntryCard {
 
 const InternalEntryCard = React.memo((props: InternalEntryCard) => {
   const { entry, sdk, loadEntityScheduledActions } = props;
+  const activeLocalesValue = props.sdk.parameters.instance.activeLocales || '[]';
+  const activeLocales =
+    typeof activeLocalesValue === 'string' ? JSON.parse(activeLocalesValue) : activeLocalesValue;
 
   const contentType = sdk.space
     .getCachedContentTypes()
@@ -47,7 +50,7 @@ const InternalEntryCard = React.memo((props: InternalEntryCard) => {
       isClickable={false}
       useLocalizedEntityStatus={sdk.parameters.instance.useLocalizedEntityStatus}
       localesStatusMap={props.localesStatusMap}
-      activeLocales={props.sdk.parameters.instance.activeLocales}
+      activeLocales={activeLocales}
     />
   );
 }, areEqual);


### PR DESCRIPTION
We should only store primitives (type is `DefinedParameters` which can be `Record<string, string | number | boolean>`)
 for extension parameters in `createFieldWidgetSDK`. This means the `activeLocales` now get passed as a string, which we have to now parse before using it.

https://contentful.atlassian.net/browse/TOL-2887