### PR TITLE
chore: add eslint rule for translation format

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -40,6 +40,7 @@ module.exports = {
     'no-restricted-imports': ['warn'],
     'react/react-in-jsx-scope': 'off',
     'no-console': 'warn',
+    'custom-lingui/enforce-translation-call-format': 'error',
     'custom-lingui/enforce-translation-key-naming': 'error',
   },
   settings: {

--- a/tools/eslint-plugin-custom-lingui/index.js
+++ b/tools/eslint-plugin-custom-lingui/index.js
@@ -1,6 +1,7 @@
 /* eslint-env node */
 module.exports = {
   rules: {
+    'enforce-translation-call-format': require('./rules/enforce-translation-call-format'),
     'enforce-translation-key-naming': require('./rules/enforce-translation-key-naming'),
   },
 };

--- a/tools/eslint-plugin-custom-lingui/rules/enforce-translation-call-format.js
+++ b/tools/eslint-plugin-custom-lingui/rules/enforce-translation-call-format.js
@@ -1,0 +1,139 @@
+/* eslint-env node */
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Ensure that translation calls are structured correctly',
+      category: 'Best Practices',
+    },
+    schema: [],
+    fixable: 'code',
+    messages: {
+      tMacroMessageMissing: 'The "message" property is required.',
+      tMacroMessageMustBeStringOrPlural:
+        'The "message" property must be a string, template literal, or plural call.',
+      parametersMustBeObject: 'The parameters object must be an object literal.',
+      pluralMacroOutsideTMacro: 'The plural macro must be used inside the t macro.',
+      tMacroAsTagFunction: 'The t macro must not be called as a tag function.',
+      transComponentMessageMissing: 'The "message" prop is required.',
+      transComponentMessageMustBeString: 'The "message" prop must be a string.',
+    },
+  },
+  create(context) {
+    // Track any aliases used for the `t` macro
+    const tImportNames = new Set();
+    // Track any aliases used for the `plural` macro
+    const pluralImportNames = new Set();
+    // Track any aliases used for the `Trans` component
+    const transImportNames = new Set();
+
+    return {
+      // Track imports to handle aliasing
+      ImportDeclaration(node) {
+        if (node.source.value === '@lingui/core/macro') {
+          node.specifiers.forEach((spec) => {
+            if (spec.imported.name === 't') {
+              tImportNames.add(spec.local.name);
+            } else if (spec.imported.name === 'plural') {
+              pluralImportNames.add(spec.local.name);
+            }
+          });
+        }
+        if (node.source.value === '@lingui/react') {
+          node.specifiers.forEach((spec) => {
+            if (spec.imported.name === 'Trans') {
+              transImportNames.add(spec.local.name);
+            }
+          });
+        }
+      },
+      // Validate t(...) and plural(...) calls
+      CallExpression(node) {
+        if (isTMacroCall(node, tImportNames)) {
+          if (!hasObjectLiteralAsFirstParameter(node)) {
+            context.report({ node: node.arguments[0], messageId: 'parametersMustBeObject' });
+            return;
+          }
+
+          const params = node.arguments[0];
+
+          const messageProp = getMessageProperty(node);
+          if (!messageProp) {
+            context.report({ node: params, messageId: 'tMacroMessageMissing' });
+            return;
+          }
+          if (!isValidTMacroMessageProperty(messageProp, pluralImportNames)) {
+            context.report({ node: params, messageId: 'tMacroMessageMustBeStringOrPlural' });
+            return;
+          }
+        } else if (isPluralMacroCall(node, pluralImportNames)) {
+          if (!isMessageInTMacroCall(node, tImportNames)) {
+            context.report({ node, messageId: 'pluralMacroOutsideTMacro' });
+          }
+        }
+      },
+      // Validate <Trans id="..." /> usages
+      JSXOpeningElement(node) {
+        const tag = node.name;
+        if (!tag || !transImportNames.has(tag.name)) return;
+
+        // Look for the message="..." prop
+        const messageAttr = node.attributes.find(
+          (attr) => attr.type === 'JSXAttribute' && attr.name.name === 'message',
+        );
+
+        if (!messageAttr) {
+          context.report({ node, messageId: 'transComponentMessageMissing' });
+          return;
+        }
+
+        if (messageAttr.value.type !== 'Literal') {
+          context.report({ node, messageId: 'transComponentMessageMustBeString' });
+          return;
+        }
+      },
+      // Catch t`...` calls
+      TaggedTemplateExpression(node) {
+        if (!tImportNames.has(node.tag.name)) return;
+
+        context.report({ node, messageId: 'tMacroAsTagFunction' });
+      },
+    };
+  },
+};
+
+function isPluralMacroCall(node, pluralImportNames) {
+  return node.type === 'CallExpression' && pluralImportNames.has(node.callee.name);
+}
+
+function isTMacroCall(node, tImportNames) {
+  return node.type === 'CallExpression' && tImportNames.has(node.callee.name);
+}
+
+function hasObjectLiteralAsFirstParameter(node) {
+  return node.arguments?.[0]?.type === 'ObjectExpression';
+}
+
+function getMessageProperty(node) {
+  return node.arguments[0].properties.find(
+    (p) => p.type === 'Property' && p.key.name === 'message',
+  );
+}
+
+function isValidTMacroMessageProperty(property, pluralImportNames) {
+  return (
+    (property.value.type === 'CallExpression' &&
+      pluralImportNames.has(property.value.callee.name)) ||
+    ['Literal', 'TemplateLiteral'].includes(property.value.type)
+  );
+}
+
+function isMessageInTMacroCall(node, tImportNames) {
+  return (
+    node.parent.type === 'Property' &&
+    node.parent.key.type === 'Identifier' &&
+    node.parent.key.name === 'message' &&
+    node.parent.parent.type === 'ObjectExpression' &&
+    isTMacroCall(node.parent.parent.parent, tImportNames)
+  );
+}

--- a/tools/eslint-plugin-custom-lingui/rules/enforce-translation-call-format.test.js
+++ b/tools/eslint-plugin-custom-lingui/rules/enforce-translation-call-format.test.js
@@ -1,0 +1,97 @@
+/* eslint-env node */
+/* eslint-disable @typescript-eslint/no-var-requires */
+const { RuleTester } = require('eslint');
+
+const rule = require('./enforce-translation-call-format');
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parserOptions: {
+      ecmaFeatures: { jsx: true },
+    },
+  },
+});
+
+ruleTester.run('translation-call-format', rule, {
+  valid: [
+    // Valid t usages
+    {
+      code: `import { t } from '@lingui/core/macro'; t({ id: '', message: '' });`,
+    },
+    {
+      code: `import { t } from '@lingui/core/macro'; t({ id: '', message: \`\` });`,
+    },
+    {
+      code: `import { plural, t } from '@lingui/core/macro'; t({ id: '', message: plural(count, { other: '' }) });`,
+    },
+    // Valid Trans usages
+    {
+      code: `import { Trans } from '@lingui/react'; <Trans id="" message="" />;`,
+    },
+  ],
+
+  invalid: [
+    // t macro’s parameters object passed as variable
+    {
+      code: `import { t } from '@lingui/core/macro'; const params = { id: '' }; t(params);`,
+      errors: [{ messageId: 'parametersMustBeObject' }],
+    },
+    {
+      code: `import { t as t2 } from '@lingui/core/macro'; const params = { id: '' }; t2(params);`,
+      errors: [{ messageId: 'parametersMustBeObject' }],
+    },
+    // t macro’s message parameter missing
+    {
+      code: `import { t } from '@lingui/core/macro'; t({ id: '' });`,
+      errors: [{ messageId: 'tMacroMessageMissing' }],
+    },
+    // t macro’s message parameter passed as variable
+    {
+      code: `import { t } from '@lingui/core/macro'; const message = ''; t({ id: '', message });`,
+      errors: [{ messageId: 'tMacroMessageMustBeStringOrPlural' }],
+    },
+    // t macro’s message parameter passed as expression
+    {
+      code: `import { t } from '@lingui/core/macro'; t({ id: '', message: '' + '' });`,
+      errors: [{ messageId: 'tMacroMessageMustBeStringOrPlural' }],
+    },
+    // t macro called as tag function
+    {
+      code: `import { t } from '@lingui/core/macro'; t\`\``,
+      errors: [{ messageId: 'tMacroAsTagFunction' }],
+    },
+    // plural macro called outside t macro
+    {
+      code: `import { plural } from '@lingui/core/macro'; const count = 1; plural(count, { other: 'message' })`,
+      errors: [{ messageId: 'pluralMacroOutsideTMacro' }],
+    },
+    {
+      code: `import { plural as plural2 } from '@lingui/core/macro'; const count = 1; plural2(count, { other: 'message' })`,
+      errors: [{ messageId: 'pluralMacroOutsideTMacro' }],
+    },
+    // Trans component’s message prop missing
+    {
+      code: `import { Trans } from '@lingui/react'; <Trans id="" />;`,
+      errors: [{ messageId: 'transComponentMessageMissing' }],
+    },
+    {
+      code: `import { Trans as Trans2 } from '@lingui/react'; <Trans2 id="" />;`,
+      errors: [{ messageId: 'transComponentMessageMissing' }],
+    },
+    // Trans component’s message prop passed as variable
+    {
+      code: `import { Trans } from '@lingui/react'; const message = ''; <Trans id="" message={message} />;`,
+      errors: [{ messageId: 'transComponentMessageMustBeString' }],
+    },
+    // Trans component’s message prop passed as template literal
+    {
+      code: `import { Trans } from '@lingui/react'; <Trans id="" message={\`\`} />;`,
+      errors: [{ messageId: 'transComponentMessageMustBeString' }],
+    },
+    // Trans component’s message prop passed as plural macro
+    {
+      code: `import { Trans } from '@lingui/react'; const count = 1; <Trans id="" message={plural(count, {other: ''})} />;`,
+      errors: [{ messageId: 'transComponentMessageMustBeString' }],
+    },
+  ],
+});


### PR DESCRIPTION
## Purpose

Add new eslint rule to check format of lingui functions/macros `t` and `plural` as well as the `Trans` component.

## Approach

The new rule only covers cases that are not yet handled by the existing key naming rule or TypeScript.