### PR TITLE
feat: bring release status components [TOL-3103]

### DIFF
--- a/packages/_shared/src/ReleaseEntityStatusBadge/Banner.tsx
+++ b/packages/_shared/src/ReleaseEntityStatusBadge/Banner.tsx
@@ -1,0 +1,32 @@
+import React, { ReactNode } from 'react';
+
+import { Text } from '@contentful/f36-components';
+import tokens from '@contentful/f36-tokens';
+import { css } from 'emotion';
+
+const styles = {
+  content: css({
+    display: 'block',
+  }),
+  banner: css({
+    background: tokens.gray100,
+    padding: tokens.spacingXs,
+    margin: `${tokens.spacingXs} ${tokens.spacingS}`,
+    borderRadius: tokens.borderRadiusSmall,
+  }),
+};
+
+export function Banner({ content, highlight }: { content: ReactNode; highlight?: ReactNode }) {
+  return (
+    <div className={styles.banner}>
+      <Text fontSize="fontSizeS" fontColor="gray700" className={styles.content}>
+        {content}
+      </Text>
+      {highlight && (
+        <Text fontSize="fontSizeS" fontColor="gray700" as="strong" fontWeight="fontWeightDemiBold">
+          {highlight}
+        </Text>
+      )}
+    </div>
+  );
+}

--- a/packages/_shared/src/ReleaseEntityStatusBadge/ReleaseEntityStatusBadge.tsx
+++ b/packages/_shared/src/ReleaseEntityStatusBadge/ReleaseEntityStatusBadge.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+
+import { Badge, BadgeVariant } from '@contentful/f36-components';
+
+import type { ReleaseAction } from './types';
+
+type ReleaseEntityActionBadgeProps = {
+  action: ReleaseAction;
+  className?: string;
+};
+
+const config: Record<ReleaseAction, { label: string; variant: BadgeVariant }> = {
+  publish: {
+    label: 'Will publish',
+    variant: 'positive' as const,
+  },
+  unpublish: {
+    label: 'Becomes draft',
+    variant: 'warning' as const,
+  },
+  'not-in-release': {
+    label: 'Not in release',
+    variant: 'secondary' as const,
+  },
+};
+
+export function ReleaseEntityStatusBadge({ className, action }: ReleaseEntityActionBadgeProps) {
+  const badgeConfig = config[action];
+
+  return (
+    <Badge
+      testId="release-entity-action-status"
+      className={className}
+      variant={badgeConfig.variant}
+    >
+      {badgeConfig.label}
+    </Badge>
+  );
+}

--- a/packages/_shared/src/ReleaseEntityStatusBadge/ReleaseEntityStatusLocale.tsx
+++ b/packages/_shared/src/ReleaseEntityStatusBadge/ReleaseEntityStatusLocale.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+
+import { Badge, BadgeVariant, Text } from '@contentful/f36-components';
+import tokens from '@contentful/f36-tokens';
+import type { LocaleProps } from 'contentful-management';
+import { css } from 'emotion';
+
+const styles = {
+  locale: css({
+    textOverflow: 'ellipsis',
+    overflow: 'hidden',
+    whiteSpace: 'nowrap',
+  }),
+  status: css({
+    flexShrink: 0,
+  }),
+  localePublishStatus: css({
+    display: 'flex',
+    gap: tokens.spacingXs,
+    justifyContent: 'space-between',
+    padding: `${tokens.spacingXs} ${tokens.spacingS}`,
+  }),
+};
+
+type ReleaseEntityStatusLocaleProps = {
+  locale: Pick<LocaleProps, 'code' | 'default' | 'name'>;
+  label: string;
+  variant: BadgeVariant;
+};
+
+export function ReleaseEntityStatusLocale({
+  locale,
+  label,
+  variant,
+}: ReleaseEntityStatusLocaleProps) {
+  return (
+    <div className={styles.localePublishStatus} data-test-id="locale-publishing-status">
+      <Text className={styles.locale} fontColor="gray700">
+        {locale.name}{' '}
+        <Text fontColor="gray500">
+          ({locale.code}){locale.default && ', Default'}
+        </Text>
+      </Text>
+      <Badge className={styles.status} variant={variant}>
+        {label}
+      </Badge>
+    </div>
+  );
+}

--- a/packages/_shared/src/ReleaseEntityStatusBadge/ReleaseEntityStatusLocalesList.tsx
+++ b/packages/_shared/src/ReleaseEntityStatusBadge/ReleaseEntityStatusLocalesList.tsx
@@ -1,0 +1,106 @@
+import React from 'react';
+
+import { MenuSectionTitle } from '@contentful/f36-components';
+import type { LocaleProps } from 'contentful-management';
+import { sortBy } from 'lodash';
+
+import { Banner } from './Banner';
+import { ReleaseEntityStatusLocale } from './ReleaseEntityStatusLocale';
+import { ReleaseLocalesStatus, ReleaseLocalesStatusMap } from './types';
+
+function groupAndSortLocales(
+  entries: [string, ReleaseLocalesStatus][],
+  activeLocales?: Pick<LocaleProps, 'code'>[]
+) {
+  // Group into selected locales (for editing) and non selected
+  const { selected, nonSelected } = entries.reduce(
+    (prev, [localeCode, localeStatusType]) => {
+      return activeLocales?.some((sl) => sl.code === localeCode)
+        ? {
+            ...prev,
+            selected: [...prev.selected, localeStatusType],
+          }
+        : {
+            ...prev,
+            nonSelected: [...prev.nonSelected, localeStatusType],
+          };
+    },
+    { selected: [] as ReleaseLocalesStatus[], nonSelected: [] as ReleaseLocalesStatus[] }
+  );
+
+  return {
+    // selected are just sorted by name
+    selected: sortBy(selected, 'locale.name'),
+    // non-selected are grouped by status and sort inside the group alphabetical
+    nonSelected: nonSelected.sort((a, b) => {
+      if (a.status === b.status) {
+        return a.locale.name.localeCompare(b.locale.name);
+      }
+
+      if (
+        a.status === 'becomesDraft' ||
+        (a.status === 'willPublish' && b.status === 'remainsDraft')
+      ) {
+        return -1;
+      }
+
+      return 1;
+    }),
+  };
+}
+
+type ReleaseEntityStatusLocalesListProps = {
+  statusMap: ReleaseLocalesStatusMap;
+  activeLocales?: Pick<LocaleProps, 'code'>[];
+};
+
+export function ReleaseEntityStatusLocalesList({
+  statusMap,
+  activeLocales,
+}: ReleaseEntityStatusLocalesListProps) {
+  const entries = [...statusMap.entries()];
+  const counters = entries.reduce(
+    (prev, [, { status }]) => ({
+      becomesDraft: prev.becomesDraft + (status === 'becomesDraft' ? 1 : 0),
+      willPublish: prev.willPublish + (status === 'willPublish' ? 1 : 0),
+      remainsDraft: prev.remainsDraft + (status === 'remainsDraft' ? 1 : 0),
+    }),
+    { willPublish: 0, becomesDraft: 0, remainsDraft: 0 }
+  );
+
+  const { selected, nonSelected } = groupAndSortLocales(entries, activeLocales);
+  return (
+    <>
+      <Banner
+        content="The statuses of the locales for this content:"
+        highlight={`${counters.becomesDraft} becomes draft, ${counters.willPublish} will publish, ${counters.remainsDraft} remains draft`}
+      />
+
+      <div data-test-id="locale-publishing-selected">
+        <MenuSectionTitle>Locales in the entry editor:</MenuSectionTitle>
+        {selected.map(({ locale, label, variant }) => (
+          <ReleaseEntityStatusLocale
+            key={`selected-${locale.code}`}
+            label={label}
+            variant={variant}
+            locale={locale}
+          />
+        ))}
+      </div>
+
+      {nonSelected.length > 0 && (
+        <div data-test-id="locale-publishing-others">
+          <MenuSectionTitle>Other locales:</MenuSectionTitle>
+          {nonSelected.map(({ locale, label, variant }) => (
+            <ReleaseEntityStatusLocale
+              key={`others-${locale.code}`}
+              label={label}
+              variant={variant}
+              locale={locale}
+            />
+          ))}
+        </div>
+      )}
+    </>
+  );
+}

--- a/packages/_shared/src/ReleaseEntityStatusBadge/ReleaseEntityStatusPopover.tsx
+++ b/packages/_shared/src/ReleaseEntityStatusBadge/ReleaseEntityStatusPopover.tsx
@@ -1,0 +1,267 @@
+import React, { useCallback, useRef, useState } from 'react';
+
+import { Badge, Flex, generateIcon, Popover, Skeleton } from '@contentful/f36-components';
+import tokens from '@contentful/f36-tokens';
+import type { LocaleProps } from 'contentful-management';
+import { cx, css } from 'emotion';
+
+import { RELEASE_BADGES } from './constants';
+import { ReleaseEntityStatusLocalesList } from './ReleaseEntityStatusLocalesList';
+import type { ReleaseLocalesStatusMap, ReleaseEntityStatus } from './types';
+
+type BadgeSVGType = {
+  isHover: boolean;
+} & (
+  | { secondary: ReleaseEntityStatus; tertiary?: never }
+  | { tertiary: ReleaseEntityStatus; secondary?: never }
+);
+
+type Status = {
+  primary: ReleaseEntityStatus;
+  secondary?: ReleaseEntityStatus;
+  tertiary?: ReleaseEntityStatus;
+};
+
+const getColor = ({ secondary, tertiary, isHover }: BadgeSVGType) => {
+  const status = secondary || tertiary;
+  return isHover ? RELEASE_BADGES[status]?.hover : RELEASE_BADGES[status]?.default;
+};
+
+const generateDynamicStyles = (status?: Status) => {
+  const wrapperClass = css({
+    '& svg[data-status="secondary"]': {
+      fill: getColor({
+        secondary: status?.secondary,
+        isHover: false,
+      } as BadgeSVGType),
+    },
+    '& svg[data-status="tertiary"]': {
+      fill: getColor({
+        tertiary: status?.tertiary,
+        isHover: false,
+      } as BadgeSVGType),
+    },
+    '&:hover svg[data-status="secondary"]': {
+      fill: getColor({
+        secondary: status?.secondary,
+        isHover: true,
+      } as BadgeSVGType),
+    },
+    '&:hover svg[data-status="tertiary"]': {
+      fill: getColor({ tertiary: status?.tertiary, isHover: true } as BadgeSVGType),
+    },
+  });
+
+  return wrapperClass;
+};
+
+const styles = {
+  badge: css({
+    '&:focus': {
+      outline: 'none',
+      boxShadow: `inset ${tokens.glowPrimary}`, // inset style necessary since wrapper component (SecretiveLink) has overflow hidden
+    },
+  }),
+  wrapper: css({
+    '& svg': {
+      transition: 'fill 0.2s ease-in-out',
+    },
+    '& svg[data-status="tertiary"]': {
+      marginLeft: '-1px',
+    },
+  }),
+  popoverContent: css({
+    maxWidth: '336px',
+    maxHeight: '368px',
+    overflowY: 'auto',
+    padding: `${tokens.spacing2Xs} 0`,
+  }),
+  skeletonBadge: css({
+    flexShrink: 0,
+    display: 'block',
+    height: '20px',
+    width: '65px',
+  }),
+};
+
+const determineBadgeStatus = (
+  localesStatusMap: ReleaseLocalesStatusMap,
+  activeLocales: Pick<LocaleProps, 'code'>[] | undefined
+): Status => {
+  // If there is only one locale, or only active locale, we would not show the stacking
+  if (activeLocales && activeLocales.length === 1) {
+    const activeLocale = activeLocales.find((locale) => localesStatusMap.has(locale.code));
+    return { primary: localesStatusMap.get(activeLocale!.code)!.status };
+  }
+
+  let becomesDraftCount = 0,
+    willPublishCount = 0,
+    remainsDraftCount = 0;
+
+  for (const [localeCode, localeStatus] of localesStatusMap.entries()) {
+    if (
+      !activeLocales ||
+      activeLocales.find((selectedLocale) => selectedLocale.code === localeCode)
+    ) {
+      switch (localeStatus.status) {
+        case 'remainsDraft':
+          remainsDraftCount += 1;
+          break;
+        case 'becomesDraft':
+          becomesDraftCount += 1;
+          break;
+        case 'willPublish':
+          willPublishCount += 1;
+          break;
+      }
+    }
+  }
+
+  const hasRemainsDraft = remainsDraftCount > 0;
+  const hasWillPublish = willPublishCount > 0;
+  const hasBecomesDraft = becomesDraftCount > 0;
+
+  switch (true) {
+    case hasRemainsDraft && hasWillPublish && hasBecomesDraft:
+      return { primary: 'becomesDraft', secondary: 'willPublish', tertiary: 'remainsDraft' };
+    case hasRemainsDraft && hasWillPublish:
+      return { primary: 'willPublish', secondary: 'remainsDraft' };
+    case hasRemainsDraft && hasBecomesDraft:
+      return { primary: 'becomesDraft', secondary: 'remainsDraft' };
+    case hasWillPublish && hasBecomesDraft:
+      return { primary: 'becomesDraft', secondary: 'willPublish' };
+    case hasWillPublish:
+      return { primary: 'willPublish', secondary: 'willPublish' };
+    case hasBecomesDraft:
+      return { primary: 'becomesDraft', secondary: 'becomesDraft' };
+    case hasRemainsDraft:
+      return { primary: 'remainsDraft', secondary: 'remainsDraft' };
+    default:
+      return { primary: 'notInRelease', secondary: 'notInRelease' };
+  }
+};
+
+type ReleaseLocalePublishingPopoverProps = {
+  ReleaseLocalesStatusMap: ReleaseLocalesStatusMap;
+  activeLocales: Pick<LocaleProps, 'code'>[];
+  isLoading?: boolean;
+};
+
+export function ReleaseEntityStatusPopover({
+  ReleaseLocalesStatusMap,
+  activeLocales,
+  isLoading = false,
+}: ReleaseLocalePublishingPopoverProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const timeoutRef = useRef<NodeJS.Timeout>();
+
+  const onMouseEnter = useCallback(() => {
+    clearTimeout(timeoutRef.current);
+    timeoutRef.current = setTimeout(() => {
+      setIsOpen(true);
+    }, 300);
+  }, []);
+
+  const onMouseLeave = useCallback(() => {
+    clearTimeout(timeoutRef.current);
+    timeoutRef.current = setTimeout(() => {
+      setIsOpen(false);
+    }, 300);
+  }, []);
+
+  const status = determineBadgeStatus(ReleaseLocalesStatusMap, activeLocales);
+  const ariaLabel = status.secondary ? 'Multiple statuses' : status.primary;
+  const wrapperClass = generateDynamicStyles(status);
+
+  // TODO: use from forma icons, once it's changed there (currently a custom one here: https://github.com/contentful/forma-36/blob/main/packages/components/navbar/src/icons/ArrowDownIcon.tsx)
+  const ArrowDownIcon = generateIcon({
+    name: 'ArrowDownIcon',
+    viewBox: '0 0 12 20',
+    path: (
+      <path
+        d="M3.03076 8C2.20109 8 1.73228 8.95209 2.23814 9.60971L5.20727 13.4696C5.60757 13.99 6.39223 13.99 6.79252 13.4696L9.76166 9.60971C10.2675 8.95209 9.79871 8 8.96904 8L3.03076 8Z"
+        fill="currentColor"
+      />
+    ),
+  });
+
+  if (isLoading) {
+    return (
+      <Skeleton.Container className={styles.skeletonBadge}>
+        <Skeleton.Image
+          testId={`Release-entity-locale-status-badge-skeleton`}
+          width="65px"
+          height="20px"
+        />
+      </Skeleton.Container>
+    );
+  }
+
+  return (
+    <Popover
+      isOpen={ReleaseLocalesStatusMap && isOpen}
+      onClose={() => setIsOpen(false)}
+      autoFocus={false}
+      placement="bottom-end"
+    >
+      <Popover.Trigger>
+        <Flex
+          aria-label={ariaLabel}
+          alignItems="center"
+          className={cx(styles.wrapper, wrapperClass)}
+        >
+          <Badge
+            tabIndex={0}
+            variant={RELEASE_BADGES[status.primary].variant}
+            onFocus={() => setIsOpen(true)}
+            onBlur={() => setIsOpen(false)}
+            endIcon={<ArrowDownIcon color={RELEASE_BADGES[status.primary].icon} />}
+            onMouseOver={onMouseEnter}
+            onMouseEnter={onMouseEnter}
+            onMouseLeave={onMouseLeave}
+          >
+            {RELEASE_BADGES[status.primary].label}
+          </Badge>
+          {status.secondary && (
+            <svg
+              data-status="secondary"
+              aria-hidden="true"
+              width="4"
+              height="18"
+              viewBox="0 0 4 18"
+            >
+              <path
+                fillRule="evenodd"
+                clipRule="evenodd"
+                d="M1.45942e-06 18H0.00296171C2.2121 18 4.00296 16.2091 4.00296 14V4C4.00296 1.79086 2.2121 0 0.00295914 0H0C0.830421 0.732944 1.35418 1.80531 1.35418 3V15C1.35418 16.1947 0.830422 17.2671 1.45942e-06 18Z"
+              />
+            </svg>
+          )}
+          {status.tertiary && (
+            <svg data-status="tertiary" aria-hidden="true" width="5" height="16" viewBox="0 0 5 16">
+              <path
+                fillRule="evenodd"
+                clipRule="evenodd"
+                d="M0.673828 16.0055H0.675391C2.88453 16.0055 4.67539 14.2146 4.67539 12.0055V3.9955C4.67539 1.88216 3.03648 0.151608 0.960312 0.00549316C1.78382 0.738158 2.30257 1.80597 2.30257 2.99493V12.7838C2.30257 14.1053 1.66172 15.2771 0.673828 16.0055Z"
+              />
+            </svg>
+          )}
+        </Flex>
+      </Popover.Trigger>
+      <Popover.Content
+        className={styles.popoverContent}
+        onMouseEnter={onMouseEnter}
+        onMouseLeave={onMouseLeave}
+      >
+        {!!ReleaseLocalesStatusMap && (
+          <>
+            <ReleaseEntityStatusLocalesList
+              statusMap={ReleaseLocalesStatusMap}
+              activeLocales={activeLocales}
+            />
+          </>
+        )}
+      </Popover.Content>
+    </Popover>
+  );
+}

--- a/packages/_shared/src/ReleaseEntityStatusBadge/constants.ts
+++ b/packages/_shared/src/ReleaseEntityStatusBadge/constants.ts
@@ -1,0 +1,32 @@
+import tokens from '@contentful/f36-tokens';
+
+export const RELEASE_BADGES = {
+  willPublish: {
+    label: 'Will publish',
+    variant: 'positive',
+    default: tokens.green300,
+    hover: tokens.green400,
+    icon: tokens.green400,
+  },
+  becomesDraft: {
+    label: 'Becomes draft',
+    variant: 'warning',
+    default: tokens.orange300,
+    hover: tokens.orange400,
+    icon: tokens.orange400,
+  },
+  remainsDraft: {
+    label: 'Remains draft',
+    variant: 'secondary',
+    default: tokens.gray300,
+    hover: tokens.gray400,
+    icon: tokens.gray400,
+  },
+  notInRelease: {
+    label: 'Not in release',
+    variant: 'secondary',
+    default: tokens.gray300,
+    hover: tokens.gray400,
+    icon: tokens.gray400,
+  },
+} as const;

--- a/packages/_shared/src/ReleaseEntityStatusBadge/index.ts
+++ b/packages/_shared/src/ReleaseEntityStatusBadge/index.ts
@@ -1,0 +1,3 @@
+export * from './ReleaseEntityStatusPopover';
+export * from './ReleaseEntityStatusBadge';
+export * from './types';

--- a/packages/_shared/src/ReleaseEntityStatusBadge/types.ts
+++ b/packages/_shared/src/ReleaseEntityStatusBadge/types.ts
@@ -1,0 +1,14 @@
+import { BadgeVariant } from '@contentful/f36-components';
+import { LocaleProps } from 'contentful-management/types';
+
+export type ReleaseAction = 'publish' | 'unpublish' | 'not-in-release';
+
+export type ReleaseEntityStatus = 'willPublish' | 'becomesDraft' | 'remainsDraft' | 'notInRelease';
+
+export type ReleaseLocalesStatus = {
+  status: ReleaseEntityStatus;
+  variant: BadgeVariant;
+  label: string;
+  locale: LocaleProps;
+};
+export type ReleaseLocalesStatusMap = Map<string, ReleaseLocalesStatus>;

--- a/packages/_shared/src/index.tsx
+++ b/packages/_shared/src/index.tsx
@@ -33,6 +33,7 @@ export { entityHelpers };
 export { ConstraintsUtils };
 
 export * from './LocalePublishingEntityStatusBadge';
+export * from './ReleaseEntityStatusBadge';
 import * as ModalDialogLauncher from './ModalDialogLauncher';
 import * as ConstraintsUtils from './utils/constraints';
 import * as entityHelpers from './utils/entityHelpers';


### PR DESCRIPTION
Migrate release status component from user interface to field editors _shared to be able to display them in reference and rich text package in follow up PRs

In a follow up ticket we could potentially avoid the duplication between `LocalePublishingEntityStatusBadge` and `TimelineEntityStatus`