### PR TITLE
chore: update eslint rules for translation calls

### DIFF
--- a/tools/eslint-plugin-custom-lingui/rules/enforce-translation-call-format.js
+++ b/tools/eslint-plugin-custom-lingui/rules/enforce-translation-call-format.js
@@ -13,7 +13,11 @@ module.exports = {
       tMacroMessageMustBeStringOrPlural:
         'The "message" property must be a string, template literal, or plural call.',
       parametersMustBeObject: 'The parameters object must be an object literal.',
+      pluralComponentPropMustBeString:
+        'The "{{ prop }}" prop must be a string or template literal.',
       pluralMacroOutsideTMacro: 'The plural macro must be used inside the t macro.',
+      pluralMacroArgumentMustBeString:
+        'The "{{ arg }}" argument must be a string or template literal.',
       tMacroAsTagFunction: 'The t macro must not be called as a tag function.',
       transComponentMessageMissing: 'The "message" prop is required.',
       transComponentMessageMustBeString: 'The "message" prop must be a string.',
@@ -24,8 +28,13 @@ module.exports = {
     const tImportNames = new Set();
     // Track any aliases used for the `plural` macro
     const pluralImportNames = new Set();
+    // Track any aliases used for the `Plural` component macro
+    const pluralComponentImportNames = new Set();
     // Track any aliases used for the `Trans` component
     const transImportNames = new Set();
+
+    const PLURAL_COMPONENT_PROPS = ['other', 'one', '_0'];
+    const PLURAL_MACRO_PROPS = ['other', 'one', 0];
 
     return {
       // Track imports to handle aliasing
@@ -46,6 +55,13 @@ module.exports = {
             }
           });
         }
+        if (node.source.value === '@lingui/react/macro') {
+          node.specifiers.forEach((spec) => {
+            if (spec.imported.name === 'Plural') {
+              pluralComponentImportNames.add(spec.local.name);
+            }
+          });
+        }
       },
       // Validate t(...) and plural(...) calls
       CallExpression(node) {
@@ -55,41 +71,62 @@ module.exports = {
             return;
           }
 
-          const params = node.arguments[0];
-
           const messageProp = getMessageProperty(node);
           if (!messageProp) {
-            context.report({ node: params, messageId: 'tMacroMessageMissing' });
+            context.report({ node: node.arguments[0], messageId: 'tMacroMessageMissing' });
             return;
           }
           if (!isValidTMacroMessageProperty(messageProp, pluralImportNames)) {
-            context.report({ node: params, messageId: 'tMacroMessageMustBeStringOrPlural' });
+            context.report({
+              node: node.arguments[0],
+              messageId: 'tMacroMessageMustBeStringOrPlural',
+            });
             return;
           }
         } else if (isPluralMacroCall(node, pluralImportNames)) {
           if (!isMessageInTMacroCall(node, tImportNames)) {
             context.report({ node, messageId: 'pluralMacroOutsideTMacro' });
+            return;
+          }
+          for (const prop of PLURAL_MACRO_PROPS) {
+            const arg = getPluralMacroProperty(node, prop);
+            if (arg && !isValidPluralMacroMessageProperty(arg)) {
+              context.report({
+                node: node.arguments[1],
+                messageId: 'pluralMacroArgumentMustBeString',
+                data: { arg },
+              });
+            }
           }
         }
       },
-      // Validate <Trans id="..." /> usages
+      // Validate <Trans id="..." /> and <Plural id="..." /> usages
       JSXOpeningElement(node) {
         const tag = node.name;
-        if (!tag || !transImportNames.has(tag.name)) return;
+        if (!tag) return;
 
-        // Look for the message="..." prop
-        const messageAttr = node.attributes.find(
-          (attr) => attr.type === 'JSXAttribute' && attr.name.name === 'message',
-        );
+        if (transImportNames.has(tag.name)) {
+          const messageProp = getComponentProp(node, 'message');
+          if (!messageProp) {
+            context.report({ node, messageId: 'transComponentMessageMissing' });
+            return;
+          }
 
-        if (!messageAttr) {
-          context.report({ node, messageId: 'transComponentMessageMissing' });
-          return;
-        }
-
-        if (messageAttr.value.type !== 'Literal') {
-          context.report({ node, messageId: 'transComponentMessageMustBeString' });
-          return;
+          if (messageProp.value.type !== 'Literal') {
+            context.report({ node, messageId: 'transComponentMessageMustBeString' });
+            return;
+          }
+        } else if (pluralComponentImportNames.has(tag.name)) {
+          for (const propName of PLURAL_COMPONENT_PROPS) {
+            const prop = getComponentProp(node, propName);
+            if (prop && !isValidPluralComponentMessageProp(prop)) {
+              context.report({
+                node,
+                messageId: 'pluralComponentPropMustBeString',
+                data: { prop: propName },
+              });
+            }
+          }
         }
       },
       // Catch t`...` calls
@@ -120,11 +157,35 @@ function getMessageProperty(node) {
   );
 }
 
+function getComponentProp(node, propName) {
+  return node.attributes.find(
+    (prop) => prop.type === 'JSXAttribute' && prop.name.name === propName,
+  );
+}
+
+function getPluralMacroProperty(node, propName) {
+  return node.arguments[1].properties.find(
+    (p) => p.type === 'Property' && (p.key.name === propName || p.key.value === propName),
+  );
+}
+
 function isValidTMacroMessageProperty(property, pluralImportNames) {
   return (
     (property.value.type === 'CallExpression' &&
       pluralImportNames.has(property.value.callee.name)) ||
     ['Literal', 'TemplateLiteral'].includes(property.value.type)
+  );
+}
+
+function isValidPluralMacroMessageProperty(property) {
+  return ['Literal', 'TemplateLiteral'].includes(property.value.type);
+}
+
+function isValidPluralComponentMessageProp(prop) {
+  return (
+    prop.value.type === 'Literal' ||
+    (prop.value.type === 'JSXExpressionContainer' &&
+      prop.value.expression.type === 'TemplateLiteral')
   );
 }
 

--- a/tools/eslint-plugin-custom-lingui/rules/enforce-translation-call-format.test.js
+++ b/tools/eslint-plugin-custom-lingui/rules/enforce-translation-call-format.test.js
@@ -5,10 +5,10 @@ const { RuleTester } = require('eslint');
 const rule = require('./enforce-translation-call-format');
 
 const ruleTester = new RuleTester({
-  languageOptions: {
-    parserOptions: {
-      ecmaFeatures: { jsx: true },
-    },
+  parserOptions: {
+    ecmaVersion: 2020,
+    sourceType: 'module',
+    ecmaFeatures: { jsx: true },
   },
 });
 
@@ -27,6 +27,13 @@ ruleTester.run('translation-call-format', rule, {
     // Valid Trans usages
     {
       code: `import { Trans } from '@lingui/react'; <Trans id="" message="" />;`,
+    },
+    // Valid Plural usages
+    {
+      code: `import { Plural } from '@lingui/react/macro'; <Plural id="" other="" />;`,
+    },
+    {
+      code: `import { Plural } from '@lingui/react/macro'; <Plural id="" other={\`\`} />;`,
     },
   ],
 
@@ -60,6 +67,7 @@ ruleTester.run('translation-call-format', rule, {
       code: `import { t } from '@lingui/core/macro'; t\`\``,
       errors: [{ messageId: 'tMacroAsTagFunction' }],
     },
+
     // plural macro called outside t macro
     {
       code: `import { plural } from '@lingui/core/macro'; const count = 1; plural(count, { other: 'message' })`,
@@ -69,6 +77,22 @@ ruleTester.run('translation-call-format', rule, {
       code: `import { plural as plural2 } from '@lingui/core/macro'; const count = 1; plural2(count, { other: 'message' })`,
       errors: [{ messageId: 'pluralMacroOutsideTMacro' }],
     },
+    // plural macro’s other parameter passed as variable
+    {
+      code: `import { plural, t } from '@lingui/core/macro'; const message = ''; t({ id: '', message: plural(count, { other: message }) });`,
+      errors: [{ messageId: 'pluralMacroArgumentMustBeString' }],
+    },
+    // plural macro’s one parameter passed as variable
+    {
+      code: `import { plural, t } from '@lingui/core/macro'; const message = ''; t({ id: '', message: plural(count, { one: message }) });`,
+      errors: [{ messageId: 'pluralMacroArgumentMustBeString' }],
+    },
+    // plural macro’s 0 parameter passed as variable
+    {
+      code: `import { plural, t } from '@lingui/core/macro'; const message = ''; t({ id: '', message: plural(count, { [0]: message }) });`,
+      errors: [{ messageId: 'pluralMacroArgumentMustBeString' }],
+    },
+
     // Trans component’s message prop missing
     {
       code: `import { Trans } from '@lingui/react'; <Trans id="" />;`,
@@ -92,6 +116,37 @@ ruleTester.run('translation-call-format', rule, {
     {
       code: `import { Trans } from '@lingui/react'; const count = 1; <Trans id="" message={plural(count, {other: ''})} />;`,
       errors: [{ messageId: 'transComponentMessageMustBeString' }],
+    },
+
+    // Plural component’s other prop passed as variable
+    {
+      code: `import { Plural } from '@lingui/react/macro'; const message = ''; <Plural id="" other={message} />;`,
+      errors: [{ messageId: 'pluralComponentPropMustBeString' }],
+    },
+    // Plural component’s other prop passed as plural macro
+    {
+      code: `import { Plural } from '@lingui/react/macro'; const count = 1; <Plural id="" other={plural(count, {other: ''})} />;`,
+      errors: [{ messageId: 'pluralComponentPropMustBeString' }],
+    },
+    // Plural component’s one prop passed as variable
+    {
+      code: `import { Plural } from '@lingui/react/macro'; const message = ''; <Plural id="" one={message} />;`,
+      errors: [{ messageId: 'pluralComponentPropMustBeString' }],
+    },
+    // Plural component’s one prop passed as plural macro
+    {
+      code: `import { Plural } from '@lingui/react/macro'; const count = 1; <Plural id="" one={plural(count, {other: ''})} />;`,
+      errors: [{ messageId: 'pluralComponentPropMustBeString' }],
+    },
+    // Plural component’s _0 prop passed as variable
+    {
+      code: `import { Plural } from '@lingui/react/macro'; const message = ''; <Plural id="" _0={message} />;`,
+      errors: [{ messageId: 'pluralComponentPropMustBeString' }],
+    },
+    // Plural component’s _0 prop passed as plural macro
+    {
+      code: `import { Plural } from '@lingui/react/macro'; const count = 1; <Plural id="" _0={plural(count, {other: ''})} />;`,
+      errors: [{ messageId: 'pluralComponentPropMustBeString' }],
     },
   ],
 });

--- a/tools/eslint-plugin-custom-lingui/rules/enforce-translation-key-naming.js
+++ b/tools/eslint-plugin-custom-lingui/rules/enforce-translation-key-naming.js
@@ -26,9 +26,11 @@ module.exports = {
       /^FieldEditors\.([A-Z][a-zA-Z0-9]*)\.([A-Z][a-zA-Z0-9]*)\.([A-Z][a-zA-Z0-9]*)$/;
 
     // Track any aliases used for the `t` function
-    let linguiTNames = new Set();
+    const linguiTNames = new Set();
     // Track any aliases used for the `Trans` component
-    let transNames = new Set();
+    const transNames = new Set();
+    // Track any aliases used for the `Plural` component macro
+    const pluralComponentNames = new Set();
 
     const toPascalCase = (str) =>
       str
@@ -90,6 +92,13 @@ module.exports = {
             }
           });
         }
+        if (node.source.value === '@lingui/react/macro') {
+          node.specifiers.forEach((spec) => {
+            if (spec.imported.name === 'Plural') {
+              pluralComponentNames.add(spec.local.name);
+            }
+          });
+        }
       },
 
       // Validate t({ id: '...' }) calls
@@ -128,7 +137,7 @@ module.exports = {
       // Validate <Trans id="..." /> usages
       JSXOpeningElement(node) {
         const tag = node.name;
-        if (!tag || !transNames.has(tag.name)) return;
+        if (!tag || (!transNames.has(tag.name) && !pluralComponentNames.has(tag.name))) return;
 
         // Look for the id="..." attribute
         const idAttr = node.attributes.find(

--- a/tools/eslint-plugin-custom-lingui/rules/enforce-translation-key-naming.test.js
+++ b/tools/eslint-plugin-custom-lingui/rules/enforce-translation-key-naming.test.js
@@ -22,6 +22,10 @@ ruleTester.run('translation-key-format', rule, {
     {
       code: `import { Trans } from '@lingui/react'; <Trans id="FieldEditors.Dashboard.Widget.Header" />;`,
     },
+    // Valid Plural usage
+    {
+      code: `import { Plural } from '@lingui/react/macro'; <Plural id="FieldEditors.Dashboard.Widget.Header" />;`,
+    },
     // Alias for t
     {
       code: `import { t as translate } from '@lingui/core/macro'; translate({ id: 'FieldEditors.About.Info.Section' });`,
@@ -29,6 +33,10 @@ ruleTester.run('translation-key-format', rule, {
     // Alias for Trans
     {
       code: `import { Trans as T } from '@lingui/react'; <T id="FieldEditors.Account.Profile.Avatar" />;`,
+    },
+    // Alias for Plural
+    {
+      code: `import { Plural as P } from '@lingui/react/macro'; <P id="FieldEditors.Account.Profile.Avatar" />;`,
     },
   ],
 
@@ -43,9 +51,14 @@ ruleTester.run('translation-key-format', rule, {
       code: `import { Trans } from '@lingui/react'; <Trans />;`,
       errors: [{ messageId: 'missingId' }],
     },
+    // Missing id in Plural
+    {
+      code: `import { Plural } from '@lingui/react/macro'; <Plural />;`,
+      errors: [{ messageId: 'missingId' }],
+    },
     // Too few segments
     {
-      code: `import { t } from '@lingui/core/macro'; t({ id: 'UI.Home' });`,
+      code: `import { t } from '@lingui/core/macro'; t({ id: 'FieldEditors.Home' });`,
       errors: [{ messageId: 'tooFewSegments' }],
     },
     // Too many segments
@@ -68,6 +81,12 @@ ruleTester.run('translation-key-format', rule, {
     {
       code: `import { Trans as T } from '@lingui/react'; <T id="FieldEditors.welcome.screen.button" />;`,
       output: `import { Trans as T } from '@lingui/react'; <T id="FieldEditors.Welcome.Screen.Button" />;`,
+      errors: [{ messageId: 'invalidIdFormat' }],
+    },
+    // Alias for Plural with invalid format (with autofix)
+    {
+      code: `import { Plural as P } from '@lingui/react/macro'; <P id="FieldEditors.welcome.screen.button" />;`,
+      output: `import { Plural as P } from '@lingui/react/macro'; <P id="FieldEditors.Welcome.Screen.Button" />;`,
       errors: [{ messageId: 'invalidIdFormat' }],
     },
   ],


### PR DESCRIPTION
## Purpose

Update our eslint rules for translation calls to cover Plural component macros.

## Details

### rulesdir/enforce-translation-key-naming

* Check presence of `id` prop in Plural component
* Check key format in Plural component `id` prop

### rulesdir/enforce-translation-call-format

* Check message format in Plural component `other`, `one`, and `_0` props
* Check message format in plural macro `other`, `one`, and `0` arguments