### PR TITLE
fix(rich-text): compute count for initial value

### DIFF
--- a/packages/rich-text/src/plugins/CharCounter/withCharCounter.ts
+++ b/packages/rich-text/src/plugins/CharCounter/withCharCounter.ts
@@ -3,6 +3,8 @@ import debounce from 'p-debounce';
 import { PlateEditor } from '../../internal';
 import { getTextContent } from './utils';
 
+const CHARACTER_COUNT_DEBOUNCE_TIME = 300;
+
 export const withCharCounter = (editor: PlateEditor) => {
   const { apply } = editor;
 
@@ -18,7 +20,7 @@ export const withCharCounter = (editor: PlateEditor) => {
 
   const recount = debounce(async () => {
     count = getTextContent(editor).length;
-  }, 300);
+  }, CHARACTER_COUNT_DEBOUNCE_TIME);
 
   editor.apply = (op) => {
     apply(op);


### PR DESCRIPTION
Plate bypasses `editor.apply` when setting the initial value of the editor (happens after plugins are initialised), causing the initial editor count always to be `0` until the editor is focused.

Since the `usePlateEditorState` re-renders after the initial value is set, the `editor.getCharacterCount` was being called but giving a stale value. The fix is to delay computing the initial count until the first call to `getCharacterCount` to make sure we are working with the initial editor value.
