### PR TITLE
feat: update markdown editor force tab to open p2 [BBEE-1138]

### DIFF
--- a/packages/markdown/src/MarkdownEditor.tsx
+++ b/packages/markdown/src/MarkdownEditor.tsx
@@ -61,6 +61,12 @@ export function MarkdownEditor(
   const [canUploadAssets, setCanUploadAssets] = React.useState<boolean>(false);
 
   React.useEffect(() => {
+    if (props.enableTab) {
+      setSelectedTab(props.enableTab);
+    }
+  }, [props.enableTab]);
+
+  React.useEffect(() => {
     if (editor && props.onReady) {
       props.onReady(editor);
       // fix: http://codemirror.977696.n3.nabble.com/codemirror-content-not-visible-in-bootstrap-modal-td4026988.html
@@ -109,7 +115,7 @@ export function MarkdownEditor(
   return (
     <div className={styles.container} data-test-id="markdown-editor">
       <MarkdownTabs
-        active={props.enableTab || selectedTab}
+        active={selectedTab}
         onSelect={(tab) => {
           if (props.enableTab) return;
           setSelectedTab(tab);


### PR DESCRIPTION
See previous [PR](https://github.com/contentful/field-editors/pull/1849) 

This change fixes a state issue in the previous PR. The issue was that the MD content was not re-rendering without setting the `selectedTab` state.