### PR TITLE
fix(ReleaseEntityStatusBadge): handle remainsDraft correctly [TOL-3393]

### DIFF
--- a/packages/_shared/src/ReleaseEntityStatusBadge/ReleaseEntityStatusBadge.tsx
+++ b/packages/_shared/src/ReleaseEntityStatusBadge/ReleaseEntityStatusBadge.tsx
@@ -2,30 +2,38 @@ import React from 'react';
 
 import { Badge, BadgeVariant } from '@contentful/f36-components';
 
-import type { ReleaseAction } from '../types';
+import type { ReleaseEntityStatus } from '../types';
 
 type ReleaseEntityActionBadgeProps = {
-  action: ReleaseAction;
+  status: ReleaseEntityStatus;
   className?: string;
 };
 
-const config: Record<ReleaseAction, { label: string; variant: BadgeVariant }> = {
-  publish: {
+const config: Record<ReleaseEntityStatus, { label: string; variant: BadgeVariant }> = {
+  willPublish: {
     label: 'Will publish',
     variant: 'positive' as const,
   },
-  unpublish: {
+  becomesDraft: {
     label: 'Becomes draft',
     variant: 'warning' as const,
   },
-  'not-in-release': {
+  remainsDraft: {
+    label: 'Remains draft',
+    variant: 'warning' as const,
+  },
+  notInRelease: {
     label: 'Not in release',
     variant: 'secondary' as const,
   },
+  published: {
+    label: 'Published',
+    variant: 'positive' as const,
+  },
 };
 
-export function ReleaseEntityStatusBadge({ className, action }: ReleaseEntityActionBadgeProps) {
-  const badgeConfig = config[action];
+export function ReleaseEntityStatusBadge({ className, status }: ReleaseEntityActionBadgeProps) {
+  const badgeConfig = config[status];
 
   return (
     <Badge

--- a/packages/_shared/src/hooks/useReleaseStatus.ts
+++ b/packages/_shared/src/hooks/useReleaseStatus.ts
@@ -9,7 +9,6 @@ import type {
 } from 'contentful-management/types';
 
 import type {
-  ReleaseAction,
   ReleaseEntityStatus,
   ReleaseLocalesStatus,
   ReleaseV2Entity,
@@ -110,12 +109,17 @@ type UseActiveReleaseLocalesStatuses = {
   previousEntityOnTimeline?: EntryProps | AssetProps;
 };
 
+type UseRelaseStatus = {
+  releaseEntityStatus: ReleaseEntityStatus;
+  releaseStatusMap: ReleaseStatusMap;
+};
+
 export function useReleaseStatus({
   entity,
   release,
   locales,
   previousEntityOnTimeline,
-}: UseActiveReleaseLocalesStatuses) {
+}: UseActiveReleaseLocalesStatuses): UseRelaseStatus {
   const sanitizedLocales = useMemo(() => sanitizeLocales(locales), [locales]);
 
   const releaseStatusMap: ReleaseStatusMap = useMemo(() => {
@@ -155,25 +159,25 @@ export function useReleaseStatus({
     );
   }, [entity?.sys, previousEntityOnTimeline, release, sanitizedLocales]);
 
-  const releaseAction: ReleaseAction | undefined = useMemo(() => {
-    if (releaseStatusMap.size === 0) {
-      return undefined;
-    }
-
+  const releaseEntityStatus: ReleaseEntityStatus = useMemo(() => {
     const releaseArray = Array.from(releaseStatusMap.values());
     if (releaseArray.find(({ status }) => status === 'willPublish')) {
-      return 'publish';
+      return 'willPublish';
     }
 
-    if (releaseArray.find(({ status }) => status === 'becomesDraft' || status === 'remainsDraft')) {
-      return 'unpublish';
+    if (releaseArray.find(({ status }) => status === 'becomesDraft')) {
+      return 'becomesDraft';
     }
 
-    return 'not-in-release';
+    if (releaseArray.find(({ status }) => status === 'remainsDraft')) {
+      return 'remainsDraft';
+    }
+
+    return 'notInRelease';
   }, [releaseStatusMap]);
 
   return {
     releaseStatusMap,
-    releaseAction,
+    releaseEntityStatus,
   };
 }

--- a/packages/reference/src/assets/WrappedAssetCard/FetchingWrappedAssetCard.tsx
+++ b/packages/reference/src/assets/WrappedAssetCard/FetchingWrappedAssetCard.tsx
@@ -42,7 +42,7 @@ export function FetchingWrappedAssetCard(props: FetchingWrappedAssetCardProps) {
   );
   const activeLocales = useActiveLocales(props.sdk);
   const localesStatusMap = useLocalePublishStatus(asset, props.sdk.locales);
-  const { releaseStatusMap, releaseAction } = useReleaseStatus({
+  const { releaseStatusMap, releaseEntityStatus } = useReleaseStatus({
     entity: asset,
     previousEntityOnTimeline: currentEntity,
     release: props.sdk.release,
@@ -112,7 +112,7 @@ export function FetchingWrappedAssetCard(props: FetchingWrappedAssetCardProps) {
       activeLocales,
       releaseStatusMap,
       release: props.sdk.release as ReleaseV2Props | undefined,
-      releaseAction,
+      releaseEntityStatus,
     };
 
     if (status === 'loading') {

--- a/packages/reference/src/assets/WrappedAssetCard/WrappedAssetCard.tsx
+++ b/packages/reference/src/assets/WrappedAssetCard/WrappedAssetCard.tsx
@@ -5,7 +5,7 @@ import { AssetCard } from '@contentful/f36-components';
 import {
   entityHelpers,
   type LocalePublishStatusMap,
-  type ReleaseAction,
+  type ReleaseEntityStatus,
   type ReleaseStatusMap,
   type ReleaseV2Props,
 } from '@contentful/field-editor-shared';
@@ -48,7 +48,7 @@ export interface WrappedAssetCardProps {
   useLocalizedEntityStatus?: boolean;
   localesStatusMap?: LocalePublishStatusMap;
   activeLocales?: Pick<LocaleProps, 'code'>[];
-  releaseAction?: ReleaseAction;
+  releaseEntityStatus?: ReleaseEntityStatus;
   releaseStatusMap?: ReleaseStatusMap;
   release?: ReleaseV2Props;
 }
@@ -88,7 +88,7 @@ export const WrappedAssetCard = ({
   onEdit,
   getAssetUrl,
   onRemove,
-  releaseAction,
+  releaseEntityStatus,
   releaseStatusMap,
   release,
 }: WrappedAssetCardProps) => {
@@ -131,7 +131,7 @@ export const WrappedAssetCard = ({
           entity={asset}
           localesStatusMap={localesStatusMap}
           activeLocales={activeLocales}
-          releaseAction={releaseAction}
+          releaseEntityStatus={releaseEntityStatus}
           releaseStatusMap={releaseStatusMap}
           release={release}
         />

--- a/packages/reference/src/assets/WrappedAssetCard/WrappedAssetLink.tsx
+++ b/packages/reference/src/assets/WrappedAssetCard/WrappedAssetLink.tsx
@@ -4,7 +4,7 @@ import { EntryCard } from '@contentful/f36-components';
 import {
   entityHelpers,
   isValidImage,
-  type ReleaseAction,
+  type ReleaseEntityStatus,
   type LocalePublishStatusMap,
   type ReleaseStatusMap,
   type ReleaseV2Props,
@@ -31,7 +31,7 @@ export interface WrappedAssetLinkProps {
   localesStatusMap?: LocalePublishStatusMap;
   activeLocales?: Pick<LocaleProps, 'code'>[];
   isClickable?: boolean;
-  releaseAction?: ReleaseAction;
+  releaseEntityStatus?: ReleaseEntityStatus;
   releaseStatusMap?: ReleaseStatusMap;
   release?: ReleaseV2Props;
 }
@@ -76,7 +76,7 @@ export const WrappedAssetLink = (props: WrappedAssetLinkProps) => {
           entity={props.asset}
           localesStatusMap={props.localesStatusMap}
           activeLocales={props.activeLocales}
-          releaseAction={props.releaseAction}
+          releaseEntityStatus={props.releaseEntityStatus}
           releaseStatusMap={props.releaseStatusMap}
           release={props.release}
         />

--- a/packages/reference/src/components/EntityStatusBadge/EntityStatusBadge.tsx
+++ b/packages/reference/src/components/EntityStatusBadge/EntityStatusBadge.tsx
@@ -6,9 +6,9 @@ import {
   LocalePublishStatusMap,
   ReleaseEntityStatusPopover,
   ReleaseEntityStatusBadge,
-  type ReleaseAction,
   type ReleaseStatusMap,
   type ReleaseV2Props,
+  type ReleaseEntityStatus,
 } from '@contentful/field-editor-shared';
 import { EntryProps, LocaleProps, AssetProps } from 'contentful-management';
 
@@ -25,7 +25,7 @@ type EntityStatusBadgeProps = Omit<UseScheduledActionsProps, 'entityId'> & {
   localesStatusMap?: LocalePublishStatusMap;
   activeLocales?: Pick<LocaleProps, 'code'>[];
   releaseStatusMap?: ReleaseStatusMap;
-  releaseAction?: ReleaseAction;
+  releaseEntityStatus?: ReleaseEntityStatus;
   release?: ReleaseV2Props;
 };
 
@@ -38,7 +38,7 @@ export function EntityStatusBadge({
   activeLocales,
   entity,
   releaseStatusMap,
-  releaseAction,
+  releaseEntityStatus,
   release,
   ...props
 }: EntityStatusBadgeProps) {
@@ -59,8 +59,8 @@ export function EntityStatusBadge({
   }
 
   // release entry + entry based publishing
-  if (release && releaseAction) {
-    return <ReleaseEntityStatusBadge action={releaseAction} />;
+  if (release && releaseEntityStatus) {
+    return <ReleaseEntityStatusBadge status={releaseEntityStatus} />;
   }
 
   // current base entry + locale based publishing

--- a/packages/reference/src/entries/WrappedEntryCard/FetchingWrappedEntryCard.tsx
+++ b/packages/reference/src/entries/WrappedEntryCard/FetchingWrappedEntryCard.tsx
@@ -71,7 +71,7 @@ export function FetchingWrappedEntryCard(props: EntryCardReferenceEditorProps) {
     [getEntityScheduledActions, props.entryId],
   );
   const localesStatusMap = useLocalePublishStatus(entry, props.sdk.locales);
-  const { releaseStatusMap, releaseAction } = useReleaseStatus({
+  const { releaseStatusMap, releaseEntityStatus } = useReleaseStatus({
     entity: entry,
     previousEntityOnTimeline: currentEntity,
     release: props.sdk.release,
@@ -161,7 +161,7 @@ export function FetchingWrappedEntryCard(props: EntryCardReferenceEditorProps) {
       activeLocales: props.activeLocales,
       releaseStatusMap,
       release: props.sdk.release as ReleaseV2Props | undefined,
-      releaseAction,
+      releaseEntityStatus,
     };
 
     const { hasCardEditActions, hasCardMoveActions, hasCardRemoveActions } = props;

--- a/packages/reference/src/entries/WrappedEntryCard/WrappedEntryCard.tsx
+++ b/packages/reference/src/entries/WrappedEntryCard/WrappedEntryCard.tsx
@@ -6,7 +6,7 @@ import {
   entityHelpers,
   isValidImage,
   LocalePublishStatusMap,
-  type ReleaseAction,
+  type ReleaseEntityStatus,
   type ReleaseStatusMap,
   type ReleaseV2Props,
 } from '@contentful/field-editor-shared';
@@ -43,7 +43,7 @@ export interface WrappedEntryCardProps {
   useLocalizedEntityStatus?: boolean;
   localesStatusMap?: LocalePublishStatusMap;
   activeLocales?: Pick<LocaleProps, 'code'>[];
-  releaseAction?: ReleaseAction;
+  releaseEntityStatus?: ReleaseEntityStatus;
   releaseStatusMap?: ReleaseStatusMap;
   release?: ReleaseV2Props;
 }
@@ -80,7 +80,7 @@ export function WrappedEntryCard({
   onRemove,
   onMoveTop,
   onMoveBottom,
-  releaseAction,
+  releaseEntityStatus,
   releaseStatusMap,
   release,
 }: WrappedEntryCardProps) {
@@ -157,7 +157,7 @@ export function WrappedEntryCard({
           entity={entry}
           localesStatusMap={localesStatusMap}
           activeLocales={activeLocales}
-          releaseAction={releaseAction}
+          releaseEntityStatus={releaseEntityStatus}
           releaseStatusMap={releaseStatusMap}
           release={release}
         />

--- a/packages/rich-text/src/plugins/shared/FetchingWrappedAssetCard.tsx
+++ b/packages/rich-text/src/plugins/shared/FetchingWrappedAssetCard.tsx
@@ -14,8 +14,8 @@ import {
   useActiveLocales,
   type ReleaseStatusMap,
   type ReleaseV2Props,
-  type ReleaseAction,
   useReleaseStatus,
+  type ReleaseEntityStatus,
 } from '@contentful/field-editor-shared';
 import areEqual from 'fast-deep-equal';
 
@@ -31,7 +31,7 @@ interface InternalAssetCardProps {
   localesStatusMap?: LocalePublishStatusMap;
   releaseStatusMap?: ReleaseStatusMap;
   release?: ReleaseV2Props;
-  releaseAction?: ReleaseAction;
+  releaseEntityStatus?: ReleaseEntityStatus;
 }
 
 const InternalAssetCard = React.memo(
@@ -47,7 +47,7 @@ const InternalAssetCard = React.memo(
     localesStatusMap,
     release,
     releaseStatusMap,
-    releaseAction,
+    releaseEntityStatus,
   }: InternalAssetCardProps) => {
     const activeLocales = useActiveLocales(sdk);
 
@@ -73,7 +73,7 @@ const InternalAssetCard = React.memo(
         }
         releaseStatusMap={releaseStatusMap}
         release={release}
-        releaseAction={releaseAction}
+        releaseEntityStatus={releaseEntityStatus}
       />
     );
   },
@@ -102,7 +102,7 @@ export function FetchingWrappedAssetCard(props: FetchingWrappedAssetCardProps) {
     [getEntityScheduledActions, props.assetId],
   );
   const localesStatusMap = useLocalePublishStatus(asset, props.sdk.locales);
-  const { releaseStatusMap, releaseAction } = useReleaseStatus({
+  const { releaseStatusMap, releaseEntityStatus } = useReleaseStatus({
     entity: asset,
     previousEntityOnTimeline: currentEntity,
     locales: props.sdk.locales,
@@ -142,7 +142,7 @@ export function FetchingWrappedAssetCard(props: FetchingWrappedAssetCardProps) {
       localesStatusMap={localesStatusMap}
       releaseStatusMap={releaseStatusMap}
       release={props.sdk.release as ReleaseV2Props | undefined}
-      releaseAction={releaseAction}
+      releaseEntityStatus={releaseEntityStatus}
     />
   );
 }

--- a/packages/rich-text/src/plugins/shared/FetchingWrappedEntryCard.tsx
+++ b/packages/rich-text/src/plugins/shared/FetchingWrappedEntryCard.tsx
@@ -16,7 +16,7 @@ import {
   useReleaseStatus,
   type ReleaseStatusMap,
   type ReleaseV2Props,
-  type ReleaseAction,
+  type ReleaseEntityStatus,
 } from '@contentful/field-editor-shared';
 import areEqual from 'fast-deep-equal';
 
@@ -32,7 +32,7 @@ interface InternalEntryCard {
   localesStatusMap?: LocalePublishStatusMap;
   releaseStatusMap?: ReleaseStatusMap;
   release?: ReleaseV2Props;
-  releaseAction?: ReleaseAction;
+  releaseEntityStatus?: ReleaseEntityStatus;
 }
 
 const InternalEntryCard = React.memo(
@@ -42,7 +42,7 @@ const InternalEntryCard = React.memo(
     loadEntityScheduledActions,
     releaseStatusMap,
     release,
-    releaseAction,
+    releaseEntityStatus,
     isSelected,
     isDisabled,
     locale,
@@ -79,7 +79,7 @@ const InternalEntryCard = React.memo(
         }
         releaseStatusMap={releaseStatusMap}
         release={release}
-        releaseAction={releaseAction}
+        releaseEntityStatus={releaseEntityStatus}
       />
     );
   },
@@ -108,7 +108,7 @@ export const FetchingWrappedEntryCard = (props: FetchingWrappedEntryCardProps) =
     [getEntityScheduledActions, entryId],
   );
   const localesStatusMap = useLocalePublishStatus(entry, props.sdk.locales);
-  const { releaseStatusMap, releaseAction } = useReleaseStatus({
+  const { releaseStatusMap, releaseEntityStatus } = useReleaseStatus({
     entity: entry,
     previousEntityOnTimeline: currentEntity,
     locales: props.sdk.locales,
@@ -148,7 +148,7 @@ export const FetchingWrappedEntryCard = (props: FetchingWrappedEntryCardProps) =
       localesStatusMap={localesStatusMap}
       releaseStatusMap={releaseStatusMap}
       release={props.sdk.release as ReleaseV2Props | undefined}
-      releaseAction={releaseAction}
+      releaseEntityStatus={releaseEntityStatus}
     />
   );
 };


### PR DESCRIPTION
Use `ReleaseEntityStatus` instead of `ReleaseActions` for the `ReleaseEntityStatusBadge` and the calcualtion before, as it shows all correct states, otherwise we would show different badges in case of locale based publishing beeing used.