### PR TITLE
feat: add new versions of slate, slate-dom and slate-react as peerDependencies of rich-text package

### DIFF
--- a/packages/rich-text/package.json
+++ b/packages/rich-text/package.json
@@ -77,7 +77,10 @@
   "peerDependencies": {
     "@lingui/core": "^5.3.0",
     "react": ">=16.14.0",
-    "react-dom": ">=16.14.0"
+    "react-dom": ">=16.14.0",
+    "slate": "0.118.1",
+    "slate-dom": "0.118.1",
+    "slate-react": "0.118.2"
   },
   "devDependencies": {
     "@contentful/field-editor-test-utils": "^1.7.0",


### PR DESCRIPTION
Conflicts with old versions of slate on consumer side are causing problems on the deployed version of rich-text.
This PR proposes to ensure these specific versions will be present on the consumer side, to ensure old versions will not bring mismatches. 