### PR TITLE
feat: [TOL-515] Add embeds as last element

### DIFF
--- a/packages/rich-text/src/plugins/shared/EmbeddedBlockUtil.ts
+++ b/packages/rich-text/src/plugins/shared/EmbeddedBlockUtil.ts
@@ -9,6 +9,7 @@ import {
 } from '../../helpers/config';
 import {
   focus,
+  getAncestorPathFromSelection,
   getNodeEntryFromSelection,
   insertEmptyParagraph,
   moveToTheNextChar,
@@ -22,9 +23,14 @@ import {
   isEmptyTextContainer,
   PlateEditor,
   setNodes,
-  select,
   KeyboardHandler,
   removeNodes,
+  moveNodes,
+  isFirstChildPath,
+  getPreviousPath,
+  getNodeEntries,
+  isAncestorEmpty,
+  Ancestor,
 } from '../../internal';
 import { TrackingPluginActions } from '../Tracking';
 
@@ -72,16 +78,12 @@ export async function selectEntityAndInsert(
     baseConfig.entityType === 'Asset' ? dialogs.selectSingleAsset : dialogs.selectSingleEntry;
   const config = { ...baseConfig, withCreate: true };
 
-  const { selection } = editor;
   const rteSlide = watchCurrentSlide(sdk.navigator);
   const entity = await selectEntity(config);
 
   if (!entity) {
     logAction('cancelCreateEmbedDialog', { nodeType });
   } else {
-    // Selection prevents incorrect position of inserted ref when RTE doesn't have focus
-    // (i.e. when using hotkeys and slide-in)
-    select(editor, selection);
     insertBlock(editor, nodeType, entity);
     ensureFollowingParagraph(editor, [BLOCKS.EMBEDDED_ASSET, BLOCKS.EMBEDDED_ENTRY]);
     logAction('insert', { nodeType, entity });
@@ -104,16 +106,11 @@ export async function selectResourceEntityAndInsert(
   const { field, dialogs } = sdk;
   const config = newResourceEntitySelectorConfigFromRichTextField(field, BLOCKS.EMBEDDED_RESOURCE);
 
-  const { selection } = editor;
-
   const entityLink = await dialogs.selectSingleResourceEntity(config);
 
   if (!entityLink) {
     logAction('cancelCreateEmbedDialog', { nodeType: BLOCKS.EMBEDDED_RESOURCE });
   } else {
-    // Selection prevents incorrect position of inserted ref when RTE doesn't have focus
-    // (i.e. when using hotkeys and slide-in)
-    select(editor, selection);
     insertBlock(editor, BLOCKS.EMBEDDED_RESOURCE, entityLink);
     ensureFollowingParagraph(editor, [BLOCKS.EMBEDDED_RESOURCE]);
     logAction('insert', { nodeType: BLOCKS.EMBEDDED_RESOURCE });
@@ -171,8 +168,6 @@ const createNode = (nodeType, entity) => {
 
 // TODO: DRY up copied code from HR
 function insertBlock(editor: PlateEditor, nodeType: string, entity) {
-  if (!editor?.selection) return;
-
   const linkedEntityBlock = createNode(nodeType, entity);
 
   const elementPath = getSelectionElementPath(editor);
@@ -182,4 +177,28 @@ function insertBlock(editor: PlateEditor, nodeType: string, entity) {
   }
 
   insertNodes(editor, linkedEntityBlock);
+  replaceEmptyParagraphWithBlock(editor);
+}
+
+export function replaceEmptyParagraphWithBlock(editor: PlateEditor) {
+  const blockPath = getAncestorPathFromSelection(editor);
+  if (!blockPath || isFirstChildPath(blockPath)) return;
+
+  const previousPath = getPreviousPath(blockPath);
+  if (!previousPath) return;
+
+  const [nodes] = getNodeEntries(editor, {
+    at: previousPath,
+    match: (node) => node.type === BLOCKS.PARAGRAPH,
+  });
+  if (!nodes) return;
+
+  const [previousNode] = nodes;
+  const isPreviousNodeTextEmpty = isAncestorEmpty(editor, previousNode as Ancestor);
+  if (isPreviousNodeTextEmpty) {
+    // Switch block with previous empty paragraph
+    moveNodes(editor, { at: blockPath, to: previousPath });
+    // Remove previous paragraph that now is under the block
+    removeNodes(editor, { at: blockPath });
+  }
 }

--- a/packages/rich-text/src/plugins/shared/EmbeddedInlineToolbarIcon.tsx
+++ b/packages/rich-text/src/plugins/shared/EmbeddedInlineToolbarIcon.tsx
@@ -8,6 +8,7 @@ import { INLINES } from '@contentful/rich-text-types';
 import { css } from '@emotion/css';
 
 import { useContentfulEditor } from '../../ContentfulEditorProvider';
+// import { focus } from '../../helpers/editor';
 import { moveToTheNextChar } from '../../helpers/editor';
 import { useSdkContext } from '../../SdkProvider';
 import { selectEntityAndInsert, selectResourceEntityAndInsert } from '../shared/EmbeddedInlineUtil';
@@ -45,7 +46,9 @@ export function EmbeddedInlineToolbarIcon({
   async function handleClick(event) {
     event.preventDefault();
 
-    if (!editor) return;
+    if (!editor) {
+      return;
+    }
 
     onClose();
 

--- a/packages/rich-text/src/plugins/shared/EmbeddedInlineToolbarIcon.tsx
+++ b/packages/rich-text/src/plugins/shared/EmbeddedInlineToolbarIcon.tsx
@@ -8,7 +8,6 @@ import { INLINES } from '@contentful/rich-text-types';
 import { css } from '@emotion/css';
 
 import { useContentfulEditor } from '../../ContentfulEditorProvider';
-// import { focus } from '../../helpers/editor';
 import { moveToTheNextChar } from '../../helpers/editor';
 import { useSdkContext } from '../../SdkProvider';
 import { selectEntityAndInsert, selectResourceEntityAndInsert } from '../shared/EmbeddedInlineUtil';

--- a/packages/rich-text/src/plugins/shared/EmbeddedInlineUtil.ts
+++ b/packages/rich-text/src/plugins/shared/EmbeddedInlineUtil.ts
@@ -64,16 +64,12 @@ export async function selectEntityAndInsert(
     ...newEntitySelectorConfigFromRichTextField(sdk.field, nodeType),
     withCreate: true,
   };
-  const { selection } = editor;
   const rteSlide = watchCurrentSlide(sdk.navigator);
   const entry = await sdk.dialogs.selectSingleEntry(config);
 
   if (!entry) {
     logAction('cancelCreateEmbedDialog', { nodeType });
   } else {
-    // Selection prevents incorrect position of inserted ref when RTE doesn't have focus
-    // (i.e. when using hotkeys and slide-in)
-    select(editor, selection);
     insertNodes(editor, createInlineEntryNode(nodeType, entry));
     logAction('insert', { nodeType, entity: entry });
   }


### PR DESCRIPTION
When RTE is not focused, by default we insert embedded element as the last node. If there's an empty paragraph node, we replace it with block element or insert inline element. This aligns embed behavior to, for example, how table injection works currently.