### PR TITLE
feat: use useActiveLocales hook instead of instance params [TOL-2887]

### DIFF
--- a/packages/_shared/src/hooks/useActiveLocales.tsx
+++ b/packages/_shared/src/hooks/useActiveLocales.tsx
@@ -1,0 +1,56 @@
+import { useEffect, useState } from 'react';
+
+import { BaseAppSDK, SharedEditorSDK } from '@contentful/app-sdk';
+
+type LocaleSettings = {
+  mode: 'single' | 'multi';
+  active?: string[];
+  focused?: string;
+};
+
+export type SDK = {
+  editor?: SharedEditorSDK['editor'];
+  locales: Pick<BaseAppSDK['locales'], 'available'>;
+};
+
+export function useActiveLocales(sdk: SDK) {
+  const [activeLocales, setActiveLocales] = useState<Array<{ code: string }>>([]);
+
+  useEffect(() => {
+    // Set all available locales if editor is not available
+    if (!sdk.editor) {
+      setActiveLocales(sdk.locales.available.map((code) => ({ code })));
+      return;
+    }
+
+    const availableLocales = new Set(sdk.locales.available);
+
+    const updateLocales = (settings: LocaleSettings) => {
+      let localeCodes: string[] = [];
+
+      if (settings.mode === 'multi' && settings.active) {
+        localeCodes = settings.active.filter((locale) => availableLocales.has(locale));
+      } else if (
+        settings.mode === 'single' &&
+        settings.focused &&
+        availableLocales.has(settings.focused)
+      ) {
+        localeCodes = [settings.focused];
+      }
+
+      setActiveLocales(localeCodes.map((code) => ({ code })));
+    };
+
+    // Set initial locales
+    updateLocales(sdk.editor.getLocaleSettings());
+
+    // Subscribe to changes
+    const unsubscribe = sdk.editor.onLocaleSettingsChanged(updateLocales);
+
+    return () => {
+      unsubscribe();
+    };
+  }, [sdk.editor, sdk.locales.available]);
+
+  return activeLocales;
+}

--- a/packages/_shared/src/index.tsx
+++ b/packages/_shared/src/index.tsx
@@ -27,6 +27,7 @@ export { Asset, Entry, File } from './typesEntity';
 export { isValidImage } from './utils/isValidImage';
 export { shortenStorageUnit, toLocaleString } from './utils/shortenStorageUnit';
 export * from './hooks/useLocalePublishStatus';
+export * from './hooks/useActiveLocales';
 export { ModalDialogLauncher };
 export { entityHelpers };
 export { ConstraintsUtils };

--- a/packages/reference/src/assets/WrappedAssetCard/FetchingWrappedAssetCard.tsx
+++ b/packages/reference/src/assets/WrappedAssetCard/FetchingWrappedAssetCard.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import { AssetCard, EntryCard } from '@contentful/f36-components';
-import { useLocalePublishStatus } from '@contentful/field-editor-shared';
+import { useLocalePublishStatus, useActiveLocales } from '@contentful/field-editor-shared';
 
 import {
   CustomEntityCardProps,
@@ -35,6 +35,7 @@ export function FetchingWrappedAssetCard(props: FetchingWrappedAssetCardProps) {
     [getEntityScheduledActions, props.assetId]
   );
   const localesStatusMap = useLocalePublishStatus(asset, props.sdk.locales);
+  const activeLocales = useActiveLocales(props.sdk);
 
   React.useEffect(() => {
     if (asset) {
@@ -96,7 +97,7 @@ export function FetchingWrappedAssetCard(props: FetchingWrappedAssetCardProps) {
       onRemove,
       useLocalizedEntityStatus: props.sdk.parameters.instance.useLocalizedEntityStatus,
       localesStatusMap,
-      activeLocales: props.sdk.parameters.instance.activeLocales,
+      activeLocales,
     };
 
     if (props.viewType === 'link') {

--- a/packages/reference/src/entries/WrappedEntryCard/FetchingWrappedEntryCard.tsx
+++ b/packages/reference/src/entries/WrappedEntryCard/FetchingWrappedEntryCard.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import { EntryCard } from '@contentful/f36-components';
-import { useLocalePublishStatus } from '@contentful/field-editor-shared';
+import { useLocalePublishStatus, useActiveLocales } from '@contentful/field-editor-shared';
 import { EntryProps } from 'contentful-management';
 import get from 'lodash/get';
 
@@ -65,6 +65,7 @@ export function FetchingWrappedEntryCard(props: EntryCardReferenceEditorProps) {
     [getEntityScheduledActions, props.entryId]
   );
   const localesStatusMap = useLocalePublishStatus(entry, props.sdk.locales);
+  const activeLocales = useActiveLocales(props.sdk);
 
   const size = props.viewType === 'link' ? 'small' : 'default';
   const { getEntity } = useEntityLoader();
@@ -146,7 +147,7 @@ export function FetchingWrappedEntryCard(props: EntryCardReferenceEditorProps) {
       isBeingDragged: props.isBeingDragged,
       useLocalizedEntityStatus: props.sdk.parameters.instance.useLocalizedEntityStatus,
       localesStatusMap,
-      activeLocales: props.sdk.parameters.instance.activeLocales,
+      activeLocales,
     };
 
     const { hasCardEditActions, hasCardMoveActions, hasCardRemoveActions } = props;

--- a/packages/rich-text/src/SdkProvider.tsx
+++ b/packages/rich-text/src/SdkProvider.tsx
@@ -8,7 +8,7 @@ interface SdkProviderProps {
 }
 
 function useSdk({ sdk }: SdkProviderProps) {
-  const sdkMemo = React.useMemo<FieldAppSDK>(() => sdk, [sdk.parameters.instance.activeLocales]); // eslint-disable-line -- TODO: explain this disable
+  const sdkMemo = React.useMemo<FieldAppSDK>(() => sdk, []); // eslint-disable-line -- TODO: explain this disable
 
   return sdkMemo;
 }

--- a/packages/rich-text/src/plugins/shared/FetchingWrappedAssetCard.tsx
+++ b/packages/rich-text/src/plugins/shared/FetchingWrappedAssetCard.tsx
@@ -8,7 +8,11 @@ import {
   MissingEntityCard,
   WrappedAssetCard,
 } from '@contentful/field-editor-reference';
-import { LocalePublishStatusMap, useLocalePublishStatus } from '@contentful/field-editor-shared';
+import {
+  LocalePublishStatusMap,
+  useLocalePublishStatus,
+  useActiveLocales,
+} from '@contentful/field-editor-shared';
 import areEqual from 'fast-deep-equal';
 
 interface InternalAssetCardProps {
@@ -23,8 +27,10 @@ interface InternalAssetCardProps {
   localesStatusMap?: LocalePublishStatusMap;
 }
 
-const InternalAssetCard = React.memo(
-  (props: InternalAssetCardProps) => (
+const InternalAssetCard = React.memo((props: InternalAssetCardProps) => {
+  const activeLocales = useActiveLocales(props.sdk);
+
+  return (
     <WrappedAssetCard
       getEntityScheduledActions={props.loadEntityScheduledActions}
       size="small"
@@ -38,11 +44,10 @@ const InternalAssetCard = React.memo(
       isClickable={false}
       useLocalizedEntityStatus={props.sdk.parameters.instance.useLocalizedEntityStatus}
       localesStatusMap={props.localesStatusMap}
-      activeLocales={props.sdk.parameters.instance.activeLocales}
+      activeLocales={activeLocales}
     />
-  ),
-  areEqual
-);
+  );
+}, areEqual);
 
 InternalAssetCard.displayName = 'InternalAssetCard';
 

--- a/packages/rich-text/src/plugins/shared/FetchingWrappedEntryCard.tsx
+++ b/packages/rich-text/src/plugins/shared/FetchingWrappedEntryCard.tsx
@@ -9,7 +9,11 @@ import {
   WrappedEntryCard,
   useEntityLoader,
 } from '@contentful/field-editor-reference';
-import { LocalePublishStatusMap, useLocalePublishStatus } from '@contentful/field-editor-shared';
+import {
+  LocalePublishStatusMap,
+  useLocalePublishStatus,
+  useActiveLocales,
+} from '@contentful/field-editor-shared';
 import areEqual from 'fast-deep-equal';
 
 interface InternalEntryCard {
@@ -30,6 +34,7 @@ const InternalEntryCard = React.memo((props: InternalEntryCard) => {
   const contentType = sdk.space
     .getCachedContentTypes()
     .find((contentType) => contentType.sys.id === entry.sys.contentType.sys.id);
+  const activeLocales = useActiveLocales(props.sdk);
 
   return (
     <WrappedEntryCard
@@ -47,7 +52,7 @@ const InternalEntryCard = React.memo((props: InternalEntryCard) => {
       isClickable={false}
       useLocalizedEntityStatus={sdk.parameters.instance.useLocalizedEntityStatus}
       localesStatusMap={props.localesStatusMap}
-      activeLocales={props.sdk.parameters.instance.activeLocales}
+      activeLocales={activeLocales}
     />
   );
 }, areEqual);


### PR DESCRIPTION
- Extract `useActiveLocales` from experience packages to field editors shared, and change the type so it can accept both `EntitySelectorExtensionSDK` and `FieldAppSDK`
- Use this new `useActiveLocales` hook to determine the active locales instead of passing it as a instance param in field editors from the webapp

Later after this PR is merged: Use the now extracted `useActiveLocales` from field editors shared in experience-packages entity-search


## Testing:
<img width="1264" alt="Screenshot 2025-03-07 at 14 07 02" src="https://github.com/user-attachments/assets/16282199-0d04-479b-a5df-b478520c9d98" />
