### PR TITLE
feat: (F36-V5) remove double nested menu

### DIFF
--- a/packages/reference/src/components/LinkActions/CombinedLinkActions.tsx
+++ b/packages/reference/src/components/LinkActions/CombinedLinkActions.tsx
@@ -10,7 +10,7 @@ import * as styles from './redesignStyles';
 
 const testIds = {
   ...sharedTextIds,
-  actionsWrapper: 'link-actions-menu-trigger'
+  actionsWrapper: 'link-actions-menu-trigger',
 };
 
 /**
@@ -48,23 +48,21 @@ function CombinedEntryLinkActions(props: LinkActionsProps) {
         hasPlusIcon={true}
         useExperimentalStyles={true}
         dropdownSettings={{
-          position: 'bottom-left'
+          position: 'bottom-left',
         }}
         onSelect={(contentTypeId) => {
           return contentTypeId ? props.onCreate(contentTypeId) : Promise.resolve();
         }}
         customDropdownItems={
           props.canLinkEntity ? (
-            <Menu>
-              <Menu.Item
-                testId={testIds.linkExisting}
-                onClick={() => {
-                  props.onLinkExisting();
-                }}
-              >
-                Add existing content
-              </Menu.Item>
-            </Menu>
+            <Menu.Item
+              testId={testIds.linkExisting}
+              onClick={() => {
+                props.onLinkExisting();
+              }}
+            >
+              Add existing content
+            </Menu.Item>
           ) : undefined
         }
       />

--- a/packages/rich-text/src/plugins/EmbeddedEntityInline/FetchingWrappedInlineEntryCard.tsx
+++ b/packages/rich-text/src/plugins/EmbeddedEntityInline/FetchingWrappedInlineEntryCard.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
-import { InlineEntryCard, Menu, MenuItem, Text } from '@contentful/f36-components';
+import { InlineEntryCard, MenuItem, Text } from '@contentful/f36-components';
 import { ClockIcon } from '@contentful/f36-icons';
 import tokens from '@contentful/f36-tokens';
 import {
   ScheduledIconWithTooltip,
   useEntity,
-  useEntityLoader
+  useEntityLoader,
 } from '@contentful/field-editor-reference';
 import { Entry, FieldAppSDK, entityHelpers } from '@contentful/field-editor-shared';
 import { INLINES } from '@contentful/rich-text-types';
@@ -17,8 +17,8 @@ const { getEntryTitle, getEntityStatus } = entityHelpers;
 const styles = {
   scheduledIcon: css({
     verticalAlign: 'text-bottom',
-    marginRight: tokens.spacing2Xs
-  })
+    marginRight: tokens.spacing2Xs,
+  }),
 };
 
 type InternalFetchingWrappedInlineEntryCardProps = Pick<
@@ -45,7 +45,7 @@ function InternalFetchingWrappedInlineEntryCard({
   getEntityScheduledActions,
   onEdit,
   onRemove,
-  isDisabled
+  isDisabled,
 }: InternalFetchingWrappedInlineEntryCardProps) {
   const contentType = React.useMemo(() => {
     if (!allContentTypes) {
@@ -53,7 +53,7 @@ function InternalFetchingWrappedInlineEntryCard({
     }
 
     return allContentTypes.find(
-      (contentType) => contentType.sys.id === entry.sys.contentType.sys.id
+      (contentType) => contentType.sys.id === entry.sys.contentType.sys.id,
     );
   }, [allContentTypes, entry]);
 
@@ -64,9 +64,9 @@ function InternalFetchingWrappedInlineEntryCard({
         contentType,
         localeCode: locale,
         defaultLocaleCode: defaultLocale,
-        defaultTitle: 'Untitled'
+        defaultTitle: 'Untitled',
       }),
-    [entry, contentType, locale, defaultLocale]
+    [entry, contentType, locale, defaultLocale],
   );
 
   return (
@@ -81,10 +81,8 @@ function InternalFetchingWrappedInlineEntryCard({
         </MenuItem>,
         <MenuItem key="remove" onClick={onRemove} disabled={isDisabled} testId="delete">
           Remove
-        </MenuItem>
-      ].map((item, i) => (
-        <Menu key={i}>{item}</Menu>
-      ))}
+        </MenuItem>,
+      ]}
     >
       <ScheduledIconWithTooltip
         getEntityScheduledActions={getEntityScheduledActions}
@@ -141,7 +139,7 @@ export function FetchingWrappedInlineEntryCard(props: FetchingWrappedInlineEntry
 
   const entryStatus = getEntityStatus(
     entry.sys,
-    props.sdk.parameters.instance.useLocalizedEntityStatus ? props.sdk.field.locale : undefined
+    props.sdk.parameters.instance.useLocalizedEntityStatus ? props.sdk.field.locale : undefined,
   );
 
   if (entryStatus === 'deleted') {
@@ -153,10 +151,8 @@ export function FetchingWrappedInlineEntryCard(props: FetchingWrappedInlineEntry
         actions={[
           <MenuItem key="remove" onClick={props.onRemove} testId="delete">
             Remove
-          </MenuItem>
-        ].map((item, i) => (
-          <Menu key={i}>{item}</Menu>
-        ))}
+          </MenuItem>,
+        ]}
       />
     );
   }

--- a/packages/rich-text/src/plugins/EmbeddedResourceInline/FetchingWrappedResourceInlineCard.tsx
+++ b/packages/rich-text/src/plugins/EmbeddedResourceInline/FetchingWrappedResourceInlineCard.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import { Entry } from '@contentful/app-sdk';
-import { InlineEntryCard, Menu, MenuItem, Text } from '@contentful/f36-components';
+import { InlineEntryCard, MenuItem, Text } from '@contentful/f36-components';
 import { ResourceLink, ResourceInfo, useResource } from '@contentful/field-editor-reference';
 import { entityHelpers } from '@contentful/field-editor-shared';
 import { FieldAppSDK } from '@contentful/field-editor-shared';
@@ -23,7 +23,7 @@ interface FetchingWrappedResourceInlineCardProps {
 export function FetchingWrappedResourceInlineCard(props: FetchingWrappedResourceInlineCardProps) {
   const { link, onEntityFetchComplete, sdk } = props;
   const { data, status: requestStatus } = useResource(link.linkType, link.urn, {
-    locale: sdk.field.locale
+    locale: sdk.field.locale,
   });
 
   React.useEffect(() => {
@@ -53,12 +53,12 @@ export function FetchingWrappedResourceInlineCard(props: FetchingWrappedResource
     contentType,
     defaultLocaleCode,
     localeCode: defaultLocaleCode,
-    defaultTitle: 'Untitled'
+    defaultTitle: 'Untitled',
   });
   const truncatedTitle = truncateTitle(title, 40);
   const status = getEntityStatus(
     entry.sys,
-    props.sdk.parameters.instance.useLocalizedEntityStatus ? props.sdk.field.locale : undefined
+    props.sdk.parameters.instance.useLocalizedEntityStatus ? props.sdk.field.locale : undefined,
   );
 
   return (
@@ -70,10 +70,8 @@ export function FetchingWrappedResourceInlineCard(props: FetchingWrappedResource
       actions={[
         <MenuItem key="remove" onClick={props.onRemove} disabled={props.isDisabled} testId="delete">
           Remove
-        </MenuItem>
-      ].map((item, i) => (
-        <Menu key={i}>{item}</Menu>
-      ))}
+        </MenuItem>,
+      ]}
     >
       <Text>{title}</Text>
     </InlineEntryCard>

--- a/packages/rich-text/src/plugins/Marks/components/MarkToolbarButton.tsx
+++ b/packages/rich-text/src/plugins/Marks/components/MarkToolbarButton.tsx
@@ -42,18 +42,16 @@ export const createMarkToolbarButton = ({ mark, title, icon }: MarkOptions) => {
 
     if (!icon) {
       return (
-        <Menu>
-          <Menu.Item
-            onClick={handleClick}
-            disabled={isDisabled}
-            className={cx({
-              [styles.isActive]: isMarkActive(editor, mark),
-            })}
-            testId={`${mark}-toolbar-button`}
-          >
-            {title}
-          </Menu.Item>
-        </Menu>
+        <Menu.Item
+          onClick={handleClick}
+          disabled={isDisabled}
+          className={cx({
+            [styles.isActive]: isMarkActive(editor, mark),
+          })}
+          testId={`${mark}-toolbar-button`}
+        >
+          {title}
+        </Menu.Item>
       );
     }
 

--- a/packages/rich-text/src/plugins/shared/EmbeddedBlockToolbarIcon.tsx
+++ b/packages/rich-text/src/plugins/shared/EmbeddedBlockToolbarIcon.tsx
@@ -50,26 +50,24 @@ export function EmbeddedBlockToolbarIcon({
   const type = getEntityTypeFromNodeType(nodeType);
   const baseClass = `rich-text__${nodeType}`;
   return (
-    <Menu>
-      <Menu.Item
-        disabled={isDisabled}
-        className={`${baseClass}-list-item`}
-        onClick={handleClick}
-        testId={`toolbar-toggle-${nodeType}`}
-      >
-        <Flex alignItems="center" flexDirection="row">
-          <Icon
-            as={type === 'Asset' ? ImageSquareIcon : EmbeddedBlockIcon}
-            className={`rich-text__embedded-entry-list-icon ${styles.icon}`}
-            color={tokens.gray900}
-          />
-          <span>
-            {type}
-            {nodeType == BLOCKS.EMBEDDED_RESOURCE && <ResourceNewBadge />}
-          </span>
-        </Flex>
-      </Menu.Item>
-    </Menu>
+    <Menu.Item
+      disabled={isDisabled}
+      className={`${baseClass}-list-item`}
+      onClick={handleClick}
+      testId={`toolbar-toggle-${nodeType}`}
+    >
+      <Flex alignItems="center" flexDirection="row">
+        <Icon
+          as={type === 'Asset' ? ImageSquareIcon : EmbeddedBlockIcon}
+          className={`rich-text__embedded-entry-list-icon ${styles.icon}`}
+          color={tokens.gray900}
+        />
+        <span>
+          {type}
+          {nodeType == BLOCKS.EMBEDDED_RESOURCE && <ResourceNewBadge />}
+        </span>
+      </Flex>
+    </Menu.Item>
   );
 }
 

--- a/packages/rich-text/src/plugins/shared/EmbeddedInlineToolbarIcon.tsx
+++ b/packages/rich-text/src/plugins/shared/EmbeddedInlineToolbarIcon.tsx
@@ -59,24 +59,22 @@ export function EmbeddedInlineToolbarIcon({
   }
 
   return (
-    <Menu>
-      <Menu.Item
-        disabled={isDisabled}
-        className="rich-text__entry-link-block-button"
-        testId={`toolbar-toggle-${nodeType}`}
-        onClick={handleClick}
-      >
-        <Flex alignItems="center" flexDirection="row">
-          <EmbeddedLineIcon
-            color={tokens.gray900}
-            className={`rich-text__embedded-entry-list-icon ${styles.icon}`}
-          />
-          <span>
-            Inline entry
-            {nodeType == INLINES.EMBEDDED_RESOURCE && <ResourceNewBadge />}
-          </span>
-        </Flex>
-      </Menu.Item>
-    </Menu>
+    <Menu.Item
+      disabled={isDisabled}
+      className="rich-text__entry-link-block-button"
+      testId={`toolbar-toggle-${nodeType}`}
+      onClick={handleClick}
+    >
+      <Flex alignItems="center" flexDirection="row">
+        <EmbeddedLineIcon
+          color={tokens.gray900}
+          className={`rich-text__embedded-entry-list-icon ${styles.icon}`}
+        />
+        <span>
+          Inline entry
+          {nodeType == INLINES.EMBEDDED_RESOURCE && <ResourceNewBadge />}
+        </span>
+      </Flex>
+    </Menu.Item>
   );
 }


### PR DESCRIPTION
- This was added as a fix for the  `useMenuContext must be used within a MenuContextProvider` error thrown in the initial F36 v5  update see [here](https://app.circleci.com/pipelines/github/contentful/field-editors/8160/workflows/b1cda325-8c9d-419b-adf1-51fc51c07ded/jobs/28541/tests)

but its unnecessary and not needed since at the root, this wraps in a `Menu` already