### PR TITLE
fix: show updated entry reference title when in a specific release [TOL-3711]

### DIFF
--- a/packages/reference/src/common/EntityStore.tsx
+++ b/packages/reference/src/common/EntityStore.tsx
@@ -201,8 +201,8 @@ const isEntityQueryKey = (queryKey: QueryKey): queryKey is EntityQueryKey => {
   return (
     Array.isArray(queryKey) &&
     (queryKey[0] === 'Entry' || queryKey[0] === 'Asset') &&
-    // length === 5 because releaseId is optional parameter
-    queryKey.length >= 4
+    // length === 4 when releaseId is not present, length === 5 when releaseId is present
+    (queryKey.length === 4 || queryKey.length === 5)
   );
 };
 


### PR DESCRIPTION
## Description

When patching a reference entry inside a release it must also invalidate cache and get a fresh entities list from `GET /entries?release=`
It was working only for current release because:
- store was not up-to-date when fetching new data with release info;
- queryKey was explicitly checking the qtd of params (and potentially ignoring when `releaseId` is present)

## Before
<img width="1517" height="786" alt="image (3) (1)" src="https://github.com/user-attachments/assets/f35688fc-d249-41e7-8648-ea95b52a602d" />

## After
![new-reference-entry](https://github.com/user-attachments/assets/1f4c6cf0-0d3a-4a60-86ea-3994cdf49054)


Jira: [TOL-3711](https://contentful.atlassian.net/browse/TOL-3711)


[TOL-3711]: https://contentful.atlassian.net/browse/TOL-3711?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ