### PR TITLE
fix: disabled state for references [TOL-2914]

### DIFF
--- a/cypress/component/reference/MultipleEntryReferenceEditor.spec.tsx
+++ b/cypress/component/reference/MultipleEntryReferenceEditor.spec.tsx
@@ -41,7 +41,7 @@ function modifyEntry(entry: Entry, modifier: Record<string, unknown>): Entry {
 
 describe('Multiple Reference Editor', () => {
   const findLinkExistingBtn = () => cy.findByTestId('linkEditor.linkExisting');
-  // const findCreateLinkBtn = () => cy.findByTestId('create-entry-link-button');
+  const findCreateLinkBtn = () => cy.findByTestId('create-entry-link-button');
   const findCustomCards = () => cy.findAllByTestId('custom-card');
   const findDefaultCards = () => cy.findAllByTestId('cf-ui-entry-card');
 
@@ -150,6 +150,21 @@ describe('Multiple Reference Editor', () => {
     findLinkExistingBtn().click(); // inserts 2 cards
     findLinkExistingBtn().click(); // inserts 1 card
     findLinkExistingBtn().should('not.exist'); // limit reached, button hidden.
+  });
+
+  it('hides card actions and drag handles when field is disabled', () => {
+    const sdk = createReferenceEditorTestSdk({
+      modifier: (sdk) => {
+        sdk.field.getIsDisabled = () => true;
+        return sdk;
+      },
+      initialValue: [asLink(fixtures.entries.published)],
+    });
+    mount(<MultipleEntryReferenceEditor {...commonProps} sdk={sdk} hasCardEditActions={false} />);
+    findLinkExistingBtn().should('be.disabled');
+    findCreateLinkBtn().should('be.disabled');
+    findDefaultCards().eq(0).findByTestId('cf-ui-card-actions').should('not.exist');
+    findDefaultCards().eq(0).findByTestId('cf-ui-drag-handle').should('not.exist');
   });
 
   it(`shows status of entries`, () => {
@@ -325,41 +340,12 @@ describe('Multiple Reference Editor', () => {
     findDefaultCards().eq(0).findByTestId('title').should('have.text', `Weather doesn't look good`);
   });
 
-  //TODO: Currently fails
-  // it('shows disabled links as disabled', () => {
-  //   const sdk = createReferenceEditorTestSdk({
-  //     initialValue: [asLink(fixtures.entries.published)],
-  //   });
-  //   mount(<MultipleEntryReferenceEditor {...commonProps} isInitiallyDisabled={true} sdk={sdk} />);
-
-  //   findLinkExistingBtn().should('be.disabled');
-  //   findCreateLinkBtn().should('be.disabled');
-
-  //   findDefaultCards().eq(0).findByTestId('cf-ui-card-actions').should('be.disabled');
-  // });
-
-  it('shows disabled links as non-draggable', () => {
-    const sdk = createReferenceEditorTestSdk({
-      initialValue: [asLink(fixtures.entries.published)],
-    });
-    mount(<MultipleEntryReferenceEditor {...commonProps} isInitiallyDisabled={true} sdk={sdk} />);
-
-    findDefaultCards().eq(0).findByTestId('cf-ui-drag-handle').should('not.exist');
-  });
-
   it('can hide edit action', () => {
     const sdk = createReferenceEditorTestSdk({
       initialValue: [asLink(fixtures.entries.published), asLink(fixtures.entries.changed)],
     });
 
-    mount(
-      <MultipleEntryReferenceEditor
-        {...commonProps}
-        hasCardEditActions={false}
-        isInitiallyDisabled={true}
-        sdk={sdk}
-      />
-    );
+    mount(<MultipleEntryReferenceEditor {...commonProps} hasCardEditActions={false} sdk={sdk} />);
 
     findDefaultCards().eq(0).findByTestId('cf-ui-card-actions').click();
     cy.findByTestId('edit').should('not.exist');

--- a/cypress/component/reference/MultipleMediaEditor.spec.tsx
+++ b/cypress/component/reference/MultipleMediaEditor.spec.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import { Asset, Button, Card, Heading } from '@contentful/f36-components';
-import { AssetProps } from 'contentful-management';
+import { AssetProps, Link } from 'contentful-management';
 
 import { CombinedLinkActions, MultipleMediaEditor } from '../../../packages/reference/src';
 import { createReferenceEditorTestSdk, fixtures } from '../../fixtures';
@@ -17,6 +17,10 @@ const commonProps = {
   },
   viewType: 'card',
 } as React.ComponentProps<typeof MultipleMediaEditor>;
+
+function asLink(asset: AssetProps): Link<'Asset'> {
+  return { sys: { type: 'Link', linkType: 'Asset', id: asset.sys.id } };
+}
 
 describe('Multiple Media Editor', () => {
   const findCreateAndLinkBtn = () => cy.findByTestId('linkEditor.createAndLink');
@@ -56,6 +60,21 @@ describe('Multiple Media Editor', () => {
 
       findCreateAndLinkBtn().click();
       findCards().should('have.length', 1);
+    });
+
+    it('should disable actions when field is disabled', () => {
+      const sdk = createReferenceEditorTestSdk({
+        modifier: (sdk) => {
+          sdk.field.getIsDisabled = () => true;
+          return sdk;
+        },
+        initialValue: [asLink(fixtures.assets.published)],
+      });
+      mount(<MultipleMediaEditor {...commonProps} sdk={sdk} />);
+      findLinkExistingBtn().should('be.disabled');
+      findCreateAndLinkBtn().should('be.disabled');
+      cy.findByTestId('cf-ui-card-actions').click();
+      cy.findByText('Remove').should('not.exist');
     });
   });
 

--- a/cypress/component/reference/MultipleResourceReferenceEditor.spec.tsx
+++ b/cypress/component/reference/MultipleResourceReferenceEditor.spec.tsx
@@ -5,7 +5,7 @@ import { Entity, ResourceLink } from '../../../packages/reference/src/types';
 import { createReferenceEditorTestSdk, fixtures } from '../../fixtures';
 import { mount } from '../mount';
 
-function asLink<E extends Entity>(entity: E): ResourceLink {
+function asLink<E extends Entity>(entity: E): ResourceLink<'Contentful:Entry'> {
   return {
     sys: {
       type: 'ResourceLink',
@@ -109,19 +109,24 @@ describe('Multiple resource editor', () => {
     findDefaultCards().eq(1).findByTestId('title').should('have.text', 'The best article ever');
   });
 
-  it('shows disabled links as non-draggable', () => {
+  it('hides card actions and drag handles when field is disabled', () => {
     const sdk = createReferenceEditorTestSdk({
+      modifier: (sdk) => {
+        sdk.field.getIsDisabled = () => true;
+        return sdk;
+      },
       initialValue: [asLink(fixtures.entries.published)],
     });
     mount(
       <MultipleResourceReferenceEditor
         {...commonProps}
         viewType="card"
-        isInitiallyDisabled={true}
+        hasCardEditActions={false}
         sdk={sdk}
       />
     );
-
+    findLinkExistingBtn().should('be.disabled');
+    findDefaultCards().eq(0).findByTestId('cf-ui-card-actions').should('not.exist');
     findDefaultCards().eq(0).findByTestId('cf-ui-drag-handle').should('not.exist');
   });
 

--- a/cypress/component/reference/SingleResourceReferenceEditor.spec.tsx
+++ b/cypress/component/reference/SingleResourceReferenceEditor.spec.tsx
@@ -5,7 +5,7 @@ import { Entity, ResourceLink } from '../../../packages/reference/src/types';
 import { createReferenceEditorTestSdk, fixtures } from '../../fixtures';
 import { mount } from '../mount';
 
-function asLink<E extends Entity>(entity: E): ResourceLink {
+function asLink<E extends Entity>(entity: E): ResourceLink<'Contentful:Entry'> {
   return {
     sys: {
       type: 'ResourceLink',
@@ -108,6 +108,25 @@ describe('Single resource editor', () => {
     findMissingCards().should('have.length', 1);
 
     findMissingCards().first().get('#cf-ui-icon-button').should('not.exist');
+  });
+
+  it('hides card actions when field is disabled', () => {
+    const sdk = createReferenceEditorTestSdk({
+      modifier: (sdk) => {
+        sdk.field.getIsDisabled = () => true;
+        return sdk;
+      },
+      initialValue: asLink(fixtures.entries.changed),
+    });
+    mount(
+      <SingleResourceReferenceEditor
+        {...commonProps}
+        viewType="card"
+        hasCardEditActions={false}
+        sdk={sdk}
+      />
+    );
+    findDefaultCards().eq(0).findByTestId('cf-ui-card-actions').should('not.exist');
   });
 
   // TODO: Enable this test after navigation is moved into sdk.navigator

--- a/packages/reference/src/assets/WrappedAssetCard/AssetCardActions.tsx
+++ b/packages/reference/src/assets/WrappedAssetCard/AssetCardActions.tsx
@@ -126,8 +126,8 @@ export function renderActions(props: {
         Download
       </Menu.Item>
     ) : null,
-    onRemove ? (
-      <Menu.Item key="remove" disabled={isDisabled} onClick={onRemove} testId="card-action-remove">
+    onRemove && !isDisabled ? (
+      <Menu.Item key="remove" onClick={onRemove} testId="card-action-remove">
         Remove
       </Menu.Item>
     ) : null,

--- a/packages/reference/src/assets/WrappedAssetCard/WrappedAssetCard.tsx
+++ b/packages/reference/src/assets/WrappedAssetCard/WrappedAssetCard.tsx
@@ -153,8 +153,8 @@ export const WrappedAssetCard = ({
           : undefined
       }
       dragHandleRender={renderDragHandle}
-      withDragHandle={!!renderDragHandle}
-      draggable={!!renderDragHandle}
+      withDragHandle={!!renderDragHandle && !isDisabled}
+      draggable={!!renderDragHandle && !isDisabled}
       actions={[
         ...renderActions({ entityFile, isDisabled: isDisabled, onEdit, onRemove }),
         ...(entityFile ? renderAssetInfo({ entityFile }) : []),

--- a/packages/reference/src/assets/WrappedAssetCard/WrappedAssetLink.tsx
+++ b/packages/reference/src/assets/WrappedAssetCard/WrappedAssetLink.tsx
@@ -85,7 +85,7 @@ export const WrappedAssetLink = (props: WrappedAssetLinkProps) => {
         }
       }}
       dragHandleRender={props.renderDragHandle}
-      withDragHandle={!!props.renderDragHandle}
+      withDragHandle={!!props.renderDragHandle && !isDisabled}
       actions={[
         renderActions({ entityFile, isDisabled: isDisabled, onEdit, onRemove }),
         entityFile ? renderAssetInfo({ entityFile }) : null,

--- a/packages/reference/src/entries/WrappedEntryCard/WrappedEntryCard.tsx
+++ b/packages/reference/src/entries/WrappedEntryCard/WrappedEntryCard.tsx
@@ -157,8 +157,8 @@ export function WrappedEntryCard({
       }
       thumbnailElement={file && isValidImage(file) ? <AssetThumbnail file={file} /> : undefined}
       dragHandleRender={renderDragHandle}
-      withDragHandle={!!renderDragHandle}
-      draggable={!!renderDragHandle}
+      withDragHandle={!!renderDragHandle && !isDisabled}
+      draggable={!!renderDragHandle && !isDisabled}
       actions={
         onEdit || onRemove
           ? [
@@ -173,7 +173,7 @@ export function WrappedEntryCard({
                   Edit
                 </MenuItem>
               ) : null,
-              hasCardRemoveActions && onRemove ? (
+              hasCardRemoveActions && onRemove && !isDisabled ? (
                 <MenuItem
                   key="delete"
                   testId="delete"
@@ -184,15 +184,15 @@ export function WrappedEntryCard({
                   Remove
                 </MenuItem>
               ) : null,
-              hasCardMoveActions && (onMoveTop || onMoveBottom) ? (
+              hasCardMoveActions && (onMoveTop || onMoveBottom) && !isDisabled ? (
                 <MenuDivider key="divider" />
               ) : null,
-              hasCardMoveActions && onMoveTop ? (
+              hasCardMoveActions && onMoveTop && !isDisabled ? (
                 <MenuItem key="move-top" onClick={() => onMoveTop && onMoveTop()} testId="move-top">
                   Move to top
                 </MenuItem>
               ) : null,
-              hasCardMoveActions && onMoveBottom ? (
+              hasCardMoveActions && onMoveBottom && !isDisabled ? (
                 <MenuItem
                   key="move-bottom"
                   onClick={() => onMoveBottom && onMoveBottom()}

--- a/packages/reference/src/resources/Cards/ResourceCard.tsx
+++ b/packages/reference/src/resources/Cards/ResourceCard.tsx
@@ -35,7 +35,6 @@ function ExistingResourceCard(
     enabled: inView,
     allowExternal: true,
   };
-  console.log('ResourceCard', resourceLink, resourceOptions);
   const { data: info, error } = useResource(
     resourceLink.sys.linkType,
     resourceLink.sys.urn,

--- a/packages/reference/src/resources/Cards/ResourceCard.tsx
+++ b/packages/reference/src/resources/Cards/ResourceCard.tsx
@@ -35,6 +35,7 @@ function ExistingResourceCard(
     enabled: inView,
     allowExternal: true,
   };
+  console.log('ResourceCard', resourceLink, resourceOptions);
   const { data: info, error } = useResource(
     resourceLink.sys.linkType,
     resourceLink.sys.urn,

--- a/packages/reference/src/resources/MultipleResourceReferenceEditor.tsx
+++ b/packages/reference/src/resources/MultipleResourceReferenceEditor.tsx
@@ -73,6 +73,7 @@ function ResourceEditor(props: EditorProps) {
       <CombinedLinkEntityActions
         {...linkActionsProps}
         renderCustomActions={props.renderCustomActions}
+        isDisabled={props.isDisabled}
       />
     </>
   );

--- a/packages/reference/src/resources/SingleResourceReferenceEditor.tsx
+++ b/packages/reference/src/resources/SingleResourceReferenceEditor.tsx
@@ -41,6 +41,7 @@ export function SingleResourceReferenceEditor(
             <CombinedLinkEntityActions
               {...linkActionsProps}
               renderCustomActions={props.renderCustomActions}
+              isDisabled={disabled}
             />
           );
         }}


### PR DESCRIPTION
References had some bugs with disabled state in the case where the field is disabled but we have permissions. This PR makes it so that any modifying actions (removing, moving, or adding) are disabled and/or hidden even if we have permission as long as the field is disabled