### PR TITLE
chore: Fix `canary` pre-release CI script [TOL-3472]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ commands:
   yarn_install:
     steps:
       - restore_cache: *cache-key
-      - run: yarn install --prefer-offline --frozen-lockfile
+      - run: yarn install --prefer-offline --pure-lockfile
       - save_cache:
           <<: *cache-key
           paths:


### PR DESCRIPTION
## Description

I suspect that after added https://github.com/contentful/field-editors/pull/1994, we stop releasing `canary` because CI can't execute `lerna` command directly.

