### PR TITLE
fix(slug-editor): [TOL-3065] Do not autogenerate slug if user has no access

### DIFF
--- a/packages/slug/src/SlugEditor.tsx
+++ b/packages/slug/src/SlugEditor.tsx
@@ -29,6 +29,8 @@ export interface SlugEditorProps {
       trackingFieldId?: string;
     };
   };
+
+  access?: boolean;
 }
 
 function isSupportedFieldTypes(val: string): val is 'Symbol' {
@@ -47,6 +49,7 @@ function FieldConnectorCallback({
   createdAt,
   performUniqueCheck,
   id,
+  access = true,
 }: {
   Component: typeof SlugEditorFieldStatic | typeof SlugEditorField;
   value: string | null | undefined;
@@ -59,6 +62,7 @@ function FieldConnectorCallback({
   createdAt: string;
   performUniqueCheck: (value: string) => Promise<boolean>;
   id?: string;
+  access?: boolean;
 }) {
   // it is needed to silent permission errors
   // this happens when setValue is called on a field which is disabled for permission reasons
@@ -70,7 +74,7 @@ function FieldConnectorCallback({
         // do nothing
       }
     },
-    [setValue]
+    [setValue],
   );
 
   return (
@@ -86,13 +90,14 @@ function FieldConnectorCallback({
         titleValue={titleValue}
         setValue={safeSetValue}
         id={id}
+        access={access}
       />
     </div>
   );
 }
 
 export function SlugEditor(props: SlugEditorProps) {
-  const { field, parameters, id } = props;
+  const { access, field, parameters, id } = props;
   const { locales, entry, space } = props.baseSdk;
 
   if (!isSupportedFieldTypes(field.type)) {
@@ -111,7 +116,7 @@ export function SlugEditor(props: SlugEditorProps) {
   // one or the title field is also localized with a custom value.
   const isOptionalFieldLocale = Boolean(!field.required || isLocaleOptional);
   const isOptionalLocaleWithFallback = Boolean(
-    isOptionalFieldLocale && localeFallbackCode && locales.available.includes(localeFallbackCode)
+    isOptionalFieldLocale && localeFallbackCode && locales.available.includes(localeFallbackCode),
   );
 
   const performUniqueCheck = React.useCallback(
@@ -127,7 +132,7 @@ export function SlugEditor(props: SlugEditorProps) {
         return res.total === 0;
       });
     },
-    [entrySys?.contentType?.sys?.id, field.id, field.locale, entrySys.id, space]
+    [entrySys?.contentType?.sys?.id, field.id, field.locale, entrySys.id, space],
   );
 
   return (
@@ -163,6 +168,7 @@ export function SlugEditor(props: SlugEditorProps) {
                 performUniqueCheck={performUniqueCheck}
                 key={`slug-editor-${externalReset}`}
                 id={id}
+                access={access}
               />
             );
           }}

--- a/packages/slug/src/SlugEditorField.tsx
+++ b/packages/slug/src/SlugEditorField.tsx
@@ -18,14 +18,26 @@ interface SlugEditorFieldProps {
   setValue: (value: string | null | undefined) => void;
   performUniqueCheck: (value: string) => Promise<boolean>;
   id?: string;
+  access?: boolean;
 }
 
 type CheckerState = 'checking' | 'unique' | 'duplicate';
 
 function useSlugUpdater(props: SlugEditorFieldProps, check: boolean) {
-  const { value, setValue, createdAt, locale, titleValue, isOptionalLocaleWithFallback } = props;
+  const {
+    access = true,
+    value,
+    setValue,
+    createdAt,
+    locale,
+    titleValue,
+    isOptionalLocaleWithFallback,
+  } = props;
 
   React.useEffect(() => {
+    if (!access) {
+      return;
+    }
     if (check === false) {
       return;
     }
@@ -37,7 +49,7 @@ function useSlugUpdater(props: SlugEditorFieldProps, check: boolean) {
     if (newSlug !== value) {
       setValue(newSlug);
     }
-  }, [value, titleValue, isOptionalLocaleWithFallback, check, createdAt, locale, setValue]);
+  }, [value, titleValue, isOptionalLocaleWithFallback, check, createdAt, locale, setValue, access]);
 }
 
 function useUniqueChecker(props: SlugEditorFieldProps) {
@@ -69,7 +81,7 @@ function useUniqueChecker(props: SlugEditorFieldProps) {
 }
 
 export function SlugEditorFieldStatic(
-  props: SlugEditorFieldProps & { onChange?: Function; onBlur?: Function }
+  props: SlugEditorFieldProps & { onChange?: Function; onBlur?: Function },
 ) {
   const { hasError, isDisabled, value, setValue, onChange, onBlur, id } = props;
 
@@ -114,7 +126,7 @@ export function SlugEditorFieldStatic(
 }
 
 export function SlugEditorField(props: SlugEditorFieldProps) {
-  const { titleValue, isOptionalLocaleWithFallback, locale, createdAt, value } = props;
+  const { titleValue, isOptionalLocaleWithFallback, locale, createdAt, value, access } = props;
 
   const areEqual = React.useCallback(() => {
     const potentialSlug = makeSlug(titleValue, {
@@ -126,6 +138,9 @@ export function SlugEditorField(props: SlugEditorFieldProps) {
   }, [titleValue, isOptionalLocaleWithFallback, locale, createdAt, value]);
 
   const [check, setCheck] = React.useState<boolean>(() => {
+    if (!access) {
+      return false;
+    }
     if (props.value) {
       if (!props.titleValue) {
         return false;


### PR DESCRIPTION
Pass down access param to prevent slug autogeneration in cases when the user doesn't have permissions to edit the field.