### PR TITLE
feat: update cached sdk on field.validations change

### DIFF
--- a/packages/rich-text/src/SdkProvider.tsx
+++ b/packages/rich-text/src/SdkProvider.tsx
@@ -8,7 +8,7 @@ interface SdkProviderProps {
 }
 
 function useSdk({ sdk }: SdkProviderProps) {
-  const sdkMemo = React.useMemo<FieldAppSDK>(() => sdk, []); // eslint-disable-line -- TODO: explain this disable
+  const sdkMemo = React.useMemo<FieldAppSDK>(() => sdk, [sdk.field.validations]); // eslint-disable-line -- TODO: explain this disable
 
   return sdkMemo;
 }


### PR DESCRIPTION
[Ticket](https://contentful.atlassian.net/browse/FUS-621?atlOrigin=eyJpIjoiOGJkZmJjZDY3NDUzNGNkZWFjYzlhMGE3ZmY5YzdkMzQiLCJwIjoiaiJ9)

[User Interface connected PR](https://github.com/contentful/user_interface/pull/27021)
## Goals
- If `sdk.fields.validations` is updated in the RichTextEditor component the `EmbedEntityWidget` should re-render to reflect those changes

## Context
In the user_interface project we are working on filtering the actions in the EmbedEntityWidget in the RichTextEditor toolbar.  With the introduction of the new `canBeReferencedByOtherSpaces` space entitlement it is possible that a user could see one of the "embed" resource actions when it would not be possible.  To prevent this we filter the enabledNodeTypes in the field validations based on the space entitlements.  This filtering will only impact organisations and spaces that are configured with these new features.  