### PR TITLE
fix: [TOL-3361] Allows bulk editing only for non active releases

### DIFF
--- a/packages/reference/src/entries/WrappedEntryCard/FetchingWrappedEntryCard.tsx
+++ b/packages/reference/src/entries/WrappedEntryCard/FetchingWrappedEntryCard.tsx
@@ -93,7 +93,7 @@ export function FetchingWrappedEntryCard(props: EntryCardReferenceEditorProps) {
 
   const onEdit = async () => {
     const slide = await openEntry(props.sdk, props.entryId, {
-      bulkEditing: props.parameters.instance.bulkEditing,
+      bulkEditing: !activeRelease && props.parameters.instance.bulkEditing,
       index: props.index,
     });
     props.onAction &&


### PR DESCRIPTION
## Description
This PR includes a small logic to check if there is an `activeRelease`  while editing a reference field. If yes, bulk editing will be disabled and it shows slide as regular (and disabled ) entry instead.

**Why?**
```
// WIP
``` 
