### PR TITLE
feat(slug): add document-level auto-generation opt-out [TOL-3879]

### DIFF
--- a/packages/slug/src/SlugEditor.tsx
+++ b/packages/slug/src/SlugEditor.tsx
@@ -29,6 +29,7 @@ export interface SlugEditorProps {
       trackingFieldId?: string;
     };
   };
+  autoGenerationStrategy?: 'field' | 'document';
 }
 
 function isSupportedFieldTypes(val: string): val is 'Symbol' {
@@ -97,9 +98,15 @@ function FieldConnectorCallback({
   );
 }
 
-export function SlugEditor(props: SlugEditorProps) {
-  const { field, parameters, id } = props;
-  const { locales, entry, cma } = props.baseSdk;
+export function SlugEditor({
+  isInitiallyDisabled,
+  autoGenerationStrategy = 'field',
+  baseSdk,
+  field,
+  parameters,
+  id,
+}: SlugEditorProps) {
+  const { locales, entry, cma } = baseSdk;
 
   if (!isSupportedFieldTypes(field.type)) {
     throw new Error(`"${field.type}" field type is not supported by SlugEditor`);
@@ -148,7 +155,7 @@ export function SlugEditor(props: SlugEditorProps) {
 
   return (
     <TrackingFieldConnector<string>
-      sdk={props.baseSdk}
+      sdk={baseSdk}
       field={field}
       defaultLocale={locales.default}
       isOptionalLocaleWithFallback={isOptionalLocaleWithFallback}
@@ -157,11 +164,12 @@ export function SlugEditor(props: SlugEditorProps) {
       {({ titleValue, isPublished, isSame }) => (
         <FieldConnector<string>
           field={field}
-          isInitiallyDisabled={props.isInitiallyDisabled}
+          isInitiallyDisabled={isInitiallyDisabled}
           debounce={0}
         >
           {({ value, errors, disabled, setValue, externalReset }) => {
-            const shouldTrackTitle = isPublished === false && isSame === false;
+            const shouldTrackTitle =
+              autoGenerationStrategy !== 'document' && isPublished === false && isSame === false;
 
             const Component = shouldTrackTitle ? SlugEditorField : SlugEditorFieldStatic;
 
@@ -189,7 +197,3 @@ export function SlugEditor(props: SlugEditorProps) {
     </TrackingFieldConnector>
   );
 }
-
-SlugEditor.defaultProps = {
-  isInitiallyDisabled: true,
-};


### PR DESCRIPTION
## Description
This PR adds an optional `autoGenerationStrategy` prop to `SlugEditor`:

- `field` keeps the current behavior and remains the default
- `document` disables field-level slug auto-generation so a host editor can manage it outside the rendered field

This keeps the package backward compatible while allowing hosts to avoid duplicate writes when slug syncing happens at the document level.

It also removes defaultProps from the SlugEditor function component and uses default parameters instead.

## Why
Some host editors use collapsed sections, lazy rendering, virtualization. In those cases, render-driven slug generation will not run because the slug field is not mounted. This prop allows those hosts to move slug syncing outside the field editor without breaking existing consumers.