### PR TITLE
feat(reference): add to release menu item [TOL-3572]

### DIFF
--- a/packages/reference/src/assets/WrappedAssetCard/AssetCardActions.tsx
+++ b/packages/reference/src/assets/WrappedAssetCard/AssetCardActions.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
 import { MenuItem, Text, MenuSectionTitle } from '@contentful/f36-components';
+import { PlusIcon } from '@contentful/f36-icons';
 import tokens from '@contentful/f36-tokens';
 import { shortenStorageUnit } from '@contentful/field-editor-shared';
 import { css } from 'emotion';
@@ -103,14 +104,27 @@ export function renderActions(props: {
   onRemove?: () => void;
   isDisabled: boolean;
   entityFile?: File;
+  onAddToReleaseAction?: () => void;
 }) {
-  const { entityFile, isDisabled, onEdit, onRemove } = props;
+  const { entityFile, isDisabled, onEdit, onRemove, onAddToReleaseAction } = props;
 
   return [
     <MenuSectionTitle key="section-title">Actions</MenuSectionTitle>,
     onEdit ? (
       <MenuItem key="edit" onClick={onEdit} testId="card-action-edit">
         Edit
+      </MenuItem>
+    ) : null,
+    onAddToReleaseAction ? (
+      <MenuItem
+        key="add-to-release"
+        testId="add-to-release"
+        onClick={() => {
+          onAddToReleaseAction();
+        }}
+      >
+        <PlusIcon size="tiny" />
+        Add to release
       </MenuItem>
     ) : null,
     entityFile ? (

--- a/packages/reference/src/assets/WrappedAssetCard/FetchingWrappedAssetCard.tsx
+++ b/packages/reference/src/assets/WrappedAssetCard/FetchingWrappedAssetCard.tsx
@@ -30,6 +30,7 @@ type FetchingWrappedAssetCardProps = {
   renderDragHandle?: RenderDragFn;
   renderCustomCard?: CustomCardRenderer;
   renderCustomMissingEntityCard?: RenderCustomMissingEntityCard;
+  addReferenceToRelease?: (reference: Asset, localeCode?: string) => Promise<void>;
 };
 
 export function FetchingWrappedAssetCard(props: FetchingWrappedAssetCardProps) {
@@ -49,6 +50,12 @@ export function FetchingWrappedAssetCard(props: FetchingWrappedAssetCardProps) {
     locales: props.sdk.locales,
     isReference: true,
   });
+
+  const onAddToRelease = () => {
+    if (asset && props.addReferenceToRelease) {
+      void props.addReferenceToRelease(asset, props.sdk.field.locale);
+    }
+  };
 
   React.useEffect(() => {
     if (asset) {
@@ -114,6 +121,7 @@ export function FetchingWrappedAssetCard(props: FetchingWrappedAssetCardProps) {
       releaseStatusMap,
       release: props.sdk.release as ReleaseV2Props | undefined,
       releaseEntityStatus,
+      onAddToRelease,
     };
 
     if (status === 'loading') {

--- a/packages/reference/src/assets/WrappedAssetCard/WrappedAssetCard.tsx
+++ b/packages/reference/src/assets/WrappedAssetCard/WrappedAssetCard.tsx
@@ -51,6 +51,7 @@ export interface WrappedAssetCardProps {
   releaseEntityStatus?: ReleaseEntityStatus;
   releaseStatusMap?: ReleaseStatusMap;
   release?: ReleaseV2Props;
+  onAddToRelease?: () => void;
 }
 
 const defaultProps = {
@@ -93,6 +94,7 @@ export const WrappedAssetCard = ({
   releaseEntityStatus,
   releaseStatusMap,
   release,
+  onAddToRelease,
 }: WrappedAssetCardProps) => {
   const status = entityHelpers.getEntityStatus(
     asset.sys,
@@ -129,6 +131,14 @@ export const WrappedAssetCard = ({
   });
 
   const href = getAssetUrl ? getAssetUrl(asset.sys.id) : undefined;
+
+  const onAddToReleaseAction =
+    releaseEntityStatus === 'notInRelease' &&
+    release !== undefined &&
+    onAddToRelease !== undefined &&
+    !isDisabled
+      ? onAddToRelease
+      : undefined;
 
   return (
     <AssetCard
@@ -181,7 +191,13 @@ export const WrappedAssetCard = ({
       withDragHandle={!!renderDragHandle && !isDisabled}
       draggable={!!renderDragHandle && !isDisabled}
       actions={[
-        ...renderActions({ entityFile, isDisabled: isDisabled, onEdit, onRemove }),
+        ...renderActions({
+          entityFile,
+          isDisabled: isDisabled,
+          onEdit,
+          onRemove,
+          onAddToReleaseAction,
+        }),
         ...(entityFile ? renderAssetInfo({ entityFile }) : []),
       ].filter((item) => item)}
       size={size}

--- a/packages/reference/src/common/ReferenceEditor.tsx
+++ b/packages/reference/src/common/ReferenceEditor.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { FieldConnector } from '@contentful/field-editor-shared';
 
 import type { LinkActionsProps } from '../components';
-import { Action, ActionLabels, FieldAppSDK, ViewType } from '../types';
+import { Action, ActionLabels, FieldAppSDK, ViewType, Entry, Asset } from '../types';
 import { CustomCardRenderer, RenderCustomMissingEntityCard } from './customCardTypes';
 import { EntityProvider } from './EntityStore';
 
@@ -35,6 +35,7 @@ export interface ReferenceEditorProps {
   };
   updateBeforeSortStart?: ({ index }: { index: number }) => void;
   onSortingEnd?: ({ oldIndex, newIndex }: { oldIndex: number; newIndex: number }) => void;
+  addReferenceToRelease?: (reference: Entry | Asset, localeCode?: string) => Promise<void>;
 }
 
 export type CustomActionProps = LinkActionsProps;
@@ -42,7 +43,7 @@ export type CustomActionProps = LinkActionsProps;
 export function ReferenceEditor<T>(
   props: ReferenceEditorProps & {
     children: FieldConnector<T>['props']['children'];
-  }
+  },
 ) {
   return (
     <EntityProvider sdk={props.sdk}>

--- a/packages/reference/src/common/SingleReferenceEditor.tsx
+++ b/packages/reference/src/common/SingleReferenceEditor.tsx
@@ -73,6 +73,7 @@ function Editor(props: EditorProps) {
   return props.children({
     ...props,
     renderCustomCard: props.renderCustomCard && customCardRenderer,
+    addReferenceToRelease: props.addReferenceToRelease,
   });
 }
 

--- a/packages/reference/src/common/customCardTypes.ts
+++ b/packages/reference/src/common/customCardTypes.ts
@@ -55,4 +55,5 @@ export type CustomEntityCardProps = {
   releaseStatusMap?: ReleaseStatusMap;
   releaseAction?: ReleaseAction;
   release?: ReleaseV2Props;
+  onAddToRelease?: () => void;
 } & Partial<WrappedAssetCardProps>;

--- a/packages/reference/src/entries/MultipleEntryReferenceEditor.tsx
+++ b/packages/reference/src/entries/MultipleEntryReferenceEditor.tsx
@@ -45,6 +45,7 @@ export function MultipleEntryReferenceEditor(props: ReferenceEditorProps) {
                 }
                 renderDragHandle={DragHandle}
                 isBeingDragged={index === indexToUpdate}
+                addReferenceToRelease={props.addReferenceToRelease}
               />
             );
           }}

--- a/packages/reference/src/entries/SingleEntryReferenceEditor.tsx
+++ b/packages/reference/src/entries/SingleEntryReferenceEditor.tsx
@@ -30,6 +30,7 @@ export function SingleEntryReferenceEditor(props: ReferenceEditorProps) {
             hasCardEditActions={hasCardEditActions}
             hasCardRemoveActions={hasCardRemoveActions}
             activeLocales={activeLocales}
+            addReferenceToRelease={props.addReferenceToRelease}
             onRemove={() => {
               setValue(null);
             }}

--- a/packages/reference/src/entries/WrappedEntryCard/FetchingWrappedEntryCard.tsx
+++ b/packages/reference/src/entries/WrappedEntryCard/FetchingWrappedEntryCard.tsx
@@ -31,6 +31,7 @@ export type EntryCardReferenceEditorProps = ReferenceEditorProps & {
   activeLocales?: {
     code: string;
   }[];
+  addReferenceToRelease?: (reference: Entry, localeCode?: string) => Promise<void>;
 };
 
 async function openEntry(
@@ -108,6 +109,12 @@ export function FetchingWrappedEntryCard(props: EntryCardReferenceEditorProps) {
     });
   };
 
+  const onAddToRelease = () => {
+    if (entry && props.addReferenceToRelease) {
+      void props.addReferenceToRelease(entry, props.sdk.field.locale);
+    }
+  };
+
   React.useEffect(() => {
     if (entry) {
       props.onAction?.({ type: 'rendered', entity: 'Entry' });
@@ -162,6 +169,7 @@ export function FetchingWrappedEntryCard(props: EntryCardReferenceEditorProps) {
       releaseStatusMap,
       release: props.sdk.release as ReleaseV2Props | undefined,
       releaseEntityStatus,
+      onAddToRelease,
     };
 
     const { hasCardEditActions, hasCardMoveActions, hasCardRemoveActions } = props;

--- a/packages/reference/src/entries/WrappedEntryCard/WrappedEntryCard.tsx
+++ b/packages/reference/src/entries/WrappedEntryCard/WrappedEntryCard.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 
 import { SpaceAPI } from '@contentful/app-sdk';
 import { EntryCard, MenuDivider, MenuItem } from '@contentful/f36-components';
+import { PlusIcon } from '@contentful/f36-icons';
 import {
   entityHelpers,
   isValidImage,
@@ -46,6 +47,7 @@ export interface WrappedEntryCardProps {
   releaseEntityStatus?: ReleaseEntityStatus;
   releaseStatusMap?: ReleaseStatusMap;
   release?: ReleaseV2Props;
+  onAddToRelease?: () => void;
 }
 
 const defaultProps = {
@@ -83,6 +85,7 @@ export function WrappedEntryCard({
   releaseEntityStatus,
   releaseStatusMap,
   release,
+  onAddToRelease,
 }: WrappedEntryCardProps) {
   const [file, setFile] = React.useState<null | File>(null);
 
@@ -139,6 +142,12 @@ export function WrappedEntryCard({
     defaultLocaleCode,
   });
 
+  const showAddToReleaseAction =
+    releaseEntityStatus === 'notInRelease' &&
+    release !== undefined &&
+    onAddToRelease !== undefined &&
+    !isDisabled;
+
   return (
     <EntryCard
       as={isClickable && entryUrl ? 'a' : 'article'}
@@ -172,7 +181,7 @@ export function WrappedEntryCard({
       withDragHandle={!!renderDragHandle && !isDisabled}
       draggable={!!renderDragHandle && !isDisabled}
       actions={
-        onEdit || onRemove
+        onEdit || onRemove || showAddToReleaseAction
           ? [
               hasCardEditActions && onEdit ? (
                 <MenuItem
@@ -194,6 +203,18 @@ export function WrappedEntryCard({
                   }}
                 >
                   Remove
+                </MenuItem>
+              ) : null,
+              showAddToReleaseAction ? (
+                <MenuItem
+                  key="add-to-release"
+                  testId="add-to-release"
+                  onClick={() => {
+                    onAddToRelease();
+                  }}
+                >
+                  <PlusIcon size="tiny" />
+                  Add to release
                 </MenuItem>
               ) : null,
               hasCardMoveActions && (onMoveTop || onMoveBottom) && !isDisabled ? (


### PR DESCRIPTION
- Adding "+ Add to release" menu item to reference cards with "Not in release" status
- When clicked, it will instantly add the entry to the release (status changes to "will publish")
- Rich text & cross-space references don't support this
<img width="1496" height="759" alt="Screenshot 2026-01-27 at 14 00 22" src="https://github.com/user-attachments/assets/fe1ffb8e-e72d-44d0-b5f1-20d2ee18614b" />

