### PR TITLE
chore: add i18n to ReleaseEntityStatusBadge and ReleaseEntityStatusPopover [TOL-3432]

### DIFF
--- a/packages/_shared/src/ReleaseEntityStatusBadge/ReleaseEntityStatusBadge.tsx
+++ b/packages/_shared/src/ReleaseEntityStatusBadge/ReleaseEntityStatusBadge.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 
 import { Badge } from '@contentful/f36-components';
-import { getReleaseStatusBadgeConfig } from 'utils/getReleaseStatusBadgeConfig';
 
 import type { ReleaseEntityStatus } from '../types';
+import { getReleaseStatusBadgeConfig } from '../utils/getReleaseStatusBadgeConfig';
 
 type ReleaseEntityActionBadgeProps = {
   status: ReleaseEntityStatus;

--- a/packages/_shared/src/ReleaseEntityStatusBadge/ReleaseEntityStatusBadge.tsx
+++ b/packages/_shared/src/ReleaseEntityStatusBadge/ReleaseEntityStatusBadge.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { Badge, BadgeVariant } from '@contentful/f36-components';
+import { t } from '@lingui/core/macro';
 
 import type { ReleaseEntityStatus } from '../types';
 
@@ -34,6 +35,7 @@ const config: Record<ReleaseEntityStatus, { label: string; variant: BadgeVariant
 
 export function ReleaseEntityStatusBadge({ className, status }: ReleaseEntityActionBadgeProps) {
   const badgeConfig = config[status];
+  const statusLabel = badgeConfig.label;
 
   return (
     <Badge
@@ -41,7 +43,11 @@ export function ReleaseEntityStatusBadge({ className, status }: ReleaseEntityAct
       className={className}
       variant={badgeConfig.variant}
     >
-      {badgeConfig.label}
+      {t({
+        id: 'FieldEditors.Shared.ReleaseEntityStatusBadge.Label',
+        // eslint-disable-next-line lingui/no-single-variables-to-translate -- status label is dynamic and comes from a config object
+        message: `${statusLabel}`,
+      })}
     </Badge>
   );
 }

--- a/packages/_shared/src/ReleaseEntityStatusBadge/ReleaseEntityStatusBadge.tsx
+++ b/packages/_shared/src/ReleaseEntityStatusBadge/ReleaseEntityStatusBadge.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { Badge, BadgeVariant } from '@contentful/f36-components';
-import { t } from '@lingui/core/macro';
+import { Badge } from '@contentful/f36-components';
+import { getReleaseStatusBadgeConfig } from 'utils/getReleaseStatusBadgeConfig';
 
 import type { ReleaseEntityStatus } from '../types';
 
@@ -10,53 +10,8 @@ type ReleaseEntityActionBadgeProps = {
   className?: string;
 };
 
-function getConfig(status: ReleaseEntityStatus): { label: string; variant: BadgeVariant } {
-  switch (status) {
-    case 'willPublish':
-      return {
-        label: t({
-          id: 'FieldEditors.Shared.ReleaseEntityStatusBadge.WillPublish',
-          message: 'Will publish',
-        }),
-        variant: 'positive' as const,
-      };
-    case 'becomesDraft':
-      return {
-        label: t({
-          id: 'FieldEditors.Shared.ReleaseEntityStatusBadge.BecomesDraft',
-          message: 'Becomes draft',
-        }),
-        variant: 'warning' as const,
-      };
-    case 'remainsDraft':
-      return {
-        label: t({
-          id: 'FieldEditors.Shared.ReleaseEntityStatusBadge.RemainsDraft',
-          message: 'Remains draft',
-        }),
-        variant: 'warning' as const,
-      };
-    case 'notInRelease':
-      return {
-        label: t({
-          id: 'FieldEditors.Shared.ReleaseEntityStatusBadge.NotInRelease',
-          message: 'Not in release',
-        }),
-        variant: 'secondary' as const,
-      };
-    case 'published':
-      return {
-        label: t({
-          id: 'FieldEditors.Shared.ReleaseEntityStatusBadge.Published',
-          message: 'Published',
-        }),
-        variant: 'positive' as const,
-      };
-  }
-}
-
 export function ReleaseEntityStatusBadge({ className, status }: ReleaseEntityActionBadgeProps) {
-  const { label, variant } = getConfig(status);
+  const { label, variant } = getReleaseStatusBadgeConfig(status);
 
   return (
     <Badge testId="release-entity-action-status" className={className} variant={variant}>

--- a/packages/_shared/src/ReleaseEntityStatusBadge/ReleaseEntityStatusBadge.tsx
+++ b/packages/_shared/src/ReleaseEntityStatusBadge/ReleaseEntityStatusBadge.tsx
@@ -10,44 +10,57 @@ type ReleaseEntityActionBadgeProps = {
   className?: string;
 };
 
-const config: Record<ReleaseEntityStatus, { label: string; variant: BadgeVariant }> = {
-  willPublish: {
-    label: 'Will publish',
-    variant: 'positive' as const,
-  },
-  becomesDraft: {
-    label: 'Becomes draft',
-    variant: 'warning' as const,
-  },
-  remainsDraft: {
-    label: 'Remains draft',
-    variant: 'warning' as const,
-  },
-  notInRelease: {
-    label: 'Not in release',
-    variant: 'secondary' as const,
-  },
-  published: {
-    label: 'Published',
-    variant: 'positive' as const,
-  },
-};
+function getConfig(status: ReleaseEntityStatus): { label: string; variant: BadgeVariant } {
+  switch (status) {
+    case 'willPublish':
+      return {
+        label: t({
+          id: 'FieldEditors.Shared.ReleaseEntityStatusBadge.WillPublish',
+          message: 'Will publish',
+        }),
+        variant: 'positive' as const,
+      };
+    case 'becomesDraft':
+      return {
+        label: t({
+          id: 'FieldEditors.Shared.ReleaseEntityStatusBadge.BecomesDraft',
+          message: 'Becomes draft',
+        }),
+        variant: 'warning' as const,
+      };
+    case 'remainsDraft':
+      return {
+        label: t({
+          id: 'FieldEditors.Shared.ReleaseEntityStatusBadge.RemainsDraft',
+          message: 'Remains draft',
+        }),
+        variant: 'warning' as const,
+      };
+    case 'notInRelease':
+      return {
+        label: t({
+          id: 'FieldEditors.Shared.ReleaseEntityStatusBadge.NotInRelease',
+          message: 'Not in release',
+        }),
+        variant: 'secondary' as const,
+      };
+    case 'published':
+      return {
+        label: t({
+          id: 'FieldEditors.Shared.ReleaseEntityStatusBadge.Published',
+          message: 'Published',
+        }),
+        variant: 'positive' as const,
+      };
+  }
+}
 
 export function ReleaseEntityStatusBadge({ className, status }: ReleaseEntityActionBadgeProps) {
-  const badgeConfig = config[status];
-  const statusLabel = badgeConfig.label;
+  const { label, variant } = getConfig(status);
 
   return (
-    <Badge
-      testId="release-entity-action-status"
-      className={className}
-      variant={badgeConfig.variant}
-    >
-      {t({
-        id: 'FieldEditors.Shared.ReleaseEntityStatusBadge.Label',
-        // eslint-disable-next-line lingui/no-single-variables-to-translate -- status label is dynamic and comes from a config object
-        message: `${statusLabel}`,
-      })}
+    <Badge testId="release-entity-action-status" className={className} variant={variant}>
+      {label}
     </Badge>
   );
 }

--- a/packages/_shared/src/ReleaseEntityStatusBadge/ReleaseEntityStatusLocale.tsx
+++ b/packages/_shared/src/ReleaseEntityStatusBadge/ReleaseEntityStatusLocale.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import { Badge, BadgeVariant, Text } from '@contentful/f36-components';
 import tokens from '@contentful/f36-tokens';
+import { t } from '@lingui/core/macro';
 import type { LocaleProps } from 'contentful-management';
 import { css } from 'emotion';
 
@@ -33,12 +34,18 @@ export function ReleaseEntityStatusLocale({
   label,
   variant,
 }: ReleaseEntityStatusLocaleProps) {
+  const localeCode = locale.code;
+  const isDefaultLocale = `${locale.default ? ', Default' : ''}`;
+
   return (
     <div className={styles.localePublishStatus} data-test-id="locale-publishing-status">
       <Text className={styles.locale} fontColor="gray700">
         {locale.name}{' '}
         <Text fontColor="gray500">
-          ({locale.code}){locale.default && ', Default'}
+          {t({
+            id: 'FieldEditors.Shared.ReleaseEntityStatusLocale.LocaleCode',
+            message: `(${localeCode}) ${isDefaultLocale}`,
+          })}
         </Text>
       </Text>
       <Badge className={styles.status} variant={variant}>

--- a/packages/_shared/src/ReleaseEntityStatusBadge/ReleaseEntityStatusLocalesList.tsx
+++ b/packages/_shared/src/ReleaseEntityStatusBadge/ReleaseEntityStatusLocalesList.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { MenuSectionTitle } from '@contentful/f36-components';
+import { t } from '@lingui/core/macro';
 import type { LocaleProps } from 'contentful-management';
 import { sortBy } from 'lodash';
 
@@ -59,7 +60,7 @@ export function ReleaseEntityStatusLocalesList({
   activeLocales,
 }: ReleaseEntityStatusLocalesListProps) {
   const entries = [...statusMap.entries()];
-  const counters = entries.reduce(
+  const { willPublish, becomesDraft, remainsDraft } = entries.reduce(
     (prev, [, { status }]) => ({
       becomesDraft: prev.becomesDraft + (status === 'becomesDraft' ? 1 : 0),
       willPublish: prev.willPublish + (status === 'willPublish' ? 1 : 0),
@@ -72,12 +73,23 @@ export function ReleaseEntityStatusLocalesList({
   return (
     <>
       <Banner
-        content="The statuses of the locales for this content:"
-        highlight={`${counters.becomesDraft} becomes draft, ${counters.willPublish} will publish, ${counters.remainsDraft} remains draft`}
+        content={t({
+          id: 'FieldEditors.Shared.ReleaseEntityStatusLocalesList.BannerContent',
+          message: 'The statuses of the locales for this content:',
+        })}
+        highlight={t({
+          id: 'FieldEditors.Shared.ReleaseEntityStatusLocalesList.BannerHighlight',
+          message: `${becomesDraft} becomes draft, ${willPublish} will publish, ${remainsDraft} remains draft`,
+        })}
       />
 
       <div data-test-id="locale-publishing-selected">
-        <MenuSectionTitle>Locales in the entry editor:</MenuSectionTitle>
+        <MenuSectionTitle>
+          {t({
+            id: 'FieldEditors.Shared.ReleaseEntityStatusLocalesList.SelectedLocalesTitle',
+            message: 'Locales in the entry editor:',
+          })}
+        </MenuSectionTitle>
         {selected.map(({ locale, label, variant }) => (
           <ReleaseEntityStatusLocale
             key={`selected-${locale.code}`}
@@ -90,7 +102,12 @@ export function ReleaseEntityStatusLocalesList({
 
       {nonSelected.length > 0 && (
         <div data-test-id="locale-publishing-others">
-          <MenuSectionTitle>Other locales:</MenuSectionTitle>
+          <MenuSectionTitle>
+            {t({
+              id: 'FieldEditors.Shared.ReleaseEntityStatusLocalesList.OtherLocalesTitle',
+              message: 'Other locales:',
+            })}
+          </MenuSectionTitle>
           {nonSelected.map(({ locale, label, variant }) => (
             <ReleaseEntityStatusLocale
               key={`others-${locale.code}`}

--- a/packages/_shared/src/ReleaseEntityStatusBadge/ReleaseEntityStatusPopover.tsx
+++ b/packages/_shared/src/ReleaseEntityStatusBadge/ReleaseEntityStatusPopover.tsx
@@ -3,12 +3,11 @@ import React, { useCallback, useRef, useState } from 'react';
 import { Badge, Flex, Popover } from '@contentful/f36-components';
 import { CaretDownIcon } from '@contentful/f36-icons';
 import tokens from '@contentful/f36-tokens';
-import { t } from '@lingui/core/macro';
 import type { LocaleProps } from 'contentful-management';
-import { cx, css } from 'emotion';
+import { css, cx } from 'emotion';
+import { getReleaseStatusBadgeConfig } from 'utils/getReleaseStatusBadgeConfig';
 
-import type { ReleaseStatusMap, ReleaseEntityStatus } from '../types';
-import { RELEASE_BADGES } from './constants';
+import type { ReleaseEntityStatus, ReleaseStatusMap } from '../types';
 import { ReleaseEntityStatusLocalesList } from './ReleaseEntityStatusLocalesList';
 
 type BadgeSVGType = {
@@ -26,7 +25,8 @@ type Status = {
 
 const getColor = ({ secondary, tertiary, isHover }: BadgeSVGType) => {
   const status = secondary || tertiary;
-  return isHover ? RELEASE_BADGES[status]?.hover : RELEASE_BADGES[status]?.default;
+  const config = getReleaseStatusBadgeConfig(status);
+  return isHover ? config?.hover : config?.default;
 };
 
 const generateDynamicStyles = (status?: Status) => {
@@ -173,8 +173,7 @@ export function ReleaseEntityStatusPopover({
   const status = determineBadgeStatus(releaseStatusMap, activeLocales);
   const ariaLabel = status.secondary ? 'Multiple statuses' : status.primary;
   const wrapperClass = generateDynamicStyles(status);
-  const statusLabel = RELEASE_BADGES[status.primary].label;
-
+  const { label, icon, variant } = getReleaseStatusBadgeConfig(status.primary);
   return (
     <Popover
       isOpen={releaseStatusMap && isOpen}
@@ -190,19 +189,15 @@ export function ReleaseEntityStatusPopover({
         >
           <Badge
             tabIndex={0}
-            variant={RELEASE_BADGES[status.primary].variant}
+            variant={variant}
             onFocus={() => setIsOpen(true)}
             onBlur={() => setIsOpen(false)}
-            endIcon={<CaretDownIcon size="tiny" color={RELEASE_BADGES[status.primary].icon} />}
+            endIcon={<CaretDownIcon size="tiny" color={icon} />}
             onMouseOver={onMouseEnter}
             onMouseEnter={onMouseEnter}
             onMouseLeave={onMouseLeave}
           >
-            {t({
-              id: 'FieldEditors.Shared.ReleaseEntityStatusPopover.Label',
-              // eslint-disable-next-line lingui/no-single-variables-to-translate -- status label is dynamic and comes from a config object
-              message: `${statusLabel}`,
-            })}
+            {label}
           </Badge>
           {status.secondary && (
             <svg

--- a/packages/_shared/src/ReleaseEntityStatusBadge/ReleaseEntityStatusPopover.tsx
+++ b/packages/_shared/src/ReleaseEntityStatusBadge/ReleaseEntityStatusPopover.tsx
@@ -5,9 +5,9 @@ import { CaretDownIcon } from '@contentful/f36-icons';
 import tokens from '@contentful/f36-tokens';
 import type { LocaleProps } from 'contentful-management';
 import { css, cx } from 'emotion';
-import { getReleaseStatusBadgeConfig } from 'utils/getReleaseStatusBadgeConfig';
 
 import type { ReleaseEntityStatus, ReleaseStatusMap } from '../types';
+import { getReleaseStatusBadgeConfig } from '../utils/getReleaseStatusBadgeConfig';
 import { ReleaseEntityStatusLocalesList } from './ReleaseEntityStatusLocalesList';
 
 type BadgeSVGType = {

--- a/packages/_shared/src/ReleaseEntityStatusBadge/ReleaseEntityStatusPopover.tsx
+++ b/packages/_shared/src/ReleaseEntityStatusBadge/ReleaseEntityStatusPopover.tsx
@@ -3,6 +3,7 @@ import React, { useCallback, useRef, useState } from 'react';
 import { Badge, Flex, Popover } from '@contentful/f36-components';
 import { CaretDownIcon } from '@contentful/f36-icons';
 import tokens from '@contentful/f36-tokens';
+import { t } from '@lingui/core/macro';
 import type { LocaleProps } from 'contentful-management';
 import { cx, css } from 'emotion';
 
@@ -172,6 +173,7 @@ export function ReleaseEntityStatusPopover({
   const status = determineBadgeStatus(releaseStatusMap, activeLocales);
   const ariaLabel = status.secondary ? 'Multiple statuses' : status.primary;
   const wrapperClass = generateDynamicStyles(status);
+  const statusLabel = RELEASE_BADGES[status.primary].label;
 
   return (
     <Popover
@@ -196,7 +198,11 @@ export function ReleaseEntityStatusPopover({
             onMouseEnter={onMouseEnter}
             onMouseLeave={onMouseLeave}
           >
-            {RELEASE_BADGES[status.primary].label}
+            {t({
+              id: 'FieldEditors.Shared.ReleaseEntityStatusPopover.Label',
+              // eslint-disable-next-line lingui/no-single-variables-to-translate -- status label is dynamic and comes from a config object
+              message: `${statusLabel}`,
+            })}
           </Badge>
           {status.secondary && (
             <svg

--- a/packages/_shared/src/index.tsx
+++ b/packages/_shared/src/index.tsx
@@ -44,3 +44,4 @@ export * from './LocalePublishingEntityStatusBadge';
 export * from './ReleaseEntityStatusBadge';
 export * from './utils/determineReleaseAction';
 export * from './utils/getEntityReleaseStatus';
+export * from './utils/getReleaseStatusBadgeConfig';

--- a/packages/_shared/src/utils/getReleaseStatusBadgeConfig.ts
+++ b/packages/_shared/src/utils/getReleaseStatusBadgeConfig.ts
@@ -1,0 +1,70 @@
+import { BadgeVariant } from '@contentful/f36-components';
+import tokens from '@contentful/f36-tokens';
+import { t } from '@lingui/core/macro';
+import { ReleaseEntityStatus } from 'types';
+
+export function getReleaseStatusBadgeConfig(status: ReleaseEntityStatus): {
+  label: string;
+  variant: BadgeVariant;
+  default: string;
+  hover: string;
+  icon: string;
+} {
+  switch (status) {
+    case 'willPublish':
+      return {
+        label: t({
+          id: 'FieldEditors.Shared.ReleaseEntityStatusBadge.WillPublish',
+          message: 'Will publish',
+        }),
+        variant: 'positive',
+        default: tokens.green300,
+        hover: tokens.green400,
+        icon: tokens.green400,
+      };
+    case 'becomesDraft':
+      return {
+        label: t({
+          id: 'FieldEditors.Shared.ReleaseEntityStatusBadge.BecomesDraft',
+          message: 'Becomes draft',
+        }),
+        variant: 'warning',
+        default: tokens.orange300,
+        hover: tokens.orange400,
+        icon: tokens.orange400,
+      };
+    case 'remainsDraft':
+      return {
+        label: t({
+          id: 'FieldEditors.Shared.ReleaseEntityStatusBadge.RemainsDraft',
+          message: 'Remains draft',
+        }),
+        variant: 'warning',
+        default: tokens.orange300,
+        hover: tokens.orange400,
+        icon: tokens.orange400,
+      };
+    case 'notInRelease':
+      return {
+        label: t({
+          id: 'FieldEditors.Shared.ReleaseEntityStatusBadge.NotInRelease',
+          message: 'Not in release',
+        }),
+        variant: 'secondary',
+        default: tokens.gray300,
+        hover: tokens.gray400,
+        icon: tokens.gray400,
+      };
+    case 'published':
+      return {
+        label: t({
+          id: 'FieldEditors.Shared.ReleaseEntityStatusBadge.Published',
+          message: 'Published',
+        }),
+        variant: 'positive',
+        default: tokens.green300,
+        hover: tokens.green400,
+        icon: tokens.green400,
+      };
+  }
+}


### PR DESCRIPTION
Make the following components internationalized:
- [x] ReleaseEntityStatusBadge
- [x] ReleaseEntityStatusPopover
- [x] ReleaseEntityStatusLocale
- [x] ReleaseEntityStatusLocalesList

Jira ticket: https://contentful.atlassian.net/browse/TOL-3432

✌🏼 Quick win: merge `RELEASE_BADGES` properties into `getReleaseStatusBadgeConfig` to avoid duplication