### PR TITLE
fix: improve rating field usability with trackpad [ZEND-6961]

### DIFF
--- a/packages/rating/src/RatingEditor.spec.tsx
+++ b/packages/rating/src/RatingEditor.spec.tsx
@@ -58,7 +58,7 @@ describe('RatingEditor', () => {
     expect(container.querySelectorAll('[data-selected="true"]')).toHaveLength(1);
     expect(container.querySelectorAll('[data-selected="false"]')).toHaveLength(4);
 
-    fireEvent.mouseDown(getByTestId('rating-editor-clear'));
+    fireEvent.click(getByTestId('rating-editor-clear'));
     expect(field.removeValue).toHaveBeenCalled();
   });
 

--- a/packages/rating/src/RatingEditor.spec.tsx
+++ b/packages/rating/src/RatingEditor.spec.tsx
@@ -26,12 +26,12 @@ describe('RatingEditor', () => {
         field={field}
         isInitiallyDisabled={false}
         parameters={{ installation: {}, instance: { stars: 20 }, invocation: {} }}
-      />
+      />,
     );
     expect(getAllByTestId('rating-editor-star')).toHaveLength(20);
   });
 
-  it('should should setValue by clicking on a item and removeValue by clicking on clear', () => {
+  it('should setValue by clicking on a item and removeValue by clicking on clear', () => {
     const [field] = createFakeFieldAPI((field) => {
       jest.spyOn(field, 'setValue');
       jest.spyOn(field, 'removeValue');
@@ -40,7 +40,7 @@ describe('RatingEditor', () => {
       };
     });
     const { container, getAllByTestId, getByTestId, queryByTestId } = render(
-      <RatingEditor field={field} isInitiallyDisabled={false} />
+      <RatingEditor field={field} isInitiallyDisabled={false} />,
     );
 
     const $stars = getAllByTestId('rating-editor-star');
@@ -48,17 +48,17 @@ describe('RatingEditor', () => {
     expect(container.querySelectorAll('[data-selected="true"]')).toHaveLength(0);
     expect(container.querySelectorAll('[data-selected="false"]')).toHaveLength(5);
 
-    fireEvent.click($stars[4]);
+    fireEvent.mouseDown($stars[4]);
     expect(field.setValue).toHaveBeenCalledWith(5);
     expect(container.querySelectorAll('[data-selected="true"]')).toHaveLength(5);
     expect(container.querySelectorAll('[data-selected="false"]')).toHaveLength(0);
 
-    fireEvent.click($stars[0]);
+    fireEvent.mouseDown($stars[0]);
     expect(field.setValue).toHaveBeenCalledWith(1);
     expect(container.querySelectorAll('[data-selected="true"]')).toHaveLength(1);
     expect(container.querySelectorAll('[data-selected="false"]')).toHaveLength(4);
 
-    fireEvent.click(getByTestId('rating-editor-clear'));
+    fireEvent.mouseDown(getByTestId('rating-editor-clear'));
     expect(field.removeValue).toHaveBeenCalled();
   });
 
@@ -71,7 +71,7 @@ describe('RatingEditor', () => {
       };
     });
     const { container, getAllByTestId, queryByTestId } = render(
-      <RatingEditor field={field} isInitiallyDisabled={false} />
+      <RatingEditor field={field} isInitiallyDisabled={false} />,
     );
 
     const $stars = getAllByTestId('rating-editor-star');

--- a/packages/rating/src/RatingEditor.tsx
+++ b/packages/rating/src/RatingEditor.tsx
@@ -40,17 +40,11 @@ function getStarCount(count?: number | string): number {
   }
 }
 
-export function RatingEditor(props: RatingEditorProps) {
-  const { field } = props;
-
-  const starsCount = getStarCount(get(props.parameters, ['instance', 'stars']));
+export function RatingEditor({ field, parameters, isInitiallyDisabled = true }: RatingEditorProps) {
+  const starsCount = getStarCount(get(parameters, ['instance', 'stars']));
 
   return (
-    <FieldConnector<number>
-      debounce={0}
-      field={field}
-      isInitiallyDisabled={props.isInitiallyDisabled}
-    >
+    <FieldConnector<number> debounce={0} field={field} isInitiallyDisabled={isInitiallyDisabled}>
       {({ disabled, value, setValue }) => {
         const clearOption = () => {
           setValue(null);
@@ -79,7 +73,3 @@ export function RatingEditor(props: RatingEditorProps) {
     </FieldConnector>
   );
 }
-
-RatingEditor.defaultProps = {
-  isInitiallyDisabled: true,
-};

--- a/packages/rating/src/RatingRibbon.tsx
+++ b/packages/rating/src/RatingRibbon.tsx
@@ -68,7 +68,7 @@ export class RatingRibbon extends React.Component<RatingRibbonProps, RatingRibbo
             testId="rating-editor-star"
             isDisabled={this.props.disabled}
             key={num}
-            onClick={() => {
+            onMouseDown={() => {
               this.props.onSelect(num);
             }}
             onKeyDown={(e: React.KeyboardEvent) => {

--- a/packages/rating/src/RatingRibbon.tsx
+++ b/packages/rating/src/RatingRibbon.tsx
@@ -68,8 +68,10 @@ export class RatingRibbon extends React.Component<RatingRibbonProps, RatingRibbo
             testId="rating-editor-star"
             isDisabled={this.props.disabled}
             key={num}
-            onMouseDown={() => {
-              this.props.onSelect(num);
+            onMouseDown={(e: React.MouseEvent) => {
+              if (e.button === 0) {
+                this.props.onSelect(num);
+              }
             }}
             onKeyDown={(e: React.KeyboardEvent) => {
               if (e.keyCode === 13) {


### PR DESCRIPTION
The onClick event for some reason was buggy with my trackpad and may have been causing users issues, so I changed it to a more reliable onMouseDown as well as fixed a very minor warning about props