### PR TITLE
chore(i18n): update catalog path []

### DIFF
--- a/lingui.config.mjs
+++ b/lingui.config.mjs
@@ -5,7 +5,7 @@ export default defineConfig({
   locales: ['en-US'],
   catalogs: [
     {
-      path: './{locale}',
+      path: 'tools/extract-new-translation-keys/{locale}',
       include: [
         '<rootDir>/packages/_shared/src',
         '<rootDir>/packages/boolean/src',


### PR DESCRIPTION
Adjusts the catalog path in the lingui configuration.

This path is used when running the upload command.