### PR TITLE
fix: remove unnecessary declaration of slate-* as peerDependencies [TOL-3613]

### DIFF
--- a/packages/rich-text/package.json
+++ b/packages/rich-text/package.json
@@ -77,10 +77,7 @@
   "peerDependencies": {
     "@lingui/core": "^5.3.0",
     "react": ">=16.14.0",
-    "react-dom": ">=16.14.0",
-    "slate": "0.118.1",
-    "slate-dom": "0.118.1",
-    "slate-react": "0.118.2"
+    "react-dom": ">=16.14.0"
   },
   "devDependencies": {
     "@contentful/field-editor-test-utils": "^1.7.0",


### PR DESCRIPTION
Because `slate-*` is already imported as `dependencies`, there is no reason for having it as `peerDependencies` too.
As `field-editors/rich-text` is one of the main users of `slate-*`, we might put it as `devDependencies` and `peerDependencies` on `experience-components` or any other package who decides to use `slate-*`, so this way we prevent the mismatching between slate versions.