### PR TITLE
feat: update markdown editor force tab to open [BBEE-1138]

### DIFF
--- a/packages/markdown/src/MarkdownEditor.tsx
+++ b/packages/markdown/src/MarkdownEditor.tsx
@@ -43,6 +43,8 @@ export interface MarkdownEditorProps {
   previewComponents?: PreviewComponents;
   onReady?: Function;
   isDisabled?: boolean;
+  /** Forces a specific tab to be active, and disables the other */
+  forceTab?: MarkdownTab;
 }
 
 export function MarkdownEditor(
@@ -107,10 +109,12 @@ export function MarkdownEditor(
   return (
     <div className={styles.container} data-test-id="markdown-editor">
       <MarkdownTabs
-        active={selectedTab}
+        active={props.forceTab || selectedTab}
         onSelect={(tab) => {
+          if (props.forceTab) return;
           setSelectedTab(tab);
         }}
+        forceTab={props.forceTab}
       />
       <MarkdownToolbar
         mode="default"

--- a/packages/markdown/src/MarkdownEditor.tsx
+++ b/packages/markdown/src/MarkdownEditor.tsx
@@ -114,7 +114,7 @@ export function MarkdownEditor(
           if (props.enableTab) return;
           setSelectedTab(tab);
         }}
-        forceTab={props.enableTab}
+        enableTab={props.enableTab}
       />
       <MarkdownToolbar
         mode="default"

--- a/packages/markdown/src/MarkdownEditor.tsx
+++ b/packages/markdown/src/MarkdownEditor.tsx
@@ -43,8 +43,8 @@ export interface MarkdownEditorProps {
   previewComponents?: PreviewComponents;
   onReady?: Function;
   isDisabled?: boolean;
-  /** Forces a specific tab to be active, and disables the other */
-  forceTab?: MarkdownTab;
+  /** Enables a specific tab to be active, and disables the other */
+  enableTab?: MarkdownTab;
 }
 
 export function MarkdownEditor(
@@ -109,12 +109,12 @@ export function MarkdownEditor(
   return (
     <div className={styles.container} data-test-id="markdown-editor">
       <MarkdownTabs
-        active={props.forceTab || selectedTab}
+        active={props.enableTab || selectedTab}
         onSelect={(tab) => {
-          if (props.forceTab) return;
+          if (props.enableTab) return;
           setSelectedTab(tab);
         }}
-        forceTab={props.forceTab}
+        forceTab={props.enableTab}
       />
       <MarkdownToolbar
         mode="default"

--- a/packages/markdown/src/components/MarkdownTabs.tsx
+++ b/packages/markdown/src/components/MarkdownTabs.tsx
@@ -53,7 +53,7 @@ const styles = {
 type MarkdownTabsProps = {
   active: MarkdownTab;
   onSelect: (selected: MarkdownTab) => void;
-} & Pick<MarkdownEditorProps, 'forceTab'>;
+} & Pick<MarkdownEditorProps, 'enableTab'>;
 
 function MarkdownTabItem(props: {
   isActive: boolean;
@@ -96,7 +96,7 @@ export function MarkdownTabs(props: MarkdownTabsProps) {
         onSelect={props.onSelect}
         isActive={props.active === 'editor'}
         testId="markdown-tab-md"
-        isDisabled={props.forceTab && props.forceTab !== 'editor'}
+        isDisabled={props.enableTab && props.enableTab !== 'editor'}
       >
         Editor
       </MarkdownTabItem>
@@ -105,7 +105,7 @@ export function MarkdownTabs(props: MarkdownTabsProps) {
         onSelect={props.onSelect}
         isActive={props.active === 'preview'}
         testId="markdown-tab-preview"
-        isDisabled={props.forceTab && props.forceTab !== 'preview'}
+        isDisabled={props.enableTab && props.enableTab !== 'preview'}
       >
         Preview
       </MarkdownTabItem>

--- a/packages/markdown/src/components/MarkdownTabs.tsx
+++ b/packages/markdown/src/components/MarkdownTabs.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 
 import tokens from '@contentful/f36-tokens';
 import { css, cx } from 'emotion';
+import { MarkdownEditorProps } from 'MarkdownEditor';
 
 import { MarkdownTab } from '../types';
 
@@ -40,12 +41,19 @@ const styles = {
       background: tokens.gray300,
     },
   }),
+  disabledTab: css({
+    cursor: 'not-allowed',
+    '&:hover': {
+      background: tokens.gray200,
+      boxShadow: 'none',
+    },
+  }),
 };
 
-interface MarkdownTabsProps {
+type MarkdownTabsProps = {
   active: MarkdownTab;
   onSelect: (selected: MarkdownTab) => void;
-}
+} & Pick<MarkdownEditorProps, 'forceTab'>;
 
 function MarkdownTabItem(props: {
   isActive: boolean;
@@ -53,11 +61,13 @@ function MarkdownTabItem(props: {
   testId: string;
   onSelect: (name: MarkdownTab) => void;
   children: React.ReactNode;
+  isDisabled?: boolean;
 }) {
   return (
     <div
       className={cx(styles.tab, {
         [styles.inactiveTab]: props.isActive === false,
+        [styles.disabledTab]: props.isDisabled === true,
       })}
       onClick={() => {
         props.onSelect(props.name);
@@ -86,6 +96,7 @@ export function MarkdownTabs(props: MarkdownTabsProps) {
         onSelect={props.onSelect}
         isActive={props.active === 'editor'}
         testId="markdown-tab-md"
+        isDisabled={props.forceTab && props.forceTab !== 'editor'}
       >
         Editor
       </MarkdownTabItem>
@@ -94,6 +105,7 @@ export function MarkdownTabs(props: MarkdownTabsProps) {
         onSelect={props.onSelect}
         isActive={props.active === 'preview'}
         testId="markdown-tab-preview"
+        isDisabled={props.forceTab && props.forceTab !== 'preview'}
       >
         Preview
       </MarkdownTabItem>


### PR DESCRIPTION
In this PR I update the `MarkdownEditor` component.

I add a new `forceTab` optional parameter. 

When given, this will force a specific tab to open and not allow the other tab to open. The disabled tab will also show the `not-allowed` cursor.


I am adding this, as the UI needed to for the '_editor_' tab to open when the AI Action is loading.

https://contentful.atlassian.net/browse/BBEE-1138