### PR TITLE
fix(shared): base initial disabled state on `sdk.field.getIsDisabled()` [TOL-2914]

### DIFF
--- a/packages/_shared/src/FieldConnector.ts
+++ b/packages/_shared/src/FieldConnector.ts
@@ -67,7 +67,7 @@ export class FieldConnector<ValueType> extends React.Component<
       externalReset: 0,
       value: initialValue,
       lastRemoteValue: initialValue,
-      disabled: props.isInitiallyDisabled ?? false,
+      disabled: props.isInitiallyDisabled || props.field.getIsDisabled(),
       errors: [],
     };
   }

--- a/packages/reference/src/resources/testHelpers/resourceEditorHelpers.ts
+++ b/packages/reference/src/resources/testHelpers/resourceEditorHelpers.ts
@@ -10,6 +10,7 @@ export function mockSdkForField(fieldDefinition: any, fieldValue?: any): FieldAp
       onSchemaErrorsChanged: () => {},
       // eslint-disable-next-line -- test helper
       onIsDisabledChanged: () => {},
+      getIsDisabled: () => false,
       // eslint-disable-next-line -- test helper
       onValueChanged: () => {},
       ...fieldDefinition,


### PR DESCRIPTION
The `FieldConnector` currently only relies on `isInitiallyDisabled` to determine the initial state for fields and is ignoring `sdk.field.getIsDisabled()`. This leads to sometimes wrong initial rendering if the `isInitiallyDisabled` is not passed