### PR TITLE
fix(shared): replace require with import

### DIFF
--- a/packages/_shared/src/queryClient.tsx
+++ b/packages/_shared/src/queryClient.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 
+import * as ReactQuery from '@tanstack/react-query';
 import {
   QueryClient,
   QueryClientProvider,
@@ -12,8 +13,7 @@ import {
 } from '@tanstack/react-query';
 
 // `version` is exported at runtime in v4.36+ and v5, but not typed in v4's type declarations.
-const rqVersion: string | undefined = (require('@tanstack/react-query') as { version?: string }) // eslint-disable-line @typescript-eslint/no-var-requires -- version is untyped in v4
-  .version;
+const rqVersion: string | undefined = (ReactQuery as any).version;
 const RQ_MAJOR = parseInt(rqVersion ?? '4', 10);
 const IS_V5 = RQ_MAJOR >= 5;
 


### PR DESCRIPTION
replace a `require()` statement with an `import`.  The require was polluting the ESM build, causing an issue in browser builds for consumers of this package.

```bash
ReferenceError: Can't find variable: require
```

More specifically `automation-api/automation-builder`, when attempting to update CMA to v12, which migrates to ESM by default.

Running playwright tests results in all tests failing with something like :

```
95) [webkit] › src/views/ActionSidebar/ActionSidebar.pw.tsx:204:9 › ActionSidebar › App action nodes › switching to "App actions" shows grouped nodes and app filters

  Error: page._wrapApiCall: ReferenceError: Can't find variable: require

    143 |   test.describe('App action nodes', () => {
    144 |     const mountWithTestContext = (mount: any, node: React.ReactNode) => {
  > 145 |       return mount(<TestContext>{node}</TestContext>)
        |              ^
    146 |     }
    147 |
    148 |     test.beforeEach(async ({ page }) => {
      at mount (automation-api/node_modules/@playwright/experimental-ct-core/lib/mount.js:45:35)
      at mountWithTestContext (automation-api/packages/automation-builder/src/views/ActionSidebar/ActionSidebar.pw.tsx:145:14)
      at automation-api/packages/automation-builder/src/views/ActionSidebar/ActionSidebar.pw.tsx:205:13
```

See: [CI failure](https://app.circleci.com/pipelines/github/contentful/automation-api/26923/workflows/69921acf-43d9-491e-afde-08054f1cb498/jobs/159550) (doesn't have very helpful logs) and local brach: `chore/upgrade-contentful-management-v12`

