### PR TITLE
fix(date): crash when rendering DateEditor with midnight in 24h mode

### DIFF
--- a/packages/date/src/TimepickerInput.spec.tsx
+++ b/packages/date/src/TimepickerInput.spec.tsx
@@ -1,0 +1,42 @@
+import * as React from 'react';
+
+import '@testing-library/jest-dom/extend-expect';
+import { cleanup, configure, render } from '@testing-library/react';
+
+import { TimepickerInput } from './TimepickerInput';
+
+configure({
+  testIdAttribute: 'data-test-id',
+});
+
+describe('TimepickerInput', () => {
+  afterEach(cleanup);
+
+  it('renders midnight (00:00) in 24h mode without crashing', () => {
+    // Regression: parse('00:00 AM', 'hh:mm a') returns Invalid Date because
+    // hh expects 1-12; format() then threw RangeError: Invalid time value.
+    const { getByTestId } = render(
+      <TimepickerInput
+        disabled={false}
+        uses12hClock={false}
+        time="00:00"
+        ampm="AM"
+        onChange={jest.fn()}
+      />,
+    );
+    expect(getByTestId('time-input')).toHaveValue('00:00');
+  });
+
+  it('renders late-night hours (e.g. 23:00) in 24h mode without crashing', () => {
+    const { getByTestId } = render(
+      <TimepickerInput
+        disabled={false}
+        uses12hClock={false}
+        time="23:00"
+        ampm="PM"
+        onChange={jest.fn()}
+      />,
+    );
+    expect(getByTestId('time-input')).toHaveValue('23:00');
+  });
+});

--- a/packages/date/src/TimepickerInput.tsx
+++ b/packages/date/src/TimepickerInput.tsx
@@ -40,7 +40,10 @@ export const TimepickerInput = ({
   });
 
   useEffect(() => {
-    setSelectedTime(formatToString(uses12hClock, parse(`${time} ${ampm}`, 'hh:mm a', REF_DATE)));
+    const parsed = uses12hClock
+      ? parse(`${time} ${ampm}`, 'hh:mm a', REF_DATE)
+      : parse(time, 'HH:mm', REF_DATE);
+    setSelectedTime(formatToString(uses12hClock, parsed));
   }, [time, ampm, uses12hClock]);
 
   const handleChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {


### PR DESCRIPTION
## Summary

- Fixes a crash when `DateEditor` renders a value with midnight time (e.g. `2023-05-03T00:00+02:00`) in 24h clock mode
- Root cause: `TimepickerInput` useEffect always parsed `time + ampm` with the 12h format `hh:mm a`; the `hh` token expects 1–12, so `'00'` (midnight in 24h) produced an `Invalid Date`, which then crashed `format()`
- Fix: when `uses12hClock=false`, parse `time` directly with `HH:mm` instead
