### PR TITLE
fix: [ZEND-7212] Rating star coloring

### DIFF
--- a/packages/rating/src/RatingRibbon.tsx
+++ b/packages/rating/src/RatingRibbon.tsx
@@ -60,6 +60,7 @@ export class RatingRibbon extends React.Component<RatingRibbonProps, RatingRibbo
             size="small"
             icon={
               <StarIcon
+                isActive={this.isSelected(num)}
                 color={this.isSelected(num) ? tokens.colorPrimary : tokens.gray600}
                 className={css({ width: '22px', height: '22px' })}
               />


### PR DESCRIPTION
Fix coloring of the rating field:
<img width="335" height="117" alt="image" src="https://github.com/user-attachments/assets/0f9f9450-1a9f-41b3-93de-dacad7bfb9ed" />
