### PR TITLE
feat: enable read-only assets and reference cards [SPA-2702]

### DIFF
--- a/packages/reference/src/assets/WrappedAssetCard/FetchingWrappedAssetCard.tsx
+++ b/packages/reference/src/assets/WrappedAssetCard/FetchingWrappedAssetCard.tsx
@@ -108,45 +108,32 @@ export function FetchingWrappedAssetCard(props: FetchingWrappedAssetCardProps) {
       );
     }
 
-    function _renderDefaultLink(props?: Partial<WrappedAssetLinkProps>) {
-      const builtinCardProps: Omit<WrappedAssetCardProps, 'isClickable'> & {
-        isClickable?: WrappedAssetCardProps['isClickable'];
-      } = {
-        ...commonProps,
-        ...props,
-        getEntityScheduledActions: loadEntityScheduledActions,
-        getAssetUrl: getEntityUrl,
-      };
-
-      return (
-        <WrappedAssetLink
-          {...builtinCardProps}
-          href={commonProps.entityUrl}
-          getEntityScheduledActions={loadEntityScheduledActions}
-        />
-      );
-    }
-
-    function _renderDefaultCard(props?: Partial<CustomEntityCardProps>) {
-      const builtinCardProps: Omit<WrappedAssetCardProps, 'isClickable'> & {
-        isClickable?: WrappedAssetCardProps['isClickable'];
-      } = {
-        ...commonProps,
-        ...props,
-        getEntityScheduledActions: loadEntityScheduledActions,
-        asset: (props?.entity as Asset) || commonProps.asset,
-        getAssetUrl: getEntityUrl,
-      };
-
-      return <WrappedAssetCard {...builtinCardProps} />;
-    }
-
     const viewType = props.viewType;
 
     function renderDefaultCard(
       props?: Partial<CustomEntityCardProps> | Partial<WrappedAssetLinkProps>,
     ) {
-      return viewType === 'link' ? _renderDefaultLink(props) : _renderDefaultCard(props);
+      const builtinCardProps: Omit<WrappedAssetCardProps, 'isClickable'> & {
+        isClickable?: WrappedAssetCardProps['isClickable'];
+      } = {
+        ...commonProps,
+        ...props,
+        getEntityScheduledActions: loadEntityScheduledActions,
+        asset: ((props as CustomEntityCardProps)?.entity as Asset) || commonProps.asset,
+        getAssetUrl: getEntityUrl,
+      };
+
+      if (viewType === 'link') {
+        return (
+          <WrappedAssetLink
+            {...builtinCardProps}
+            href={commonProps.entityUrl}
+            getEntityScheduledActions={loadEntityScheduledActions}
+          />
+        );
+      }
+
+      return <WrappedAssetCard {...builtinCardProps} />;
     }
 
     if (props.renderCustomCard) {

--- a/packages/reference/src/assets/WrappedAssetCard/FetchingWrappedAssetCard.tsx
+++ b/packages/reference/src/assets/WrappedAssetCard/FetchingWrappedAssetCard.tsx
@@ -44,20 +44,17 @@ export function FetchingWrappedAssetCard(props: FetchingWrappedAssetCardProps) {
     // eslint-disable-next-line react-hooks/exhaustive-deps -- TODO: Evaluate the dependencies
   }, [asset]);
 
-  const onEdit =
-    typeof props.sdk.navigator.openAsset === 'function'
-      ? async () => {
-          const { slide } = await props.sdk.navigator.openAsset(props.assetId, { slideIn: true });
-          props.onAction &&
-            props.onAction({
-              entity: 'Asset',
-              type: 'edit',
-              id: props.assetId,
-              contentTypeId: '',
-              slide,
-            });
-        }
-      : undefined;
+  const onEdit = async () => {
+    const { slide } = await props.sdk.navigator.openAsset(props.assetId, { slideIn: true });
+    props.onAction &&
+      props.onAction({
+        entity: 'Asset',
+        type: 'edit',
+        id: props.assetId,
+        contentTypeId: '',
+        slide,
+      });
+  };
 
   const onRemove = () => {
     props.onRemove();

--- a/packages/reference/src/assets/WrappedAssetCard/WrappedAssetCard.tsx
+++ b/packages/reference/src/assets/WrappedAssetCard/WrappedAssetCard.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { SpaceAPI } from '@contentful/app-sdk';
 import { AssetCard } from '@contentful/f36-components';
 import { entityHelpers, LocalePublishStatusMap } from '@contentful/field-editor-shared';
-// @ts-expect-error
+// @ts-expect-error mimetype is not typed
 import mimetype from '@contentful/mimetype';
 import { LocaleProps } from 'contentful-management';
 
@@ -38,7 +38,7 @@ export interface WrappedAssetCardProps {
   onRemove?: () => void;
   size: 'default' | 'small';
   renderDragHandle?: RenderDragFn;
-  isClickable: boolean;
+  isClickable?: boolean;
   useLocalizedEntityStatus?: boolean;
   localesStatusMap?: LocalePublishStatusMap;
   activeLocales?: Pick<LocaleProps, 'code'>[];
@@ -82,7 +82,7 @@ export const WrappedAssetCard = ({
 }: WrappedAssetCardProps) => {
   const status = entityHelpers.getEntityStatus(
     asset.sys,
-    useLocalizedEntityStatus ? localeCode : undefined
+    useLocalizedEntityStatus ? localeCode : undefined,
   );
 
   if (status === 'deleted') {
@@ -104,12 +104,12 @@ export const WrappedAssetCard = ({
 
   return (
     <AssetCard
-      as={href ? 'a' : 'article'}
+      as={isClickable && href ? 'a' : 'article'}
       type={getFileType(entityFile)}
       title={entityTitle}
       className={className}
       isSelected={isSelected}
-      href={href}
+      href={isClickable ? href : undefined}
       badge={
         <EntityStatusBadge
           getEntityScheduledActions={getEntityScheduledActions}

--- a/packages/reference/src/assets/WrappedAssetCard/WrappedAssetLink.tsx
+++ b/packages/reference/src/assets/WrappedAssetCard/WrappedAssetLink.tsx
@@ -53,11 +53,6 @@ export const WrappedAssetLink = (props: WrappedAssetLinkProps) => {
     ? props.asset.fields.file[props.localeCode] || props.asset.fields.file[props.defaultLocaleCode]
     : undefined;
 
-  const handleClick = (e: React.MouseEvent<HTMLElement>) => {
-    e.preventDefault();
-    onEdit && onEdit();
-  };
-
   return (
     <EntryCard
       as={isClickable && href ? 'a' : 'article'}
@@ -80,7 +75,14 @@ export const WrappedAssetLink = (props: WrappedAssetLinkProps) => {
       thumbnailElement={
         entityFile && isValidImage(entityFile) ? <AssetThumbnail file={entityFile} /> : undefined
       }
-      onClick={isClickable ? handleClick : undefined}
+      onClick={
+        isClickable
+          ? (e: React.MouseEvent<HTMLElement>) => {
+              e.preventDefault();
+              onEdit && onEdit();
+            }
+          : undefined
+      }
       onKeyDown={
         isClickable
           ? (e: React.KeyboardEvent<HTMLElement>) => {

--- a/packages/reference/src/assets/WrappedAssetCard/WrappedAssetLink.tsx
+++ b/packages/reference/src/assets/WrappedAssetCard/WrappedAssetLink.tsx
@@ -21,20 +21,21 @@ export interface WrappedAssetLinkProps {
   href?: string;
   className?: string;
   isDisabled: boolean;
-  onEdit: () => void;
-  onRemove: () => void;
+  onEdit?: () => void;
+  onRemove?: () => void;
   renderDragHandle?: RenderDragFn;
   useLocalizedEntityStatus?: boolean;
   localesStatusMap?: LocalePublishStatusMap;
   activeLocales?: Pick<LocaleProps, 'code'>[];
+  isClickable?: boolean;
 }
 
 export const WrappedAssetLink = (props: WrappedAssetLinkProps) => {
-  const { className, href, onEdit, onRemove, isDisabled } = props;
+  const { className, href, onEdit, onRemove, isDisabled, isClickable = true } = props;
 
   const status = entityHelpers.getEntityStatus(
     props.asset.sys,
-    props.useLocalizedEntityStatus ? props.localeCode : undefined
+    props.useLocalizedEntityStatus ? props.localeCode : undefined,
   );
 
   if (status === 'deleted') {
@@ -52,13 +53,18 @@ export const WrappedAssetLink = (props: WrappedAssetLinkProps) => {
     ? props.asset.fields.file[props.localeCode] || props.asset.fields.file[props.defaultLocaleCode]
     : undefined;
 
+  const handleClick = (e: React.MouseEvent<HTMLElement>) => {
+    e.preventDefault();
+    onEdit && onEdit();
+  };
+
   return (
     <EntryCard
-      as={href ? 'a' : 'article'}
+      as={isClickable && href ? 'a' : 'article'}
       contentType="Asset"
       title={entityTitle}
       className={className}
-      href={href}
+      href={isClickable ? href : undefined}
       size="small"
       badge={
         <EntityStatusBadge
@@ -74,16 +80,17 @@ export const WrappedAssetLink = (props: WrappedAssetLinkProps) => {
       thumbnailElement={
         entityFile && isValidImage(entityFile) ? <AssetThumbnail file={entityFile} /> : undefined
       }
-      onClick={(e: React.MouseEvent<HTMLElement>) => {
-        e.preventDefault();
-        onEdit();
-      }}
-      onKeyDown={(e: React.KeyboardEvent<HTMLElement>) => {
-        if (e.key === 'Enter' && onEdit) {
-          e.preventDefault();
-          onEdit();
-        }
-      }}
+      onClick={isClickable ? handleClick : undefined}
+      onKeyDown={
+        isClickable
+          ? (e: React.KeyboardEvent<HTMLElement>) => {
+              if (e.key === 'Enter' && onEdit) {
+                e.preventDefault();
+                onEdit();
+              }
+            }
+          : undefined
+      }
       dragHandleRender={props.renderDragHandle}
       withDragHandle={!!props.renderDragHandle && !isDisabled}
       actions={[

--- a/packages/reference/src/common/MultipleReferenceEditor.tsx
+++ b/packages/reference/src/common/MultipleReferenceEditor.tsx
@@ -8,7 +8,7 @@ import { LinkActionsProps, LinkEntityActions } from '../components';
 import { useLinkActionsProps } from '../components/LinkActions/LinkEntityActions';
 import { ReferenceValue, ContentEntityType, ContentType } from '../types';
 import { useSortIDs } from '../utils/useSortIDs';
-import { CustomEntityCardProps, DefaultCardRenderer } from './customCardTypes';
+import { CustomCardRenderer, CustomEntityCardProps, DefaultCardRenderer } from './customCardTypes';
 import { ReferenceEditor, ReferenceEditorProps } from './ReferenceEditor';
 import { useEditorPermissions } from './useEditorPermissions';
 
@@ -34,7 +34,7 @@ function onLinkOrCreate(
   entityType: ChildProps['entityType'],
   items: ChildProps['items'],
   ids: string[],
-  index = items.length
+  index = items.length,
 ): void {
   const links: ReferenceValue[] = ids.map((id) => ({
     sys: { type: 'Link', linkType: entityType, id },
@@ -78,7 +78,7 @@ function Editor(props: EditorProps) {
       setIndexToUpdate && setIndexToUpdate(undefined);
       document.body.classList.remove('grabbing');
     },
-    [items, onSortingEnd, setIndexToUpdate, setValue]
+    [items, onSortingEnd, setIndexToUpdate, setValue],
   );
 
   const onMove = useCallback(
@@ -87,17 +87,17 @@ function Editor(props: EditorProps) {
       rearrangeSortIDs(oldIndex, newIndex);
       setValue(newItems);
     },
-    [items, rearrangeSortIDs, setValue]
+    [items, rearrangeSortIDs, setValue],
   );
 
   const onCreate = useCallback(
     (id: string, index?: number) => onLinkOrCreate(setValue, entityType, items, [id], index),
-    [setValue, items, entityType]
+    [setValue, items, entityType],
   );
 
   const onLink = useCallback(
     (ids: string[], index?: number) => onLinkOrCreate(setValue, entityType, items, ids, index),
-    [setValue, items, entityType]
+    [setValue, items, entityType],
   );
 
   const linkActionsProps = useLinkActionsProps({
@@ -113,14 +113,14 @@ function Editor(props: EditorProps) {
     (
       cardProps: CustomEntityCardProps,
       _: LinkActionsProps,
-      renderDefaultCard: DefaultCardRenderer
+      renderDefaultCard: DefaultCardRenderer,
     ) =>
       props.renderCustomCard
         ? props.renderCustomCard(cardProps, linkActionsProps, renderDefaultCard)
         : false,
     // eslint-disable-next-line react-hooks/exhaustive-deps -- TODO: Evaluate the dependencies
-    [linkActionsProps]
-  );
+    [linkActionsProps],
+  ) as CustomCardRenderer;
 
   return (
     <>
@@ -141,7 +141,7 @@ export function MultipleReferenceEditor(
     entityType: ContentEntityType;
     children: (props: ReferenceEditorProps & ChildProps) => React.ReactElement;
     setIndexToUpdate?: React.Dispatch<React.SetStateAction<number | undefined>>;
-  }
+  },
 ) {
   const allContentTypes = props.sdk.space.getCachedContentTypes();
 

--- a/packages/reference/src/common/SingleReferenceEditor.tsx
+++ b/packages/reference/src/common/SingleReferenceEditor.tsx
@@ -4,7 +4,7 @@ import { useCallback } from 'react';
 import { LinkActionsProps, LinkEntityActions } from '../components';
 import { useLinkActionsProps } from '../components/LinkActions/LinkEntityActions';
 import { ContentType, ContentEntityType, ReferenceValue } from '../types';
-import { CustomEntityCardProps, DefaultCardRenderer } from './customCardTypes';
+import { CustomCardRenderer, CustomEntityCardProps, DefaultCardRenderer } from './customCardTypes';
 import { ReferenceEditor, ReferenceEditorProps } from './ReferenceEditor';
 import { useEditorPermissions } from './useEditorPermissions';
 
@@ -30,14 +30,14 @@ function Editor(props: EditorProps) {
 
   const onCreate = useCallback(
     (id: string) => void setValue({ sys: { type: 'Link', linkType: entityType, id } }),
-    [setValue, entityType]
+    [setValue, entityType],
   );
   const onLink = useCallback(
     (ids: string[]) => {
       const [id] = ids;
       setValue({ sys: { type: 'Link', linkType: entityType, id } });
     },
-    [setValue, entityType]
+    [setValue, entityType],
   );
 
   const linkActionsProps = useLinkActionsProps({
@@ -52,14 +52,14 @@ function Editor(props: EditorProps) {
     (
       cardProps: CustomEntityCardProps,
       _: LinkActionsProps,
-      renderDefaultCard: DefaultCardRenderer
+      renderDefaultCard: DefaultCardRenderer,
     ) =>
       props.renderCustomCard
         ? props.renderCustomCard(cardProps, linkActionsProps, renderDefaultCard)
         : false,
     // eslint-disable-next-line react-hooks/exhaustive-deps -- TODO: Evaluate the dependencies
-    [linkActionsProps]
-  );
+    [linkActionsProps],
+  ) as CustomCardRenderer;
 
   if (!props.entityId) {
     return (
@@ -77,7 +77,7 @@ export function SingleReferenceEditor(
   props: ReferenceEditorProps & {
     entityType: ContentEntityType;
     children: (props: ChildProps) => React.ReactElement;
-  }
+  },
 ) {
   const allContentTypes = props.sdk.space.getCachedContentTypes();
 

--- a/packages/reference/src/common/customCardTypes.ts
+++ b/packages/reference/src/common/customCardTypes.ts
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { LocalePublishStatusMap } from '@contentful/field-editor-shared';
 import { LocaleProps } from 'contentful-management';
 
+import { WrappedAssetCardProps } from '../assets/WrappedAssetCard/WrappedAssetCard';
 import { Asset, ContentType, Entry, RenderDragFn } from '../types';
 import { CustomActionProps } from './ReferenceEditor';
 
@@ -18,12 +19,12 @@ export type RenderCustomMissingEntityCard = ({
   defaultCard,
 }: MissingEntityCardProps) => React.ReactElement;
 
-export type DefaultCardRenderer = (props?: CustomEntityCardProps) => React.ReactElement;
+export type DefaultCardRenderer = (props?: Partial<CustomEntityCardProps>) => React.ReactElement;
 
 export type CustomCardRenderer = (
   props: CustomEntityCardProps,
   linkActionsProps: CustomActionProps,
-  renderDefaultCard: DefaultCardRenderer
+  renderDefaultCard: DefaultCardRenderer,
 ) => React.ReactElement | false;
 
 export type CustomEntityCardProps = {
@@ -46,4 +47,4 @@ export type CustomEntityCardProps = {
   useLocalizedEntityStatus?: boolean;
   localesStatusMap?: LocalePublishStatusMap;
   activeLocales?: Pick<LocaleProps, 'code'>[];
-};
+} & Partial<WrappedAssetCardProps>;

--- a/packages/reference/src/common/customCardTypes.ts
+++ b/packages/reference/src/common/customCardTypes.ts
@@ -24,7 +24,7 @@ export type DefaultCardRenderer = (props?: Partial<CustomEntityCardProps>) => Re
 export type CustomCardRenderer = (
   props: CustomEntityCardProps,
   linkActionsProps: CustomActionProps,
-  renderDefaultCard: DefaultCardRenderer,
+  renderDefaultCard?: DefaultCardRenderer,
 ) => React.ReactElement | false;
 
 export type CustomEntityCardProps = {

--- a/packages/reference/src/entries/WrappedEntryCard/FetchingWrappedEntryCard.tsx
+++ b/packages/reference/src/entries/WrappedEntryCard/FetchingWrappedEntryCard.tsx
@@ -33,7 +33,7 @@ export type EntryCardReferenceEditorProps = ReferenceEditorProps & {
 async function openEntry(
   sdk: FieldAppSDK,
   entryId: string,
-  options: { bulkEditing?: boolean; index?: number }
+  options: { bulkEditing?: boolean; index?: number },
 ) {
   let slide: NavigatorSlideInfo | undefined;
 
@@ -65,7 +65,7 @@ export function FetchingWrappedEntryCard(props: EntryCardReferenceEditorProps) {
   const { getEntityScheduledActions } = useEntityLoader();
   const loadEntityScheduledActions = React.useCallback(
     () => getEntityScheduledActions('Entry', props.entryId),
-    [getEntityScheduledActions, props.entryId]
+    [getEntityScheduledActions, props.entryId],
   );
   const localesStatusMap = useLocalePublishStatus(entry, props.sdk.locales);
 
@@ -135,7 +135,7 @@ export function FetchingWrappedEntryCard(props: EntryCardReferenceEditorProps) {
       entity: entry,
       entityUrl: props.getEntityUrl && props.getEntityUrl(entry.sys.id),
       contentType: props.allContentTypes.find(
-        (contentType) => contentType.sys.id === entry.sys.contentType.sys.id
+        (contentType) => contentType.sys.id === entry.sys.contentType.sys.id,
       ),
       isDisabled: props.isDisabled,
       size,
@@ -154,7 +154,7 @@ export function FetchingWrappedEntryCard(props: EntryCardReferenceEditorProps) {
 
     const { hasCardEditActions, hasCardMoveActions, hasCardRemoveActions } = props;
 
-    function renderDefaultCard(props?: CustomEntityCardProps) {
+    function renderDefaultCard(props?: Partial<CustomEntityCardProps>) {
       const builtinCardProps: WrappedEntryCardProps = {
         ...sharedCardProps,
         ...props,
@@ -175,7 +175,7 @@ export function FetchingWrappedEntryCard(props: EntryCardReferenceEditorProps) {
       const renderedCustomCard = props.renderCustomCard(
         sharedCardProps,
         {} as LinkActionsProps,
-        renderDefaultCard
+        renderDefaultCard,
       );
       // Only `false` indicates to render the original card. E.g. `null` would result in no card.
       if (renderedCustomCard !== false) {

--- a/packages/reference/src/entries/WrappedEntryCard/WrappedEntryCard.tsx
+++ b/packages/reference/src/entries/WrappedEntryCard/WrappedEntryCard.tsx
@@ -88,7 +88,7 @@ export function WrappedEntryCard({
           localeCode,
           defaultLocaleCode,
         },
-        getAsset
+        getAsset,
       )
         .then((file) => {
           if (mounted) {
@@ -132,8 +132,8 @@ export function WrappedEntryCard({
 
   return (
     <EntryCard
-      as={entryUrl ? 'a' : 'article'}
-      href={entryUrl}
+      as={isClickable && entryUrl ? 'a' : 'article'}
+      href={isClickable ? entryUrl : undefined}
       title={title}
       description={description}
       contentType={contentType?.name}

--- a/packages/reference/stories/MultipleMediaEditor/MultipleMediaEditor.stories.tsx
+++ b/packages/reference/stories/MultipleMediaEditor/MultipleMediaEditor.stories.tsx
@@ -66,6 +66,37 @@ export const Link: Story = {
   },
 };
 
+export const UnclickableLink: Story = {
+  parameters: {
+    controls: { hideNoControlsWarning: true },
+  },
+  render: () => {
+    const [sdk, mitt] = newReferenceEditorFakeSdk();
+    return (
+      <div>
+        <MultipleMediaEditor
+          viewType="link"
+          sdk={sdk}
+          isInitiallyDisabled={false}
+          parameters={{
+            instance: {
+              showCreateEntityAction: true,
+              showLinkEntityAction: true,
+            },
+          }}
+          renderCustomCard={(_, __, renderDefaultCard) => {
+            return renderDefaultCard({
+              isClickable: false,
+              renderDragHandle: undefined,
+            });
+          }}
+        />
+        <ActionsPlayground mitt={mitt} />
+      </div>
+    );
+  },
+};
+
 export const CustomActions: Story = {
   parameters: {
     controls: { hideNoControlsWarning: true },
@@ -130,6 +161,37 @@ export const CustomCard: Story = {
                 <Button onClick={props.onRemove}>Remove</Button>
               </Card>
             );
+          }}
+        />
+        <ActionsPlayground mitt={mitt} />
+      </div>
+    );
+  },
+};
+
+export const UnclickableCard: Story = {
+  parameters: {
+    controls: { hideNoControlsWarning: true },
+  },
+  render: () => {
+    const [sdk, mitt] = newReferenceEditorFakeSdk();
+    return (
+      <div data-test-id="multiple-media-editor-custom-cards-integration-test">
+        <MultipleMediaEditor
+          viewType="card"
+          sdk={sdk}
+          isInitiallyDisabled={false}
+          parameters={{
+            instance: {
+              showCreateEntityAction: true,
+              showLinkEntityAction: true,
+            },
+          }}
+          renderCustomCard={(_, __, renderDefaultCard) => {
+            return renderDefaultCard({
+              isClickable: false,
+              renderDragHandle: undefined,
+            });
           }}
         />
         <ActionsPlayground mitt={mitt} />

--- a/packages/reference/stories/SingleEntryReferenceEditor/SingleEntryReferenceEditor.stories.tsx
+++ b/packages/reference/stories/SingleEntryReferenceEditor/SingleEntryReferenceEditor.stories.tsx
@@ -62,9 +62,12 @@ export const CustomCard: Story = {
         <SingleEntryReferenceEditor
           hasCardEditActions={false}
           renderCustomCard={(props) =>
+            // @ts-expect-error
             props.entity.fields.exField ? (
               <Card testId="custom-card">
+                {/*@ts-expect-error*/}
                 <Heading>{props.entity.fields.exField.en}</Heading>
+                {/*@ts-expect-error*/}
                 <Paragraph>{props.entity.fields.exDesc.en}</Paragraph>
                 <Button onClick={props.onEdit} style={{ marginRight: '10px' }}>
                   Edit
@@ -105,9 +108,41 @@ export const CustomCardRelyingOnDefaultCard: Story = {
       <div data-test-id="custom-card-using-default">
         <SingleEntryReferenceEditor
           hasCardEditActions={false}
-          renderCustomCard={(props, _, renderDefaultCard) => {
-            // @ts-expect-error
+          renderCustomCard={(_, __, renderDefaultCard) => {
             return renderDefaultCard({ size: 'small' });
+          }}
+          viewType="card"
+          sdk={sdk}
+          isInitiallyDisabled={false}
+          parameters={{
+            instance: instanceParams ?? {
+              showCreateEntityAction: true,
+              showLinkEntityAction: true,
+            },
+          }}
+        />
+        <ActionsPlayground mitt={mitt} />
+      </div>
+    );
+  },
+};
+
+export const UnclickableCustomCard: Story = {
+  parameters: {
+    controls: { hideNoControlsWarning: true },
+  },
+  render: () => {
+    const instanceParams = JSON.parse(window.localStorage.getItem('instanceParams') as string) as {
+      showCreateEntityAction: boolean;
+      showLinkEntityAction: boolean;
+    };
+    const [sdk, mitt] = newReferenceEditorFakeSdk();
+    return (
+      <div data-test-id="custom-card-using-default">
+        <SingleEntryReferenceEditor
+          hasCardEditActions={false}
+          renderCustomCard={(_, __, renderDefaultCard) => {
+            return renderDefaultCard({ size: 'small', isClickable: false });
           }}
           viewType="card"
           sdk={sdk}

--- a/packages/reference/stories/SingleMediaEditor/SingleMediaEditor.stories.tsx
+++ b/packages/reference/stories/SingleMediaEditor/SingleMediaEditor.stories.tsx
@@ -121,3 +121,33 @@ export const CustomCard: Story = {
     );
   },
 };
+
+export const UnclickableCard: Story = {
+  parameters: {
+    controls: { hideNoControlsWarning: true },
+  },
+  render: () => {
+    const [sdk, mitt] = newReferenceEditorFakeSdk();
+    return (
+      <div>
+        <SingleMediaEditor
+          viewType="card"
+          sdk={sdk}
+          isInitiallyDisabled={false}
+          parameters={{
+            instance: {
+              showCreateEntityAction: true,
+              showLinkEntityAction: true,
+            },
+          }}
+          renderCustomCard={(_, __, renderDefaultCard) => {
+            return renderDefaultCard({
+              isClickable: false,
+            });
+          }}
+        />
+        <ActionsPlayground mitt={mitt} />
+      </div>
+    );
+  },
+};


### PR DESCRIPTION
This PR modifies several reference cards to allow rendering truly non-interactive cards. This is a prerequisite for [SPA-2702](https://contentful.atlassian.net/browse/SPA-2702)

[SPA-2702]: https://contentful.atlassian.net/browse/SPA-2702?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ