### PR TITLE
fix(list): listen for external value updates

### DIFF
--- a/packages/list/src/ListEditor.spec.tsx
+++ b/packages/list/src/ListEditor.spec.tsx
@@ -2,7 +2,14 @@ import * as React from 'react';
 
 import { createFakeFieldAPI, createFakeLocalesAPI } from '@contentful/field-editor-test-utils';
 import '@testing-library/jest-dom/extend-expect';
-import { RenderResult, cleanup, configure, fireEvent, render } from '@testing-library/react';
+import {
+  RenderResult,
+  cleanup,
+  configure,
+  fireEvent,
+  render,
+  waitFor,
+} from '@testing-library/react';
 
 import { ListEditor } from './ListEditor';
 
@@ -31,7 +38,7 @@ describe('ListEditor', () => {
       };
     });
     const renderResult = render(
-      <ListEditor field={field} locales={createFakeLocalesAPI()} isInitiallyDisabled={false} />
+      <ListEditor field={field} locales={createFakeLocalesAPI()} isInitiallyDisabled={false} />,
     );
 
     expectInputValue(renderResult, '');
@@ -48,7 +55,7 @@ describe('ListEditor', () => {
     }, initialValue);
 
     const renderResult = render(
-      <ListEditor field={field} locales={createFakeLocalesAPI()} isInitiallyDisabled={false} />
+      <ListEditor field={field} locales={createFakeLocalesAPI()} isInitiallyDisabled={false} />,
     );
 
     expectInputValue(renderResult, 'test1, test2, test3');
@@ -65,7 +72,7 @@ describe('ListEditor', () => {
     });
 
     const renderResult = render(
-      <ListEditor field={field} locales={createFakeLocalesAPI()} isInitiallyDisabled={false} />
+      <ListEditor field={field} locales={createFakeLocalesAPI()} isInitiallyDisabled={false} />,
     );
 
     changeInputValue(renderResult, 'test1');
@@ -91,16 +98,41 @@ describe('ListEditor', () => {
           validations: [],
         };
       },
-      ['test1']
+      ['test1'],
     );
 
     const renderResult = render(
-      <ListEditor field={field} locales={createFakeLocalesAPI()} isInitiallyDisabled={false} />
+      <ListEditor field={field} locales={createFakeLocalesAPI()} isInitiallyDisabled={false} />,
     );
 
     changeInputValue(renderResult, 'test1,');
 
     expect(field.setValue).toHaveBeenLastCalledWith(['test1']);
     expectInputValue(renderResult, 'test1,');
+  });
+
+  it('listens to external changes', async () => {
+    const [field] = createFakeFieldAPI(
+      (field) => {
+        jest.spyOn(field, 'setValue');
+        return {
+          ...field,
+          validations: [],
+        };
+      },
+      ['test1'],
+    );
+
+    const renderResult = render(
+      <ListEditor field={field} locales={createFakeLocalesAPI()} isInitiallyDisabled={false} />,
+    );
+
+    expectInputValue(renderResult, 'test1');
+
+    field.setValue(['test1', 'test2']);
+
+    await waitFor(() => {
+      expectInputValue(renderResult, 'test1, test2');
+    });
   });
 });

--- a/packages/list/src/ListEditor.tsx
+++ b/packages/list/src/ListEditor.tsx
@@ -35,6 +35,20 @@ function isEmptyListValue(value: ListValue | null) {
   return value === null || value.length === 0;
 }
 
+const useExternalChanges = (cb: (newValue: string) => void, externalValue?: ListValue | null) => {
+  const lastExternalValue = React.useRef(externalValue);
+
+  React.useEffect(() => {
+    if (isEqual(lastExternalValue.current, externalValue)) {
+      return;
+    }
+
+    lastExternalValue.current = externalValue;
+
+    cb((externalValue ?? []).join(', '));
+  }, [cb, externalValue]);
+};
+
 export function ListEditor(props: ListEditorProps) {
   const { field, locales, id } = props;
 
@@ -85,6 +99,9 @@ function ListEditorInternal({
     const valueAsString = valueAsArray.join(', ');
     setValueState(changed ? valueAsString : e.target.value);
   };
+
+  // Ensure changes done via sdk.field.setValue are reflected
+  useExternalChanges(setValueState, value);
 
   return (
     <TextInput


### PR DESCRIPTION
Previously changes done via `sdk.field.setValue()` were not reflected in the editor