### PR TITLE
chore: [TOL-3461] add i18n when createReleaseLocaleStatus

### DIFF
--- a/packages/_shared/src/hooks/useReleaseStatus.ts
+++ b/packages/_shared/src/hooks/useReleaseStatus.ts
@@ -11,57 +11,26 @@ import type {
 import type {
   ReleaseEntityStatus,
   ReleaseLocalesStatus,
+  ReleaseStatusMap,
   ReleaseV2Entity,
   ReleaseV2EntityWithLocales,
   ReleaseV2Props,
-  ReleaseStatusMap,
 } from '../types';
 import { getEntityStatus } from '../utils/entityHelpers';
+import { getReleaseStatusBadgeConfig } from '../utils/getReleaseStatusBadgeConfig';
 import { sanitizeLocales } from '../utils/sanitizeLocales';
 
 function createReleaseLocaleStatus(
   locale: Pick<LocaleProps, 'code' | 'default' | 'name'>,
   status: ReleaseEntityStatus,
 ): ReleaseLocalesStatus {
-  switch (status) {
-    case 'published':
-      return {
-        variant: 'positive',
-        status,
-        label: 'Published',
-        locale,
-      };
-    case 'willPublish':
-      return {
-        variant: 'positive',
-        status: 'willPublish',
-        label: 'Will publish',
-        locale,
-      };
-    case 'becomesDraft':
-      return {
-        variant: 'warning',
-        status: 'becomesDraft',
-        label: 'Becomes draft',
-        locale,
-      };
-    case 'remainsDraft':
-      return {
-        variant: 'warning',
-        status: 'remainsDraft',
-        label: 'Remains draft',
-        locale,
-      };
-    case 'notInRelease':
-      return {
-        variant: 'secondary',
-        status: 'notInRelease',
-        label: 'Not in release',
-        locale,
-      };
-    default:
-      throw new Error(`Unknown release entity status: ${status}`);
-  }
+  const { label, variant } = getReleaseStatusBadgeConfig(status);
+  return {
+    variant,
+    status,
+    label,
+    locale,
+  };
 }
 
 function getReleaseItemLocaleStatus(

--- a/packages/_shared/src/utils/getReleaseStatusBadgeConfig.ts
+++ b/packages/_shared/src/utils/getReleaseStatusBadgeConfig.ts
@@ -66,5 +66,7 @@ export function getReleaseStatusBadgeConfig(status: ReleaseEntityStatus): {
         hover: tokens.green400,
         icon: tokens.green400,
       };
+    default:
+      throw new Error(`Unknown release entity status: ${status}`);
   }
 }


### PR DESCRIPTION
## Description
Reused a function that I created before (`getReleaseStatusBadgeConfig`) to ensure that labels from `useReleaseStatus` are correctly translated.

Ticket: https://contentful.atlassian.net/browse/TOL-3461