### PR TITLE
feat(releases): add opts to control behavior for reference cards [TOL-3572]

### DIFF
--- a/packages/reference/src/assets/WrappedAssetCard/FetchingWrappedAssetCard.tsx
+++ b/packages/reference/src/assets/WrappedAssetCard/FetchingWrappedAssetCard.tsx
@@ -30,7 +30,14 @@ type FetchingWrappedAssetCardProps = {
   renderDragHandle?: RenderDragFn;
   renderCustomCard?: CustomCardRenderer;
   renderCustomMissingEntityCard?: RenderCustomMissingEntityCard;
-  addReferenceToRelease?: (reference: Asset, localeCode?: string) => Promise<void>;
+  addReferenceToRelease?: (
+    reference: Asset,
+    localeCode?: string,
+    options?: {
+      openModalForVersionSelection?: boolean;
+      skipNestedReferencesPrompt?: boolean;
+    },
+  ) => Promise<void>;
 };
 
 export function FetchingWrappedAssetCard(props: FetchingWrappedAssetCardProps) {
@@ -53,7 +60,10 @@ export function FetchingWrappedAssetCard(props: FetchingWrappedAssetCardProps) {
 
   const onAddToRelease = () => {
     if (asset && props.addReferenceToRelease) {
-      void props.addReferenceToRelease(asset, props.sdk.field.locale);
+      void props.addReferenceToRelease(asset, props.sdk.field.locale, {
+        openModalForVersionSelection: true,
+        skipNestedReferencesPrompt: true,
+      });
     }
   };
 

--- a/packages/reference/src/common/ReferenceEditor.tsx
+++ b/packages/reference/src/common/ReferenceEditor.tsx
@@ -35,7 +35,14 @@ export interface ReferenceEditorProps {
   };
   updateBeforeSortStart?: ({ index }: { index: number }) => void;
   onSortingEnd?: ({ oldIndex, newIndex }: { oldIndex: number; newIndex: number }) => void;
-  addReferenceToRelease?: (reference: Entry | Asset, localeCode?: string) => Promise<void>;
+  addReferenceToRelease?: (
+    reference: Entry | Asset,
+    localeCode?: string,
+    options?: {
+      openModalForVersionSelection?: boolean;
+      skipNestedReferencesPrompt?: boolean;
+    },
+  ) => Promise<void>;
 }
 
 export type CustomActionProps = LinkActionsProps;

--- a/packages/reference/src/entries/WrappedEntryCard/FetchingWrappedEntryCard.tsx
+++ b/packages/reference/src/entries/WrappedEntryCard/FetchingWrappedEntryCard.tsx
@@ -31,7 +31,14 @@ export type EntryCardReferenceEditorProps = ReferenceEditorProps & {
   activeLocales?: {
     code: string;
   }[];
-  addReferenceToRelease?: (reference: Entry, localeCode?: string) => Promise<void>;
+  addReferenceToRelease?: (
+    reference: Entry,
+    localeCode?: string,
+    options?: {
+      openModalForVersionSelection?: boolean;
+      skipNestedReferencesPrompt?: boolean;
+    },
+  ) => Promise<void>;
 };
 
 async function openEntry(
@@ -111,7 +118,10 @@ export function FetchingWrappedEntryCard(props: EntryCardReferenceEditorProps) {
 
   const onAddToRelease = () => {
     if (entry && props.addReferenceToRelease) {
-      void props.addReferenceToRelease(entry, props.sdk.field.locale);
+      void props.addReferenceToRelease(entry, props.sdk.field.locale, {
+        openModalForVersionSelection: true,
+        skipNestedReferencesPrompt: true,
+      });
     }
   };
 


### PR DESCRIPTION
When users manually add references to a release via the reference card menu, the behavior should differ from automatic add-to-release during entry linking:

- Add `openModalForVersionSelection` option to open the add-to-release modal instead of showing a notification when the entity has multiple versions
- Add `skipNestedReferencesPrompt` option to skip the automatic prompt for adding nested references
