### PR TITLE
feat: pass correct params to show release status [TOL-3103]

### DIFF
--- a/packages/_shared/src/hooks/useActiveReleaseLocalesStatuses.ts
+++ b/packages/_shared/src/hooks/useActiveReleaseLocalesStatuses.ts
@@ -18,8 +18,8 @@ export const useActiveReleaseLocalesStatuses = ({
   entryId: string;
   releaseVersionMap: Map<string, Map<string, ReleaseAction>>;
   locales: LocaleProps[];
-  activeRelease: ReleaseV2Props;
-  releases: CollectionProp<ReleaseV2Props>;
+  activeRelease: ReleaseV2Props | undefined;
+  releases: CollectionProp<ReleaseV2Props> | undefined;
 }) => {
   const previousReleaseEntity = useMemo(
     () =>

--- a/packages/_shared/src/utils/parseReleaseParameters.ts
+++ b/packages/_shared/src/utils/parseReleaseParameters.ts
@@ -6,9 +6,9 @@ import type { ReleaseAction } from '../types';
 export type ParsedReleaseParams = {
   releaseVersionMap: Map<string, Map<string, ReleaseAction>>;
   locales: LocaleProps[];
-  activeRelease: ReleaseV2Props;
+  activeRelease: ReleaseV2Props | undefined;
   isActiveReleaseLoading: boolean;
-  releases: CollectionProp<ReleaseV2Props>;
+  releases: CollectionProp<ReleaseV2Props> | undefined;
 };
 
 type RawReleaseParams = {
@@ -19,8 +19,19 @@ type RawReleaseParams = {
   releases: CollectionProp<ReleaseV2Props>;
 };
 
-export function parseReleaseParams(raw: string): ParsedReleaseParams {
+export function parseReleaseParams(raw: string | undefined): ParsedReleaseParams {
   let parsedRaw: RawReleaseParams;
+
+  if (!raw) {
+    return {
+      releaseVersionMap: new Map(),
+      locales: [],
+      activeRelease: undefined,
+      isActiveReleaseLoading: false,
+      releases: undefined,
+    };
+  }
+
   try {
     parsedRaw = JSON.parse(raw) as RawReleaseParams;
   } catch (e) {

--- a/packages/rich-text/src/SdkProvider.tsx
+++ b/packages/rich-text/src/SdkProvider.tsx
@@ -8,7 +8,7 @@ interface SdkProviderProps {
 }
 
 function useSdk({ sdk }: SdkProviderProps) {
-  const sdkMemo = React.useMemo<FieldAppSDK>(() => sdk, []); // eslint-disable-line -- TODO: explain this disable
+  const sdkMemo = React.useMemo<FieldAppSDK>(() => sdk, [sdk.parameters.instance.release]); // eslint-disable-line -- TODO: explain this disable
 
   return sdkMemo;
 }

--- a/packages/rich-text/src/plugins/shared/FetchingWrappedEntryCard.tsx
+++ b/packages/rich-text/src/plugins/shared/FetchingWrappedEntryCard.tsx
@@ -13,6 +13,10 @@ import {
   LocalePublishStatusMap,
   useLocalePublishStatus,
   useActiveLocales,
+  parseReleaseParams,
+  useActiveReleaseLocalesStatuses,
+  type ReleaseLocalesStatusMap,
+  type ReleaseV2Props,
 } from '@contentful/field-editor-shared';
 import areEqual from 'fast-deep-equal';
 
@@ -26,10 +30,20 @@ interface InternalEntryCard {
   onEdit?: VoidFunction;
   onRemove?: VoidFunction;
   localesStatusMap?: LocalePublishStatusMap;
+  releaseLocalesStatusMap?: ReleaseLocalesStatusMap;
+  isActiveReleaseLoading?: boolean;
+  activeRelease?: ReleaseV2Props;
 }
 
 const InternalEntryCard = React.memo((props: InternalEntryCard) => {
-  const { entry, sdk, loadEntityScheduledActions } = props;
+  const {
+    entry,
+    sdk,
+    loadEntityScheduledActions,
+    releaseLocalesStatusMap,
+    isActiveReleaseLoading,
+    activeRelease,
+  } = props;
 
   const contentType = sdk.space
     .getCachedContentTypes()
@@ -58,6 +72,9 @@ const InternalEntryCard = React.memo((props: InternalEntryCard) => {
           ? (dragHandleProps) => <DragHandle label="drag embedded entry" {...dragHandleProps} />
           : undefined
       }
+      releaseLocalesStatusMap={releaseLocalesStatusMap}
+      isReleasesLoading={isActiveReleaseLoading}
+      activeRelease={activeRelease}
     />
   );
 }, areEqual);
@@ -81,9 +98,19 @@ export const FetchingWrappedEntryCard = (props: FetchingWrappedEntryCardProps) =
   const { getEntityScheduledActions } = useEntityLoader();
   const loadEntityScheduledActions = React.useCallback(
     () => getEntityScheduledActions('Entry', entryId),
-    [getEntityScheduledActions, entryId]
+    [getEntityScheduledActions, entryId],
   );
   const localesStatusMap = useLocalePublishStatus(entry, props.sdk.locales);
+  const { releaseVersionMap, locales, activeRelease, releases, isActiveReleaseLoading } =
+    parseReleaseParams(props.sdk.parameters.instance.release);
+  const { releaseLocalesStatusMap } = useActiveReleaseLocalesStatuses({
+    currentEntryDraft: entry,
+    entryId: props.entryId,
+    releaseVersionMap,
+    locales,
+    activeRelease,
+    releases,
+  });
 
   React.useEffect(() => {
     if (status === 'success') {
@@ -116,6 +143,9 @@ export const FetchingWrappedEntryCard = (props: FetchingWrappedEntryCardProps) =
       onRemove={props.onRemove}
       loadEntityScheduledActions={loadEntityScheduledActions}
       localesStatusMap={localesStatusMap}
+      releaseLocalesStatusMap={releaseLocalesStatusMap}
+      isActiveReleaseLoading={isActiveReleaseLoading}
+      activeRelease={activeRelease}
     />
   );
 };


### PR DESCRIPTION
Passing the correct params to the rich text embedded entry components so we can show the status badge in release entries
<img width="991" alt="Screenshot 2025-06-06 at 12 18 58" src="https://github.com/user-attachments/assets/45f398aa-2156-475d-a875-34b47e36a01b" />
