### PR TITLE
fix(date): correct 24h time snap-back and timezone date shift [ES-141][ES-143][ES-145]

### DIFF
--- a/packages/date/src/TimepickerInput.spec.tsx
+++ b/packages/date/src/TimepickerInput.spec.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import '@testing-library/jest-dom/extend-expect';
-import { cleanup, configure, render } from '@testing-library/react';
+import { cleanup, configure, fireEvent, render } from '@testing-library/react';
 
 import { TimepickerInput } from './TimepickerInput';
 
@@ -38,5 +38,135 @@ describe('TimepickerInput', () => {
       />,
     );
     expect(getByTestId('time-input')).toHaveValue('23:00');
+  });
+
+  describe('onChange on blur — 24h mode', () => {
+    it('emits 19:00 (not 07:00) when user types 19:00 in 24h mode', () => {
+      const onChange = jest.fn();
+      const { getByTestId } = render(
+        <TimepickerInput
+          disabled={false}
+          uses12hClock={false}
+          time="19:00"
+          ampm="PM"
+          onChange={onChange}
+        />,
+      );
+      const input = getByTestId('time-input');
+      fireEvent.focus(input);
+      fireEvent.change(input, { target: { value: '19:00' } });
+      fireEvent.blur(input);
+      expect(onChange).toHaveBeenCalledWith({ time: '19:00', ampm: 'PM' });
+    });
+
+    it('emits 23:59 (not 11:59) when user types 23:59 in 24h mode', () => {
+      const onChange = jest.fn();
+      const { getByTestId } = render(
+        <TimepickerInput
+          disabled={false}
+          uses12hClock={false}
+          time="23:59"
+          ampm="PM"
+          onChange={onChange}
+        />,
+      );
+      const input = getByTestId('time-input');
+      fireEvent.focus(input);
+      fireEvent.change(input, { target: { value: '23:59' } });
+      fireEvent.blur(input);
+      expect(onChange).toHaveBeenCalledWith({ time: '23:59', ampm: 'PM' });
+    });
+
+    it('emits 00:00 when user types 00:00 in 24h mode', () => {
+      const onChange = jest.fn();
+      const { getByTestId } = render(
+        <TimepickerInput
+          disabled={false}
+          uses12hClock={false}
+          time="00:00"
+          ampm="AM"
+          onChange={onChange}
+        />,
+      );
+      const input = getByTestId('time-input');
+      fireEvent.focus(input);
+      fireEvent.change(input, { target: { value: '00:00' } });
+      fireEvent.blur(input);
+      expect(onChange).toHaveBeenCalledWith({ time: '00:00', ampm: 'AM' });
+    });
+
+    it('emits 12:00 (noon) correctly in 24h mode', () => {
+      const onChange = jest.fn();
+      const { getByTestId } = render(
+        <TimepickerInput
+          disabled={false}
+          uses12hClock={false}
+          time="12:00"
+          ampm="PM"
+          onChange={onChange}
+        />,
+      );
+      const input = getByTestId('time-input');
+      fireEvent.focus(input);
+      fireEvent.change(input, { target: { value: '12:00' } });
+      fireEvent.blur(input);
+      expect(onChange).toHaveBeenCalledWith({ time: '12:00', ampm: 'PM' });
+    });
+
+    it('emits 13:00 (not 01:00) when user types 13:00 in 24h mode', () => {
+      const onChange = jest.fn();
+      const { getByTestId } = render(
+        <TimepickerInput
+          disabled={false}
+          uses12hClock={false}
+          time="13:00"
+          ampm="PM"
+          onChange={onChange}
+        />,
+      );
+      const input = getByTestId('time-input');
+      fireEvent.focus(input);
+      fireEvent.change(input, { target: { value: '13:00' } });
+      fireEvent.blur(input);
+      expect(onChange).toHaveBeenCalledWith({ time: '13:00', ampm: 'PM' });
+    });
+  });
+
+  describe('onChange on blur — 12h mode', () => {
+    it('emits 07:00 AM correctly in 12h mode', () => {
+      const onChange = jest.fn();
+      const { getByTestId } = render(
+        <TimepickerInput
+          disabled={false}
+          uses12hClock={true}
+          time="07:00"
+          ampm="AM"
+          onChange={onChange}
+        />,
+      );
+      const input = getByTestId('time-input');
+      fireEvent.focus(input);
+      fireEvent.change(input, { target: { value: '07:00 AM' } });
+      fireEvent.blur(input);
+      expect(onChange).toHaveBeenCalledWith({ time: '07:00', ampm: 'AM' });
+    });
+
+    it('emits 07:00 PM correctly in 12h mode', () => {
+      const onChange = jest.fn();
+      const { getByTestId } = render(
+        <TimepickerInput
+          disabled={false}
+          uses12hClock={true}
+          time="07:00"
+          ampm="PM"
+          onChange={onChange}
+        />,
+      );
+      const input = getByTestId('time-input');
+      fireEvent.focus(input);
+      fireEvent.change(input, { target: { value: '07:00 PM' } });
+      fireEvent.blur(input);
+      expect(onChange).toHaveBeenCalledWith({ time: '07:00', ampm: 'PM' });
+    });
   });
 });

--- a/packages/date/src/TimepickerInput.spec.tsx
+++ b/packages/date/src/TimepickerInput.spec.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
 
 import '@testing-library/jest-dom/extend-expect';
-import { cleanup, configure, fireEvent, render } from '@testing-library/react';
+import { cleanup, configure, render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import { TimepickerInput } from './TimepickerInput';
 
@@ -52,10 +53,9 @@ describe('TimepickerInput', () => {
           onChange={onChange}
         />,
       );
-      const input = getByTestId('time-input');
-      fireEvent.focus(input);
-      fireEvent.change(input, { target: { value: '19:00' } });
-      fireEvent.blur(input);
+      userEvent.clear(getByTestId('time-input'));
+      userEvent.type(getByTestId('time-input'), '19:00');
+      userEvent.tab();
       expect(onChange).toHaveBeenCalledWith({ time: '19:00', ampm: 'PM' });
     });
 
@@ -70,10 +70,9 @@ describe('TimepickerInput', () => {
           onChange={onChange}
         />,
       );
-      const input = getByTestId('time-input');
-      fireEvent.focus(input);
-      fireEvent.change(input, { target: { value: '23:59' } });
-      fireEvent.blur(input);
+      userEvent.clear(getByTestId('time-input'));
+      userEvent.type(getByTestId('time-input'), '23:59');
+      userEvent.tab();
       expect(onChange).toHaveBeenCalledWith({ time: '23:59', ampm: 'PM' });
     });
 
@@ -88,10 +87,9 @@ describe('TimepickerInput', () => {
           onChange={onChange}
         />,
       );
-      const input = getByTestId('time-input');
-      fireEvent.focus(input);
-      fireEvent.change(input, { target: { value: '00:00' } });
-      fireEvent.blur(input);
+      userEvent.clear(getByTestId('time-input'));
+      userEvent.type(getByTestId('time-input'), '00:00');
+      userEvent.tab();
       expect(onChange).toHaveBeenCalledWith({ time: '00:00', ampm: 'AM' });
     });
 
@@ -106,10 +104,9 @@ describe('TimepickerInput', () => {
           onChange={onChange}
         />,
       );
-      const input = getByTestId('time-input');
-      fireEvent.focus(input);
-      fireEvent.change(input, { target: { value: '12:00' } });
-      fireEvent.blur(input);
+      userEvent.clear(getByTestId('time-input'));
+      userEvent.type(getByTestId('time-input'), '12:00');
+      userEvent.tab();
       expect(onChange).toHaveBeenCalledWith({ time: '12:00', ampm: 'PM' });
     });
 
@@ -124,10 +121,9 @@ describe('TimepickerInput', () => {
           onChange={onChange}
         />,
       );
-      const input = getByTestId('time-input');
-      fireEvent.focus(input);
-      fireEvent.change(input, { target: { value: '13:00' } });
-      fireEvent.blur(input);
+      userEvent.clear(getByTestId('time-input'));
+      userEvent.type(getByTestId('time-input'), '13:00');
+      userEvent.tab();
       expect(onChange).toHaveBeenCalledWith({ time: '13:00', ampm: 'PM' });
     });
   });
@@ -144,10 +140,9 @@ describe('TimepickerInput', () => {
           onChange={onChange}
         />,
       );
-      const input = getByTestId('time-input');
-      fireEvent.focus(input);
-      fireEvent.change(input, { target: { value: '07:00 AM' } });
-      fireEvent.blur(input);
+      userEvent.clear(getByTestId('time-input'));
+      userEvent.type(getByTestId('time-input'), '07:00 AM');
+      userEvent.tab();
       expect(onChange).toHaveBeenCalledWith({ time: '07:00', ampm: 'AM' });
     });
 
@@ -162,10 +157,9 @@ describe('TimepickerInput', () => {
           onChange={onChange}
         />,
       );
-      const input = getByTestId('time-input');
-      fireEvent.focus(input);
-      fireEvent.change(input, { target: { value: '07:00 PM' } });
-      fireEvent.blur(input);
+      userEvent.clear(getByTestId('time-input'));
+      userEvent.type(getByTestId('time-input'), '07:00 PM');
+      userEvent.tab();
       expect(onChange).toHaveBeenCalledWith({ time: '07:00', ampm: 'PM' });
     });
   });

--- a/packages/date/src/TimepickerInput.tsx
+++ b/packages/date/src/TimepickerInput.tsx
@@ -12,7 +12,18 @@ export type TimepickerProps = {
   ampm?: string;
 };
 
-const validInputFormats = ['hh:mm a', 'h:mm a', 'hh:mm', 'kk:mm', 'k:mm', 'h a', 'HH', 'H:mm', 'h'];
+const validInputFormats = [
+  'hh:mm a',
+  'h:mm a',
+  'HH:mm',
+  'hh:mm',
+  'kk:mm',
+  'k:mm',
+  'h a',
+  'HH',
+  'H:mm',
+  'h',
+];
 const REF_DATE = new Date(2000, 0, 1);
 
 function parseRawInput(raw: string): Date | null {
@@ -60,7 +71,8 @@ export const TimepickerInput = ({
     const parsedTime = parseRawInput(selectedTime);
     const value = parsedTime ?? getDefaultTime();
     setSelectedTime(formatToString(uses12hClock, value));
-    onChange({ time: format(value, 'hh:mm'), ampm: format(value, 'a').toUpperCase() });
+    const timeStr = uses12hClock ? format(value, 'hh:mm') : format(value, 'HH:mm');
+    onChange({ time: timeStr, ampm: format(value, 'a').toUpperCase() });
   }, [selectedTime, uses12hClock, onChange]);
 
   return (

--- a/packages/date/src/utils/data.spec.ts
+++ b/packages/date/src/utils/data.spec.ts
@@ -443,4 +443,51 @@ describe('date utils', () => {
       expect(getDefaultAMPM()).toBe('AM');
     });
   });
+
+  describe('buildFieldValue — date does not shift due to timezone offset', () => {
+    // These cases demonstrate the bug: parseISO of an offset-aware string gives a UTC
+    // instant that, when formatted in local time (UTC in CI), lands on a different date
+    // than the nominal date in the original string.
+
+    it('April 27 23:00-02:00 round-trips as April 27 (UTC would parse as April 28 01:00Z)', () => {
+      // parseISO('2026-04-27T23:00-02:00') = 2026-04-28T01:00:00Z → local date is April 28 in UTC
+      const result = userInputFromDatetime({
+        value: '2026-04-27T23:00-02:00',
+        uses12hClock: false,
+      });
+      const built = buildFieldValue({
+        data: result,
+        usesTime: true,
+        usesTimezone: true,
+      });
+      expect(built.valid).toBe('2026-04-27T23:00-02:00');
+    });
+
+    it('April 28 01:00+02:00 round-trips as April 28 (UTC would parse as April 27 23:00Z)', () => {
+      // parseISO('2026-04-28T01:00+02:00') = 2026-04-27T23:00:00Z → local date is April 27 in UTC
+      const result = userInputFromDatetime({
+        value: '2026-04-28T01:00+02:00',
+        uses12hClock: false,
+      });
+      const built = buildFieldValue({
+        data: result,
+        usesTime: true,
+        usesTimezone: true,
+      });
+      expect(built.valid).toBe('2026-04-28T01:00+02:00');
+    });
+
+    it('preserves date for 23:59-01:00 (UTC: April 28 00:59Z → would show as April 28)', () => {
+      const result = userInputFromDatetime({
+        value: '2026-06-15T23:59-01:00',
+        uses12hClock: false,
+      });
+      const built = buildFieldValue({
+        data: result,
+        usesTime: true,
+        usesTimezone: true,
+      });
+      expect(built.valid).toBe('2026-06-15T23:59-01:00');
+    });
+  });
 });

--- a/packages/date/src/utils/date.ts
+++ b/packages/date/src/utils/date.ts
@@ -1,4 +1,4 @@
-import { format, getHours, getMinutes, isValid, parse, parseISO, set } from 'date-fns';
+import { format, getHours, getMinutes, isValid, parse, set } from 'date-fns';
 
 import { TimeResult } from '../types';
 
@@ -15,17 +15,8 @@ function parseUtcOffset(datetimeString: string): string {
 }
 
 function fieldValueToDate(datetimeString: string | null | undefined): Date | null {
-  if (!datetimeString) {
-    return null;
-  }
-  // Extract yyyy-MM-dd directly from the string to avoid timezone conversion.
-  // parseISO shifts to local time, which can move the date across midnight.
-  const datePart = datetimeString.match(/^(\d{4}-\d{2}-\d{2})/);
-  if (datePart) {
-    const date = parse(datePart[1], 'yyyy-MM-dd', new Date(0));
-    return isValid(date) ? date : null;
-  }
-  const date = parseISO(datetimeString);
+  if (!datetimeString) return null;
+  const date = parse(datetimeString.slice(0, 10), 'yyyy-MM-dd', new Date(0));
   return isValid(date) ? date : null;
 }
 

--- a/packages/date/src/utils/date.ts
+++ b/packages/date/src/utils/date.ts
@@ -18,6 +18,13 @@ function fieldValueToDate(datetimeString: string | null | undefined): Date | nul
   if (!datetimeString) {
     return null;
   }
+  // Extract yyyy-MM-dd directly from the string to avoid timezone conversion.
+  // parseISO shifts to local time, which can move the date across midnight.
+  const datePart = datetimeString.match(/^(\d{4}-\d{2}-\d{2})/);
+  if (datePart) {
+    const date = parse(datePart[1], 'yyyy-MM-dd', new Date(0));
+    return isValid(date) ? date : null;
+  }
   const date = parseISO(datetimeString);
   return isValid(date) ? date : null;
 }


### PR DESCRIPTION
## Summary

- **24h snap-back**: `TimepickerInput.handleBlur` was always emitting `hh:mm` (12h format) via `format(value, 'hh:mm')`, even in 24h mode. Entering `19:00` would fire `onChange({ time: '07:00', ampm: 'PM' })`, causing the field to snap to `07:00` on blur. Fixed by branching on `uses12hClock`.
- **Noon parsed as midnight**: `parseRawInput` tried `'hh:mm'` before any 24h format — `12:00` matched as 12h with no AM/PM suffix, defaulting to AM (midnight). Fixed by inserting `'HH:mm'` before `'hh:mm'` in `validInputFormats`.
- **Date shift across midnight**: `fieldValueToDate` used `parseISO` which converts offset-aware strings to a UTC instant. For e.g. `2026-04-27T23:00-02:00` (= `2026-04-28T01:00Z`), the local Date object carried April 28, causing the stored value to shift by one day. Fixed by extracting the `yyyy-MM-dd` part directly from the ISO string, bypassing timezone conversion entirely.
