### PR TITLE
fix: useReleaseStatus respects Published status

### DIFF
--- a/packages/_shared/src/hooks/useReleaseStatus.ts
+++ b/packages/_shared/src/hooks/useReleaseStatus.ts
@@ -130,6 +130,10 @@ export function useReleaseStatus({
 
   const releaseEntityStatus: ReleaseEntityStatus = useMemo(() => {
     const releaseArray = Array.from(releaseStatusMap.values());
+    if (releaseArray.find(({ status }) => status === 'published')) {
+      return 'published';
+    }
+
     if (releaseArray.find(({ status }) => status === 'willPublish')) {
       return 'willPublish';
     }


### PR DESCRIPTION
The refactor of useReleaseStatus was missing a case for published status in the returned `releaseEntityStatus`, this restores it so we get the correct status instead of the default "not in release'