### PR TITLE
build: fix canary version on CI prerelease job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,6 +109,7 @@ jobs:
     executor: linux-node
     steps:
       - checkout
+      - run: git fetch --tags --prune --unshallow || git fetch --tags --prune
       - vault/get-secrets:
           template-preset: 'semantic-release'
       - yarn_install
@@ -117,8 +118,7 @@ jobs:
           echo "//npm.pkg.github.com/:_authToken=${GITHUB_PACKAGES_WRITE_TOKEN}" > ~/.npmrc
           echo "@contentful:registry=https://npm.pkg.github.com" >> ~/.npmrc
       - run: yarn build
-      - run: yarn lerna version --no-private --conventional-commits --yes --exact --conventional-prerelease --no-git-tag-version --no-push
-      - run: yarn lerna publish from-git --yes --canary
+      - run: yarn lerna publish --no-private --canary --preid canary --dist-tag canary --conventional-commits --yes
 
 workflows:
   version: 2


### PR DESCRIPTION
## Description

This PR fixes the prerelease (canary) workflow and makes CI more reliable:

- Publish canary packages on merges to canary using lerna publish --canary
- Stop creating git tags/commits during prereleases (prevents tag collisions in CI)
- Use the canary dist-tag with SemVer prerelease versions (e.g. 2.17.1-canary.0+<sha>)
- Ensure full git history/tags are available for Lerna in CI

### Result

- Merges to canary → unique canary packages are published
- Merges to master → normal releases continue unchanged
- CI reruns are safe and idempotent