### PR TITLE
fix: reorganize slate-* deps imports to avoid future need of override versions on consumer side [TOL-3613]

### DIFF
--- a/packages/rich-text/package.json
+++ b/packages/rich-text/package.json
@@ -68,11 +68,8 @@
     "moment": "^2.20.0",
     "p-debounce": "^2.1.0",
     "react-popper": "^2.3.0",
-    "slate": "0.118.1",
-    "slate-dom": "0.118.1",
     "slate-history": "0.100.0",
-    "slate-hyperscript": "0.77.0",
-    "slate-react": "0.118.2"
+    "slate-hyperscript": "0.77.0"
   },
   "peerDependencies": {
     "@lingui/core": "^5.3.0",
@@ -89,7 +86,10 @@
     "@types/is-hotkey": "^0.1.6",
     "@udecode/plate-test-utils": "^3.2.0",
     "prism-react-renderer": "2.4.1",
-    "react": "18.3.1"
+    "react": "18.3.1",
+    "slate": "0.118.1",
+    "slate-dom": "0.118.1",
+    "slate-react": "0.118.2"
   },
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/"


### PR DESCRIPTION
## Description
Adding `slate` as a `peerDependency` (and removing it from dependencies) will reduce or even eliminate the need for consumers to use overrides as long as their app is already using a compatible Slate version. From Contentful internal apps we are now all aligned with the same `slate-*` version.
Ticket: https://contentful.atlassian.net/browse/TOL-3613

## What happens in the consumer app

The consumer installs slate (prompted/enforced by `peerDependencies`).

At runtime, `require('slate')` inside `field-editors/rich-text` resolves to the consumer’s top-level slate.

Because now we didn’t list `slate-*` in dependencies, there’s no second copy under node_modules/@contentful/field-editor-rich-text, avoiding the duplicate-instance bugs we had before.

From this change there is no need to add this on consumer's apps
```js
// package.json
{

    overrides: {
        "slate": "0.118.1",
        "slate-dom": "0.118.1",
        "slate-react": "0.118.2"
    }
}
```
