### PR TITLE
fix: add useFocused hook from slate-react update to show TableActions

### DIFF
--- a/packages/rich-text/src/plugins/Table/components/Cell.tsx
+++ b/packages/rich-text/src/plugins/Table/components/Cell.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import tokens from '@contentful/f36-tokens';
 import { TableCell } from '@contentful/rich-text-types';
 import { css } from 'emotion';
-import { useSelected } from 'slate-react';
+import { useSelected, useFocused } from 'slate-react';
 
 import { RenderElementProps } from '../../../internal/types';
 import { TableActions } from './TableActions';
@@ -23,6 +23,7 @@ const style = css`
 
 export const Cell = (props: RenderElementProps) => {
   const isSelected = useSelected();
+  const isFocused = useFocused();
   return (
     <td
       {...props.attributes}
@@ -32,7 +33,7 @@ export const Cell = (props: RenderElementProps) => {
       {...(props.element.data as TableCell['data'])}
       className={style}
     >
-      {isSelected && <TableActions />}
+      {isSelected && isFocused && <TableActions />}
       {props.children}
     </td>
   );

--- a/packages/rich-text/src/plugins/Table/components/HeaderCell.tsx
+++ b/packages/rich-text/src/plugins/Table/components/HeaderCell.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import tokens from '@contentful/f36-tokens';
 import { TableHeaderCell } from '@contentful/rich-text-types';
 import { css } from 'emotion';
-import { useSelected } from 'slate-react';
+import { useSelected, useFocused } from 'slate-react';
 
 import { RenderElementProps } from '../../../internal/types';
 import { TableActions } from './TableActions';
@@ -26,6 +26,7 @@ const style = css`
 
 export const HeaderCell = (props: RenderElementProps) => {
   const isSelected = useSelected();
+  const isFocused = useFocused();
 
   return (
     <th
@@ -36,7 +37,7 @@ export const HeaderCell = (props: RenderElementProps) => {
       {...(props.element.data as TableHeaderCell['data'])}
       className={style}
     >
-      {isSelected && <TableActions />}
+      {isSelected && isFocused && <TableActions />}
       {props.children}
     </th>
   );


### PR DESCRIPTION
After bumping `slate-react`, is needed to check both `useSelect` AND `useFocused` to determine if an element should show interactive UI elements. e.g.: `<TableActions/>`