### PR TITLE
feat(richTextEditor): add stickytoolbaroffset as prop

### DIFF
--- a/packages/rich-text/src/RichTextEditor.tsx
+++ b/packages/rich-text/src/RichTextEditor.tsx
@@ -39,6 +39,7 @@ type RichTextProps = {
    */
   onChange?: (doc: Contentful.Document) => unknown;
   withCharValidation?: boolean;
+  stickyToolbarOffset?: number;
 };
 
 type ConnectedRichTextProps = {
@@ -132,6 +133,7 @@ const RichTextEditor = (props: RichTextProps) => {
     restrictedMarks,
     onChange,
     isDisabled,
+    stickyToolbarOffset,
     ...otherProps
   } = props;
   const isEmptyValue = React.useCallback(
@@ -164,6 +166,7 @@ const RichTextEditor = (props: RichTextProps) => {
           isDisabled={disabled}
           onChange={setValue}
           restrictedMarks={restrictedMarks}
+          stickyToolbarOffset={stickyToolbarOffset}
           withCharValidation={props.withCharValidation ?? true}
         />
       )}


### PR DESCRIPTION
`stickyToolbarOffset` is currently a prop for the `ConnectedRichTextEditor` but not for the `RichTextEditor` which I understand as the one we should use for apps. I would like to add `stickyToolbarOffset` as a prop of the `RichTextEditor` so that when a rich text field is used in an app, we can optionally have a sticky toolbar.

Why am I doing this now?
I received a[ Zendesk ticket](https://contentful.atlassian.net/browse/ZEND-7083) from a customer saying they like the new rich-text-versioning app but do not find it worth using because the toolbar is not sticky. Let's change that :)