### PR TITLE
feat: show release action badge entry publishing [TOL-3103]

### DIFF
--- a/packages/_shared/src/index.tsx
+++ b/packages/_shared/src/index.tsx
@@ -18,25 +18,30 @@ export {
   SpaceAPI,
   WindowAPI,
 } from '@contentful/app-sdk';
+
 export { CharCounter } from './CharCounter';
 export { CharValidation } from './CharValidation';
+export { ConstraintsUtils };
+export { entityHelpers };
 export { FieldConnector } from './FieldConnector';
-export type { FieldConnectorChildProps } from './FieldConnector';
+export { ModalDialogLauncher };
 export { PredefinedValuesError } from './PredefinedValuesError';
 export { Asset, Entry, File } from './typesEntity';
 export { isValidImage } from './utils/isValidImage';
 export { shortenStorageUnit, toLocaleString } from './utils/shortenStorageUnit';
-export * from './utils/parseReleaseParameters';
-export * from './hooks/useLocalePublishStatus';
-export * from './hooks/useActiveLocales';
-export { ModalDialogLauncher };
-export { entityHelpers };
-export { ConstraintsUtils };
-export * from './types';
-export * from './hooks/useActiveReleaseLocalesStatuses';
 
+export type { FieldConnectorChildProps } from './FieldConnector';
+export * from './types';
+
+export * from './hooks/useActiveLocales';
+export * from './hooks/useActiveReleaseLocalesStatuses';
+export * from './hooks/useLocalePublishStatus';
 export * from './LocalePublishingEntityStatusBadge';
 export * from './ReleaseEntityStatusBadge';
+export * from './utils/determineReleaseAction';
+export * from './utils/getEntryReleaseStatus';
+export * from './utils/parseReleaseParameters';
+
 import * as ModalDialogLauncher from './ModalDialogLauncher';
 import * as ConstraintsUtils from './utils/constraints';
 import * as entityHelpers from './utils/entityHelpers';

--- a/packages/_shared/src/utils/determineReleaseAction.ts
+++ b/packages/_shared/src/utils/determineReleaseAction.ts
@@ -1,0 +1,84 @@
+import type {
+  ReleaseAction,
+  ReleaseV2Entity,
+  ReleaseV2EntityWithLocales,
+  ReleaseV2Props,
+} from '../types';
+
+type DetermineActionResult = {
+  releaseAction: ReleaseAction;
+  entityItem?: ReleaseV2Entity | ReleaseV2EntityWithLocales;
+  addLocales?: string[];
+  removeLocales?: string[];
+};
+
+function isEntryBasedAction(
+  entityItem: ReleaseV2Entity | ReleaseV2EntityWithLocales,
+): entityItem is ReleaseV2Entity {
+  return (
+    'action' in entityItem && (entityItem.action === 'publish' || entityItem.action === 'unpublish')
+  );
+}
+
+function getLocalesFromEntity(entityItem: ReleaseV2EntityWithLocales): {
+  addLocales: string[];
+  removeLocales: string[];
+} {
+  const addLocales = entityItem?.add?.fields?.['*'] ?? [];
+  const removeLocales = entityItem?.remove?.fields?.['*'] ?? [];
+  return { addLocales, removeLocales };
+}
+
+function getLocaleBasedAction(addLocales: string[], removeLocales: string[]): ReleaseAction {
+  const hasPublish = addLocales.length > 0;
+  const hasUnpublish = removeLocales.length > 0;
+
+  if (hasPublish && !hasUnpublish) {
+    return 'publish';
+  }
+
+  if (!hasPublish && hasUnpublish) {
+    return 'unpublish';
+  }
+
+  return 'publish';
+}
+
+// Look inside one release and decide what will happen to the requested entry (entry-based vs locale-based)
+export function determineReleaseAction(
+  entryId: string,
+  release?: ReleaseV2Props,
+): DetermineActionResult {
+  if (!release) {
+    return { releaseAction: 'not-in-release' };
+  }
+
+  const entityItem = release.entities?.items.find((item) => item.entity.sys.id === entryId);
+
+  if (!entityItem) {
+    return { releaseAction: 'not-in-release' };
+  }
+
+  // Entry based publishing
+  if (isEntryBasedAction(entityItem)) {
+    return {
+      releaseAction: entityItem.action,
+      entityItem,
+    };
+  }
+
+  // Locale based publishing
+  // Pull arrays of locales from add.fields['*'] and remove.fields['*']
+  const { addLocales, removeLocales } = getLocalesFromEntity(entityItem);
+  // If only addLocales: treat as 'publish'.
+  // If only removeLocales: treat as 'unpublish'.
+  // If both: defaults to 'publish'
+  const releaseAction = getLocaleBasedAction(addLocales, removeLocales);
+
+  return {
+    releaseAction,
+    entityItem,
+    addLocales,
+    removeLocales,
+  };
+}

--- a/packages/_shared/src/utils/getEntryReleaseStatus.ts
+++ b/packages/_shared/src/utils/getEntryReleaseStatus.ts
@@ -1,0 +1,52 @@
+import type { LocaleProps } from 'contentful-management/types';
+
+import type {
+  ReleaseAction,
+  ReleaseV2Entity,
+  ReleaseV2EntityWithLocales,
+  ReleaseV2Props,
+} from '../types';
+import { determineReleaseAction } from './determineReleaseAction';
+
+type GetEntryReleaseStatusResult = {
+  releaseAction: ReleaseAction;
+  localesCount?: number;
+  entityItem?: ReleaseV2Entity | ReleaseV2EntityWithLocales;
+  addLocales?: string[];
+  removeLocales?: string[];
+};
+
+export function getEntryReleaseStatus(
+  entryId: string,
+  locales: LocaleProps[],
+  release?: ReleaseV2Props,
+): GetEntryReleaseStatusResult {
+  const { releaseAction, entityItem, addLocales, removeLocales } = determineReleaseAction(
+    entryId,
+    release,
+  );
+
+  if (releaseAction === 'not-in-release' || !entityItem) {
+    return { releaseAction };
+  }
+
+  // Entry based publishing
+  if ('action' in entityItem) {
+    return {
+      releaseAction,
+      localesCount: locales.length,
+      entityItem,
+    };
+  }
+
+  // Locale based publishing
+  const localesCount = addLocales && addLocales.length > 0 ? addLocales.length : locales.length;
+
+  return {
+    releaseAction,
+    localesCount,
+    entityItem,
+    addLocales,
+    removeLocales,
+  };
+}

--- a/packages/reference/src/entries/WrappedEntryCard/FetchingWrappedEntryCard.tsx
+++ b/packages/reference/src/entries/WrappedEntryCard/FetchingWrappedEntryCard.tsx
@@ -5,6 +5,7 @@ import {
   parseReleaseParams,
   useLocalePublishStatus,
   useActiveReleaseLocalesStatuses,
+  getEntryReleaseStatus,
 } from '@contentful/field-editor-shared';
 import { EntryProps } from 'contentful-management';
 import get from 'lodash/get';
@@ -83,6 +84,7 @@ export function FetchingWrappedEntryCard(props: EntryCardReferenceEditorProps) {
     activeRelease,
     releases,
   });
+  const { releaseAction } = getEntryReleaseStatus(props.entryId, locales, activeRelease);
 
   const size = props.viewType === 'link' ? 'small' : 'default';
   const { getEntity } = useEntityLoader();
@@ -168,6 +170,7 @@ export function FetchingWrappedEntryCard(props: EntryCardReferenceEditorProps) {
       releaseLocalesStatusMap,
       isReleasesLoading: isActiveReleaseLoading,
       activeRelease,
+      releaseAction,
     };
 
     const { hasCardEditActions, hasCardMoveActions, hasCardRemoveActions } = props;

--- a/packages/rich-text/src/plugins/shared/FetchingWrappedEntryCard.tsx
+++ b/packages/rich-text/src/plugins/shared/FetchingWrappedEntryCard.tsx
@@ -15,8 +15,10 @@ import {
   useActiveLocales,
   parseReleaseParams,
   useActiveReleaseLocalesStatuses,
+  getEntryReleaseStatus,
   type ReleaseLocalesStatusMap,
   type ReleaseV2Props,
+  type ReleaseAction,
 } from '@contentful/field-editor-shared';
 import areEqual from 'fast-deep-equal';
 
@@ -33,6 +35,7 @@ interface InternalEntryCard {
   releaseLocalesStatusMap?: ReleaseLocalesStatusMap;
   isActiveReleaseLoading?: boolean;
   activeRelease?: ReleaseV2Props;
+  releaseAction?: ReleaseAction;
 }
 
 const InternalEntryCard = React.memo((props: InternalEntryCard) => {
@@ -43,6 +46,7 @@ const InternalEntryCard = React.memo((props: InternalEntryCard) => {
     releaseLocalesStatusMap,
     isActiveReleaseLoading,
     activeRelease,
+    releaseAction,
   } = props;
 
   const contentType = sdk.space
@@ -75,6 +79,7 @@ const InternalEntryCard = React.memo((props: InternalEntryCard) => {
       releaseLocalesStatusMap={releaseLocalesStatusMap}
       isReleasesLoading={isActiveReleaseLoading}
       activeRelease={activeRelease}
+      releaseAction={releaseAction}
     />
   );
 }, areEqual);
@@ -111,6 +116,7 @@ export const FetchingWrappedEntryCard = (props: FetchingWrappedEntryCardProps) =
     activeRelease,
     releases,
   });
+  const { releaseAction } = getEntryReleaseStatus(props.entryId, locales, activeRelease);
 
   React.useEffect(() => {
     if (status === 'success') {
@@ -146,6 +152,7 @@ export const FetchingWrappedEntryCard = (props: FetchingWrappedEntryCardProps) =
       releaseLocalesStatusMap={releaseLocalesStatusMap}
       isActiveReleaseLoading={isActiveReleaseLoading}
       activeRelease={activeRelease}
+      releaseAction={releaseAction}
     />
   );
 };


### PR DESCRIPTION
Show the release status badges also for **entry based**

Approach
- migrates logic from user interface to field editors shared
- uses that logic to calculate the release action in rich text and reference package

<img width="475" alt="Screenshot 2025-06-25 at 10 46 06" src="https://github.com/user-attachments/assets/c0634cea-aed5-4b1a-9480-dd92c4a1f8ff" />

