### PR TITLE
chore: add ESM entry point to reference package

### DIFF
--- a/packages/reference/package.json
+++ b/packages/reference/package.json
@@ -8,6 +8,7 @@
     ".": {
       "types": "./dist/types/index.d.ts",
       "require": "./dist/cjs/index.js",
+      "import": "./dist/esm/index.js",
       "default": "./dist/cjs/index.js"
     },
     "./package.json": "./package.json"


### PR DESCRIPTION
Add an ECMAscript module [entry point](https://nodejs.org/api/packages.html#package-entry-points) to the reference field editor, potentially fixing https://github.com/contentful/field-editors/issues/1914.

## Background

Apps created with `create-contentful-app` duplicate the lingui package because they can’t bundle an ESM version of our packages and have to fall back to CJS. The duplication leads to the lingui singleton no longer working which causes the host app to configure a different lingui instance than the field editor uses.

I tested this fix locally by editing the package.json in the node_modules of my test app. If this also works with the released package, I’ll update all field editors to fix this once and for all.