### PR TITLE
feat: Improve Accessibility of field editors by enabling associating them with labels [UFO-1737]

### DIFF
--- a/packages/boolean/src/BooleanEditor.tsx
+++ b/packages/boolean/src/BooleanEditor.tsx
@@ -54,15 +54,15 @@ export function BooleanEditor(props: BooleanEditorProps) {
 
         return (
           <Flex testId="boolean-editor" alignItems="center" marginTop="spacingS">
-            {options.map((item) => {
-              const id = ['entity', field.id, field.locale, item.value, item.id].join('.');
-              const checked = value === item.value;
+            {options.map((option) => {
+              const id = ['entity', field.id, field.locale, option.value, option.id].join('.');
+              const checked = value === option.value;
               return (
                 <Flex marginRight="spacingM" key={id}>
                   <Radio
                     id={id}
                     isDisabled={disabled}
-                    value={item.value === undefined ? '' : String(item.value)}
+                    value={option.value === undefined ? '' : String(option.value)}
                     isChecked={checked}
                     onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
                       if (e.target.checked) {
@@ -70,7 +70,7 @@ export function BooleanEditor(props: BooleanEditorProps) {
                       }
                     }}
                   >
-                    {item.label}
+                    {option.label}
                   </Radio>
                 </Flex>
               );

--- a/packages/boolean/stories/BooleanEditor.stories.tsx
+++ b/packages/boolean/stories/BooleanEditor.stories.tsx
@@ -1,18 +1,19 @@
 import * as React from 'react';
 
+import { FormControl } from '@contentful/f36-components';
 import { ActionsPlayground, createFakeFieldAPI } from '@contentful/field-editor-test-utils';
 import type { Meta, StoryObj } from '@storybook/react';
 
-import * as Editor from '../src/BooleanEditor';
+import { BooleanEditor } from '../src/BooleanEditor';
 
-const meta: Meta<typeof Editor.BooleanEditor> = {
+const meta: Meta<typeof BooleanEditor> = {
   title: 'editors/Boolean',
-  component: Editor.BooleanEditor,
+  component: BooleanEditor,
 };
 
 export default meta;
 
-type Story = StoryObj<typeof Editor.BooleanEditor>;
+type Story = StoryObj<typeof BooleanEditor>;
 
 export const Default: Story = {
   parameters: {
@@ -21,10 +22,10 @@ export const Default: Story = {
   render: () => {
     const [field, mitt] = createFakeFieldAPI();
     return (
-      <div>
-        <Editor.BooleanEditor field={field} isInitiallyDisabled={false} />
+      <FormControl as="fieldset" aria-label="Choose one">
+        <BooleanEditor field={field} isInitiallyDisabled={false} />
         <ActionsPlayground mitt={mitt} />
-      </div>
+      </FormControl>
     );
   },
 };

--- a/packages/dropdown/src/DropdownEditor.tsx
+++ b/packages/dropdown/src/DropdownEditor.tsx
@@ -25,10 +25,15 @@ export interface DropdownEditorProps {
    * sdk.locales
    */
   locales: LocalesAPI;
+
+  /**
+   * id used for associating the input field with its label
+   */
+  id?: string;
 }
 
 export function DropdownEditor(props: DropdownEditorProps) {
-  const { field, locales } = props;
+  const { field, locales, id } = props;
 
   const options = getOptions(field);
   const misconfigured = options.length === 0;
@@ -48,6 +53,7 @@ export function DropdownEditor(props: DropdownEditorProps) {
       {({ value, errors, disabled, setValue }) => (
         <Select
           testId="dropdown-editor"
+          id={id}
           isInvalid={errors.length > 0}
           isDisabled={disabled}
           className={direction === 'rtl' ? styles.rightToLeft : ''}

--- a/packages/dropdown/stories/DropdownEditor.stories.tsx
+++ b/packages/dropdown/stories/DropdownEditor.stories.tsx
@@ -35,6 +35,7 @@ export const Default: Story = {
           field={field}
           locales={createFakeLocalesAPI()}
           isInitiallyDisabled={false}
+          id="dropdown-field-editor-default"
         />
         <ActionsPlayground mitt={mitt} />
       </div>

--- a/packages/list/src/ListEditor.tsx
+++ b/packages/list/src/ListEditor.tsx
@@ -22,6 +22,11 @@ export interface ListEditorProps {
    * sdk.locales
    */
   locales: LocalesAPI;
+
+  /**
+   * id used for associating the input field with its label
+   */
+  id?: string;
 }
 
 type ListValue = string[];
@@ -31,7 +36,7 @@ function isEmptyListValue(value: ListValue | null) {
 }
 
 export function ListEditor(props: ListEditorProps) {
-  const { field, locales } = props;
+  const { field, locales, id } = props;
 
   const direction = locales.direction[field.locale] || 'ltr';
 
@@ -43,7 +48,12 @@ export function ListEditor(props: ListEditorProps) {
       isInitiallyDisabled={props.isInitiallyDisabled}
     >
       {(childProps) => (
-        <ListEditorInternal {...childProps} direction={direction} isRequired={field.required} />
+        <ListEditorInternal
+          {...childProps}
+          direction={direction}
+          isRequired={field.required}
+          id={id}
+        />
       )}
     </FieldConnector>
   );
@@ -56,7 +66,12 @@ function ListEditorInternal({
   disabled,
   direction,
   isRequired,
-}: FieldConnectorChildProps<ListValue> & { direction: 'rtl' | 'ltr'; isRequired: boolean }) {
+  id,
+}: FieldConnectorChildProps<ListValue> & {
+  direction: 'rtl' | 'ltr';
+  isRequired: boolean;
+  id?: string;
+}) {
   const [valueState, setValueState] = React.useState(() => (value || []).join(', '));
 
   const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -73,6 +88,7 @@ function ListEditorInternal({
 
   return (
     <TextInput
+      id={id}
       testId="list-editor-input"
       className={direction === 'rtl' ? styles.rightToLeft : ''}
       isRequired={isRequired}

--- a/packages/list/stories/ListEditor.stories.tsx
+++ b/packages/list/stories/ListEditor.stories.tsx
@@ -26,7 +26,12 @@ export const Default: Story = {
     const [field, mitt] = createFakeFieldAPI();
     return (
       <div>
-        <ListEditor field={field} locales={createFakeLocalesAPI()} isInitiallyDisabled={false} />
+        <ListEditor
+          id="field-editor-list"
+          field={field}
+          locales={createFakeLocalesAPI()}
+          isInitiallyDisabled={false}
+        />
         <ActionsPlayground mitt={mitt} />
       </div>
     );

--- a/packages/multiple-line/src/MultipleLineEditor.tsx
+++ b/packages/multiple-line/src/MultipleLineEditor.tsx
@@ -34,10 +34,12 @@ export interface MultipleLineEditorProps {
   locales: LocalesAPI;
 
   isDisabled?: boolean;
+
+  id?: string;
 }
 
 export function MultipleLineEditor(props: MultipleLineEditorProps) {
-  const { field, locales, isInitiallyDisabled, withCharValidation, isDisabled } = props;
+  const { field, locales, isInitiallyDisabled, withCharValidation, isDisabled, id } = props;
 
   const constraints = ConstraintsUtils.fromFieldValidations(
     field.validations,
@@ -56,6 +58,7 @@ export function MultipleLineEditor(props: MultipleLineEditorProps) {
         return (
           <div data-test-id="multiple-line-editor">
             <Textarea
+              id={id}
               className={direction === 'rtl' ? styles.rightToLeft : ''}
               rows={3}
               isRequired={field.required}

--- a/packages/multiple-line/src/MultipleLineEditor.tsx
+++ b/packages/multiple-line/src/MultipleLineEditor.tsx
@@ -2,8 +2,8 @@ import * as React from 'react';
 
 import { Textarea } from '@contentful/f36-components';
 import {
-  FieldAPI,
-  LocalesAPI,
+  type FieldAPI,
+  type LocalesAPI,
   FieldConnector,
   CharCounter,
   CharValidation,
@@ -33,6 +33,9 @@ export interface MultipleLineEditorProps {
    */
   locales: LocalesAPI;
 
+  /**
+   * alias for disabled native property
+   */
   isDisabled?: boolean;
 
   /**

--- a/packages/multiple-line/src/MultipleLineEditor.tsx
+++ b/packages/multiple-line/src/MultipleLineEditor.tsx
@@ -35,6 +35,9 @@ export interface MultipleLineEditorProps {
 
   isDisabled?: boolean;
 
+  /**
+   * id used for associating the input field with its label
+   */
   id?: string;
 }
 

--- a/packages/multiple-line/stories/MultipleLineEditor.stories.tsx
+++ b/packages/multiple-line/stories/MultipleLineEditor.stories.tsx
@@ -32,7 +32,12 @@ export const Default: Story = {
     const locales = createFakeLocalesAPI();
     return (
       <div>
-        <MultipleLineEditor field={field} locales={locales} isInitiallyDisabled={false} />
+        <MultipleLineEditor
+          id="multi-line-editor-default"
+          field={field}
+          locales={locales}
+          isInitiallyDisabled={false}
+        />
         <ActionsPlayground mitt={mitt} />
       </div>
     );

--- a/packages/number/src/NumberEditor.tsx
+++ b/packages/number/src/NumberEditor.tsx
@@ -23,6 +23,9 @@ export interface NumberEditorProps {
    */
   field: FieldAPI;
 
+  /**
+   * id used for associating the input field with its label
+   */
   id?: string;
 }
 

--- a/packages/number/src/NumberEditor.tsx
+++ b/packages/number/src/NumberEditor.tsx
@@ -3,9 +3,9 @@ import * as React from 'react';
 import { TextInput } from '@contentful/f36-components';
 import { ArrowUpTrimmedIcon, ArrowDownTrimmedIcon } from '@contentful/f36-icons';
 import {
-  FieldAPI,
+  type FieldAPI,
   FieldConnector,
-  FieldConnectorChildProps,
+  type FieldConnectorChildProps,
 } from '@contentful/field-editor-shared';
 
 import { styles } from './NumberEditor.styles';

--- a/packages/number/src/NumberEditor.tsx
+++ b/packages/number/src/NumberEditor.tsx
@@ -22,6 +22,8 @@ export interface NumberEditorProps {
    * sdk.field
    */
   field: FieldAPI;
+
+  id?: string;
 }
 
 type InnerNumberEditorProps = Pick<
@@ -29,6 +31,7 @@ type InnerNumberEditorProps = Pick<
   'disabled' | 'errors' | 'setValue' | 'value'
 > & {
   field: NumberEditorProps['field'];
+  id: NumberEditorProps['id'];
 };
 
 enum StepChangeType {
@@ -44,6 +47,7 @@ function InnerNumberEditor({
   field,
   setValue,
   value: sdkValue,
+  id,
 }: InnerNumberEditorProps) {
   const [inputValue, setInputValue] = React.useState(valueToString(sdkValue));
   const range = getRangeFromField(field);
@@ -126,6 +130,7 @@ function InnerNumberEditor({
         // so we use "text" instead and fully rely on our own validation.
         // See more details: https://github.com/facebook/react/issues/6556
         type="text"
+        id={id}
         testId="number-editor-input"
         className={styles.input}
         min={range.min}
@@ -155,14 +160,16 @@ function InnerNumberEditor({
             tabIndex={-1}
             className={styles.control}
             onClick={() => changeValueByStep(StepChangeType.Increment)}
-            onPointerDown={handleControlPointerDown}>
+            onPointerDown={handleControlPointerDown}
+          >
             <ArrowUpTrimmedIcon size="medium" />
           </button>
           <button
             tabIndex={-1}
             className={styles.control}
             onClick={() => changeValueByStep(StepChangeType.Decrement)}
-            onPointerDown={handleControlPointerDown}>
+            onPointerDown={handleControlPointerDown}
+          >
             <ArrowDownTrimmedIcon size="medium" />
           </button>
         </div>
@@ -172,7 +179,7 @@ function InnerNumberEditor({
 }
 
 export function NumberEditor(props: NumberEditorProps) {
-  const { field } = props;
+  const { field, id } = props;
 
   return (
     <FieldConnector<number> field={field} isInitiallyDisabled={props.isInitiallyDisabled}>
@@ -183,6 +190,7 @@ export function NumberEditor(props: NumberEditorProps) {
         setValue,
       }: Pick<FieldConnectorChildProps<number>, 'disabled' | 'errors' | 'setValue' | 'value'>) => (
         <InnerNumberEditor
+          id={id}
           disabled={disabled}
           errors={errors}
           field={field}

--- a/packages/number/stories/NumberEditor.stories.tsx
+++ b/packages/number/stories/NumberEditor.stories.tsx
@@ -22,7 +22,7 @@ export const Default: Story = {
     const [field, mitt] = createFakeFieldAPI();
     return (
       <div>
-        <NumberEditor field={field} isInitiallyDisabled={false} />
+        <NumberEditor field={field} isInitiallyDisabled={false} id="number-field-edtior-default" />
         <ActionsPlayground mitt={mitt} />
       </div>
     );

--- a/packages/single-line/src/SingleLineEditor.tsx
+++ b/packages/single-line/src/SingleLineEditor.tsx
@@ -51,6 +51,8 @@ export interface SingleLineEditorProps {
    * focus event handler
    */
   onFocus?: (event: React.FocusEvent<HTMLInputElement>) => void;
+
+  id?: string;
 }
 
 function isSupportedFieldTypes(val: string): val is 'Symbol' | 'Text' {
@@ -67,6 +69,7 @@ export function SingleLineEditor(props: SingleLineEditorProps) {
     onFocus,
     withCharInformation = true,
     withCharValidation = true,
+    id,
   } = props;
 
   if (!isSupportedFieldTypes(field.type)) {
@@ -88,6 +91,7 @@ export function SingleLineEditor(props: SingleLineEditorProps) {
         return (
           <div data-test-id="single-line-editor">
             <TextInput
+              id={id}
               className={direction === 'rtl' ? styles.rightToLeft : ''}
               isRequired={field.required}
               isInvalid={errors.length > 0}

--- a/packages/single-line/src/SingleLineEditor.tsx
+++ b/packages/single-line/src/SingleLineEditor.tsx
@@ -2,12 +2,12 @@ import * as React from 'react';
 
 import { TextInput } from '@contentful/f36-components';
 import {
-  FieldAPI,
+  type FieldAPI,
   FieldConnector,
   ConstraintsUtils,
   CharCounter,
   CharValidation,
-  LocalesAPI,
+  type LocalesAPI,
 } from '@contentful/field-editor-shared';
 
 import * as styles from './styles';

--- a/packages/single-line/src/SingleLineEditor.tsx
+++ b/packages/single-line/src/SingleLineEditor.tsx
@@ -52,6 +52,9 @@ export interface SingleLineEditorProps {
    */
   onFocus?: (event: React.FocusEvent<HTMLInputElement>) => void;
 
+  /**
+   * id used for associating the input field with its label
+   */
   id?: string;
 }
 

--- a/packages/slug/src/SlugEditor.tsx
+++ b/packages/slug/src/SlugEditor.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { FieldAppSDK, FieldAPI, ValidationError } from '@contentful/app-sdk';
+import type { FieldAppSDK, FieldAPI, ValidationError } from '@contentful/app-sdk';
 import { FieldConnector } from '@contentful/field-editor-shared';
 
 import { SlugEditorField, SlugEditorFieldStatic } from './SlugEditorField';
@@ -18,6 +18,11 @@ export interface SlugEditorProps {
    * sdk.field
    */
   field: FieldAPI;
+
+  /**
+   * id used for associating the input field with its label
+   */
+  id?: string;
 
   parameters?: {
     instance: {
@@ -41,6 +46,7 @@ function FieldConnectorCallback({
   locale,
   createdAt,
   performUniqueCheck,
+  id,
 }: {
   Component: typeof SlugEditorFieldStatic | typeof SlugEditorField;
   value: string | null | undefined;
@@ -52,6 +58,7 @@ function FieldConnectorCallback({
   locale: FieldAPI['locale'];
   createdAt: string;
   performUniqueCheck: (value: string) => Promise<boolean>;
+  id?: string;
 }) {
   // it is needed to silent permission errors
   // this happens when setValue is called on a field which is disabled for permission reasons
@@ -78,13 +85,14 @@ function FieldConnectorCallback({
         isDisabled={disabled}
         titleValue={titleValue}
         setValue={safeSetValue}
+        id={id}
       />
     </div>
   );
 }
 
 export function SlugEditor(props: SlugEditorProps) {
-  const { field, parameters } = props;
+  const { field, parameters, id } = props;
   const { locales, entry, space } = props.baseSdk;
 
   if (!isSupportedFieldTypes(field.type)) {
@@ -154,6 +162,7 @@ export function SlugEditor(props: SlugEditorProps) {
                 locale={field.locale}
                 performUniqueCheck={performUniqueCheck}
                 key={`slug-editor-${externalReset}`}
+                id={id}
               />
             );
           }}

--- a/packages/slug/src/SlugEditorField.tsx
+++ b/packages/slug/src/SlugEditorField.tsx
@@ -17,6 +17,7 @@ interface SlugEditorFieldProps {
   createdAt: string;
   setValue: (value: string | null | undefined) => void;
   performUniqueCheck: (value: string) => Promise<boolean>;
+  id?: string;
 }
 
 type CheckerState = 'checking' | 'unique' | 'duplicate';
@@ -70,7 +71,7 @@ function useUniqueChecker(props: SlugEditorFieldProps) {
 export function SlugEditorFieldStatic(
   props: SlugEditorFieldProps & { onChange?: Function; onBlur?: Function }
 ) {
-  const { hasError, isDisabled, value, setValue, onChange, onBlur } = props;
+  const { hasError, isDisabled, value, setValue, onChange, onBlur, id } = props;
 
   const status = useUniqueChecker(props);
 
@@ -82,6 +83,7 @@ export function SlugEditorFieldStatic(
         isInvalid={hasError || status === 'duplicate'}
         isDisabled={isDisabled}
         value={value || ''}
+        id={id}
         onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
           setValue(e.target.value);
           if (onChange) {

--- a/packages/slug/stories/SlugEditor.stories.tsx
+++ b/packages/slug/stories/SlugEditor.stories.tsx
@@ -71,7 +71,7 @@ export const DefaultLocale: Story = {
         />
         <div style={{ marginTop: 20 }} />
         {/* @ts-expect-error */}
-        <SlugEditor baseSdk={sdk} field={field} isInitiallyDisabled={false} />
+        <SlugEditor baseSdk={sdk} field={field} isInitiallyDisabled={false} id="slug-field" />
         <ActionsPlayground mitt={mitt} />
       </React.Fragment>
     );

--- a/packages/tags/src/TagsEditor.tsx
+++ b/packages/tags/src/TagsEditor.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useState } from 'react';
 
 import { DragHandle, Pill, TextInput } from '@contentful/f36-components';
 import tokens from '@contentful/f36-tokens';
-import { DndContext, DragEndEvent } from '@dnd-kit/core';
+import { DndContext, type DragEndEvent } from '@dnd-kit/core';
 import { restrictToParentElement } from '@dnd-kit/modifiers';
 import { arrayMove, SortableContext, useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
@@ -10,7 +10,7 @@ import { css, cx } from 'emotion';
 import noop from 'lodash/noop';
 
 import { TagsEditorConstraints } from './TagsEditorConstraints';
-import { Constraint, ConstraintsType } from './types';
+import type { Constraint, ConstraintsType } from './types';
 
 export interface TagsEditorProps {
   items: string[];
@@ -19,6 +19,7 @@ export interface TagsEditorProps {
   constraintsType?: ConstraintsType;
   constraints?: Constraint;
   onUpdate: (items: string[]) => void;
+  id?: string;
 }
 
 const styles = {
@@ -77,7 +78,7 @@ const SortablePill = ({ id, label, index, disabled, onRemove }: SortablePillProp
 export function TagsEditor(props: TagsEditorProps) {
   const [pendingValue, setPendingValue] = useState('');
 
-  const { isDisabled, items, constraints, constraintsType, hasError, onUpdate } = props;
+  const { isDisabled, items, constraints, constraintsType, hasError, onUpdate, id } = props;
   const itemsMap = React.useMemo(
     () => items.map((item, index) => ({ id: item + index, value: item })),
     [items]
@@ -107,6 +108,7 @@ export function TagsEditor(props: TagsEditorProps) {
     <div data-test-id="tag-editor-container">
       <TextInput
         testId="tag-editor-input"
+        id={id}
         className={styles.input}
         isDisabled={isDisabled}
         isInvalid={hasError}

--- a/packages/tags/src/TagsEditorContainer.tsx
+++ b/packages/tags/src/TagsEditorContainer.tsx
@@ -1,20 +1,26 @@
 import * as React from 'react';
 
-import { FieldAPI, FieldConnector } from '@contentful/field-editor-shared';
+import { type FieldAPI, FieldConnector } from '@contentful/field-editor-shared';
 import isNumber from 'lodash/isNumber';
 
 import { TagsEditor } from './TagsEditor';
-import { ConstraintsType, Constraint } from './types';
+import type { ConstraintsType, Constraint } from './types';
 
 export interface TagsEditorContainerProps {
   /**
    * is the field disabled initially
    */
   isInitiallyDisabled: boolean;
+
   /**
    * sdk.field
    */
   field: FieldAPI;
+
+  /**
+   * id used for associating the input field with its label
+   */
+  id?: string;
 }
 
 type TagEditorValue = string[];
@@ -24,23 +30,25 @@ function isEmptyTagsValue(value: TagEditorValue | null) {
 }
 
 function getConstraintsType(sizeConstraints?: Constraint): ConstraintsType | undefined {
-  if (!sizeConstraints) {
+  if (!sizeConstraints || (!isNumber(sizeConstraints.min) && !isNumber(sizeConstraints.max))) {
     return undefined;
   }
   if (isNumber(sizeConstraints.min) && isNumber(sizeConstraints.max)) {
     return 'min-max';
-  } else if (isNumber(sizeConstraints.min)) {
-    return 'min';
-  } else if (isNumber(sizeConstraints.max)) {
-    return 'max';
-  } else {
-    return undefined;
   }
+
+  if (isNumber(sizeConstraints.min)) {
+    return 'min';
+  }
+
+  if (isNumber(sizeConstraints.max)) {
+    return 'max';
+  }
+
+  return undefined;
 }
 
-export function TagsEditorContainer(props: TagsEditorContainerProps) {
-  const field = props.field;
-
+export function TagsEditorContainer({ isInitiallyDisabled, field, id }: TagsEditorContainerProps) {
   const validations = field.validations || [];
 
   const sizeValidations = (validations as { size?: Constraint }[])
@@ -54,7 +62,7 @@ export function TagsEditorContainer(props: TagsEditorContainerProps) {
   return (
     <FieldConnector<TagEditorValue>
       field={field}
-      isInitiallyDisabled={props.isInitiallyDisabled}
+      isInitiallyDisabled={isInitiallyDisabled}
       isEmptyValue={isEmptyTagsValue}
       debounce={0}
     >
@@ -62,6 +70,7 @@ export function TagsEditorContainer(props: TagsEditorContainerProps) {
         const items = value || [];
         return (
           <TagsEditor
+            id={id}
             constraints={constraints}
             constraintsType={constraintsType}
             isDisabled={disabled}

--- a/packages/tags/stories/TagsEditor.stories.tsx
+++ b/packages/tags/stories/TagsEditor.stories.tsx
@@ -22,7 +22,7 @@ export const EmptyInitialValue: Story = {
     const [field, mitt] = createFakeFieldAPI();
     return (
       <div>
-        <TagsEditor field={field} isInitiallyDisabled={false} />
+        <TagsEditor field={field} isInitiallyDisabled={false} id="initial-empty-tags-editor" />
         <ActionsPlayground mitt={mitt} />
       </div>
     );

--- a/packages/url/src/UrlEditor.tsx
+++ b/packages/url/src/UrlEditor.tsx
@@ -3,7 +3,6 @@ import * as React from 'react';
 import { TextInput } from '@contentful/f36-components';
 import { FieldAPI, FieldConnector } from '@contentful/field-editor-shared';
 
-
 export interface UrlEditorProps {
   /**
    * is the field disabled initially
@@ -15,11 +14,13 @@ export interface UrlEditorProps {
    */
   field: FieldAPI;
 
+  id?: string;
+
   children?: (props: { value: string | null | undefined }) => React.ReactNode;
 }
 
 export function UrlEditor(props: UrlEditorProps) {
-  const { field } = props;
+  const { field, id } = props;
 
   return (
     <FieldConnector<string> field={field} isInitiallyDisabled={props.isInitiallyDisabled}>
@@ -27,6 +28,7 @@ export function UrlEditor(props: UrlEditorProps) {
         return (
           <div data-test-id="url-editor">
             <TextInput
+              id={id}
               isRequired={field.required}
               isInvalid={errors.length > 0}
               isDisabled={disabled}

--- a/packages/url/src/UrlEditor.tsx
+++ b/packages/url/src/UrlEditor.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import { TextInput } from '@contentful/f36-components';
-import { FieldAPI, FieldConnector } from '@contentful/field-editor-shared';
+import { type FieldAPI, FieldConnector } from '@contentful/field-editor-shared';
 
 export interface UrlEditorProps {
   /**
@@ -14,6 +14,9 @@ export interface UrlEditorProps {
    */
   field: FieldAPI;
 
+  /**
+   * id used for associating the input field with its label
+   */
   id?: string;
 
   children?: (props: { value: string | null | undefined }) => React.ReactNode;

--- a/packages/url/stories/UrlEditor.stories.tsx
+++ b/packages/url/stories/UrlEditor.stories.tsx
@@ -22,7 +22,7 @@ export const Default: Story = {
     const [field, mitt] = createFakeFieldAPI();
     return (
       <div>
-        <UrlEditor field={field} isInitiallyDisabled={false} />
+        <UrlEditor field={field} isInitiallyDisabled={false} id="url-editor-default" />
         <ActionsPlayground mitt={mitt} />
       </div>
     );


### PR DESCRIPTION
### Problem:

our field editors did not accept or forward an ID prop, which is a anti pattern for accessibility. Associating a label with an input field enables autofocusing of the associated input field when selecting / clicking on the label. 

### Risks

fields could get, on accident, the same ID (when e.g. using an array index for id) which worsens the accessibility and violates HTML5 rules.
