### PR TITLE
fix: dnd embedded entities in firefox [TOL-2460]

### DIFF
--- a/packages/reference/src/assets/WrappedAssetCard/WrappedAssetCard.tsx
+++ b/packages/reference/src/assets/WrappedAssetCard/WrappedAssetCard.tsx
@@ -154,6 +154,7 @@ export const WrappedAssetCard = ({
       }
       dragHandleRender={renderDragHandle}
       withDragHandle={!!renderDragHandle}
+      draggable={!!renderDragHandle}
       actions={[
         ...renderActions({ entityFile, isDisabled: isDisabled, onEdit, onRemove }),
         ...(entityFile ? renderAssetInfo({ entityFile }) : []),

--- a/packages/reference/src/entries/WrappedEntryCard/WrappedEntryCard.tsx
+++ b/packages/reference/src/entries/WrappedEntryCard/WrappedEntryCard.tsx
@@ -158,6 +158,7 @@ export function WrappedEntryCard({
       thumbnailElement={file && isValidImage(file) ? <AssetThumbnail file={file} /> : undefined}
       dragHandleRender={renderDragHandle}
       withDragHandle={!!renderDragHandle}
+      draggable={!!renderDragHandle}
       actions={
         onEdit || onRemove
           ? [

--- a/packages/rich-text/src/plugins/shared/FetchingWrappedAssetCard.tsx
+++ b/packages/rich-text/src/plugins/shared/FetchingWrappedAssetCard.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import { Asset, FieldAppSDK, ScheduledAction } from '@contentful/app-sdk';
-import { AssetCard } from '@contentful/f36-components';
+import { AssetCard, DragHandle } from '@contentful/f36-components';
 import {
   useEntity,
   useEntityLoader,
@@ -45,6 +45,11 @@ const InternalAssetCard = React.memo((props: InternalAssetCardProps) => {
       useLocalizedEntityStatus={props.sdk.parameters.instance.useLocalizedEntityStatus}
       localesStatusMap={props.localesStatusMap}
       activeLocales={activeLocales}
+      renderDragHandle={
+        !props.isDisabled
+          ? (dragHandleProps) => <DragHandle label="drag embedded asset" {...dragHandleProps} />
+          : undefined
+      }
     />
   );
 }, areEqual);

--- a/packages/rich-text/src/plugins/shared/FetchingWrappedEntryCard.tsx
+++ b/packages/rich-text/src/plugins/shared/FetchingWrappedEntryCard.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import { FieldAppSDK } from '@contentful/app-sdk';
 import { ScheduledAction, Entry } from '@contentful/app-sdk';
-import { EntryCard } from '@contentful/f36-components';
+import { DragHandle, EntryCard } from '@contentful/f36-components';
 import {
   useEntity,
   MissingEntityCard,
@@ -53,6 +53,11 @@ const InternalEntryCard = React.memo((props: InternalEntryCard) => {
       useLocalizedEntityStatus={sdk.parameters.instance.useLocalizedEntityStatus}
       localesStatusMap={props.localesStatusMap}
       activeLocales={activeLocales}
+      renderDragHandle={
+        !props.isDisabled
+          ? (dragHandleProps) => <DragHandle label="drag embedded entry" {...dragHandleProps} />
+          : undefined
+      }
     />
   );
 }, areEqual);

--- a/packages/rich-text/src/plugins/shared/FetchingWrappedResourceCard.tsx
+++ b/packages/rich-text/src/plugins/shared/FetchingWrappedResourceCard.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import { Entry, FieldAppSDK } from '@contentful/app-sdk';
-import { EntryCard } from '@contentful/f36-components';
+import { DragHandle, EntryCard } from '@contentful/f36-components';
 import {
   ResourceEntityErrorCard,
   ResourceInfo,
@@ -44,6 +44,11 @@ const InternalEntryCard = React.memo((props: InternalEntryCard) => {
       isClickable={false}
       getEntityScheduledActions={() => Promise.resolve([])}
       useLocalizedEntityStatus={props.sdk.parameters.instance.useLocalizedEntityStatus}
+      renderDragHandle={
+        !props.isDisabled
+          ? (dragHandleProps) => <DragHandle label="drag resource entry" {...dragHandleProps} />
+          : undefined
+      }
     />
   );
 }, areEqual);


### PR DESCRIPTION
Adding drag handle to embedded entities, if drag handle is provided then adding `draggable` to the `EntryCard` or `AssetCard` respectively, this makes them draggable in firefox.