### PR TITLE
docs: specify and type field wrapper sdk story mock data

### DIFF
--- a/packages/default-field-editors/stories/DefaultFieldEditors.stories.tsx
+++ b/packages/default-field-editors/stories/DefaultFieldEditors.stories.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { Text } from '@contentful/f36-components';
 import { PencilSimpleIcon, InfoIcon } from '@contentful/f36-icons';
 import { BooleanEditor } from '@contentful/field-editor-boolean';
+import { FieldAppSDK } from '@contentful/field-editor-shared';
 import {
   ActionsPlayground,
   createFakeFieldAPI,
@@ -28,40 +29,112 @@ export const Default: Story = {
     controls: { hideNoControlsWarning: true },
   },
   render: () => {
-    const [field, mitt] = createFakeFieldAPI(
-      // @ts-expect-error
+    // Create separate field APIs for different field types
+    const [textField, mitt] = createFakeFieldAPI(
       (mock) => ({
         ...mock,
-        items: {
-          validations: [{ in: ['test1', 'test2'] }],
-        },
+        id: 'text-field-id',
+        name: 'field',
+        type: 'Symbol', // Text field type
       }),
-      [],
+      '',
     );
+
+    const [ratingField] = createFakeFieldAPI(
+      (mock) => ({
+        ...mock,
+        id: 'rating-field-id',
+        name: 'anotherField',
+        type: 'Integer', // Rating is a number
+      }),
+      undefined,
+    );
+
+    const [dateField] = createFakeFieldAPI(
+      (mock) => ({
+        ...mock,
+        id: 'date-field-id',
+        name: 'customField',
+        type: 'Date', // Date picker field type
+      }),
+      undefined,
+    );
+
+    const [booleanField] = createFakeFieldAPI(
+      (mock) => ({
+        ...mock,
+        id: 'boolean-field-id',
+        name: 'customEditor',
+        type: 'Boolean',
+      }),
+      false,
+    );
+
     const space = createFakeSpaceAPI();
     const locales = createFakeLocalesAPI();
-    const sdk = {
-      field,
+
+    // Create SDK for text field
+    const textSdk: FieldAppSDK = {
+      field: textField,
       space,
       locales,
       contentType: { displayField: 'name' },
       parameters: {
         instance: {
-          helpText: 'Field help text',
+          helpText: 'This is a text field',
         },
       },
-    };
+    } as unknown as FieldAppSDK;
+
+    // Create SDK for rating field
+    const ratingSdk: FieldAppSDK = {
+      field: ratingField,
+      space,
+      locales,
+      contentType: { displayField: 'name' },
+      parameters: {
+        instance: {
+          helpText: 'This is a rating field',
+        },
+      },
+    } as unknown as FieldAppSDK;
+
+    // Create SDK for date field
+    const dateSdk: FieldAppSDK = {
+      field: dateField,
+      space,
+      locales,
+      contentType: { displayField: 'name' },
+      parameters: {
+        instance: {
+          helpText: 'This is a date field',
+        },
+      },
+    } as unknown as FieldAppSDK;
+
+    // Create SDK for boolean field
+    const booleanSdk: FieldAppSDK = {
+      field: booleanField,
+      space,
+      locales,
+      contentType: { displayField: 'name' },
+      parameters: {
+        instance: {
+          helpText: 'This is a boolean field',
+        },
+      },
+    } as unknown as FieldAppSDK;
 
     return (
       <div data-test-id="default-field-editors-test">
-        <FieldWrapper sdk={sdk as any} name="field">
-          <Field sdk={sdk as any} widgetId="singleLine" />
+        <FieldWrapper sdk={textSdk} name="field">
+          <Field sdk={textSdk} widgetId="singleLine" />
         </FieldWrapper>
-        <FieldWrapper sdk={sdk as any} name="anotherField">
-          <Field sdk={sdk as any} widgetId="rating" />
+        <FieldWrapper sdk={ratingSdk} name="anotherField">
+          <Field sdk={ratingSdk} widgetId="rating" />
         </FieldWrapper>
         <FieldWrapper
-          sdk={sdk as any}
+          sdk={dateSdk}
           name="customField"
           renderHeading={(name) => (
             <div>
@@ -74,11 +147,11 @@ export const Default: Story = {
             </Text>
           )}
         >
-          <Field sdk={sdk as any} widgetId="datePicker" />
+          <Field sdk={dateSdk} widgetId="datePicker" />
         </FieldWrapper>
-        <FieldWrapper sdk={sdk as any} name="customEditor">
+        <FieldWrapper sdk={booleanSdk} name="customEditor">
           <Field
-            sdk={sdk as any}
+            sdk={booleanSdk}
             renderFieldEditor={(widgetId, sdk, isInitiallyDisabled) => {
               return (
                 <div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -24455,7 +24455,7 @@ string-natural-compare@^3.0.1:
   resolved "https://registry.yarnpkg.com/string-natural-compare/-/string-natural-compare-3.0.1.tgz#7a42d58474454963759e8e8b7ae63d71c1e7fdf4"
   integrity sha512-n3sPwynL1nwKi3WJ6AIsClwBMa0zTi54fn2oLU6ndfTSIO05xaznjSf15PcBZU6FNWbmN5Q6cxT4V5hGvB4taw==
 
-"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -24472,6 +24472,15 @@ string-width@^1.0.1:
     code-point-at "^1.0.0"
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
+
+"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
 
 string-width@^2.0.0, string-width@^2.1.1:
   version "2.1.1"
@@ -24625,7 +24634,7 @@ stringify-object@^3.3.0:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -24652,6 +24661,13 @@ strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.0, strip-ansi@^7.0.1, strip-ansi@^7.1.0:
   version "7.1.0"
@@ -26896,7 +26912,7 @@ workerpool@^6.5.1:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.5.1.tgz#060f73b39d0caf97c6db64da004cd01b4c099544"
   integrity sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -26926,6 +26942,15 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
## Description

On Default Field Editors story, the interaction with fields was broken because the mock data was reused across different data-types, for example, `text` and `date`.

This PR creates specific mock sdks objects for each field, in order to avoid throwing an exception because of wrong type validation.

[Jira ticket](https://contentful.atlassian.net/browse/TOL-2494)

## Before:

| Default | Docs |
|---|---|
|<img alt="Screenshot 2026-01-13 at 10 36 06" src="https://github.com/user-attachments/assets/467b3162-e751-4efd-aa7b-5fe106307c64" />|![field-editors-storybook-error](https://github.com/user-attachments/assets/e4a9b1fe-068f-4978-b91b-af9bde8fdc19)|




## After
| Default | Docs |
|---|---|
|<img alt="Screenshot 2026-01-13 at 10 35 48" src="https://github.com/user-attachments/assets/e1779cdd-2c4b-43cf-bc5a-70f98f16077c" />|![field-editors-storybook-fixed](https://github.com/user-attachments/assets/9cc28c27-54f5-43e3-9173-e49f4bdf7683)|





