### PR TITLE
feat: add Fragment and Experience support to shared release entity types [TOL-3946]

### DIFF
--- a/packages/_shared/src/hooks/useReleaseStatus.spec.ts
+++ b/packages/_shared/src/hooks/useReleaseStatus.spec.ts
@@ -10,7 +10,7 @@ import type {
 import type { PublishStatus } from './useLocalePublishStatus';
 import { useReleaseStatus } from './useReleaseStatus';
 
-type EntityType = 'Entry' | 'Asset';
+type EntityType = 'Entry' | 'Asset' | 'Fragment' | 'Experience';
 
 interface EntityBuilder {
   withStatus: (status: PublishStatus) => EntryProps | AssetProps;
@@ -43,6 +43,8 @@ const createEntityBuilder = (entityType: EntityType, defaultId: string): EntityB
 
 const entryBuilder = () => createEntityBuilder('Entry', 'entry-1');
 const assetBuilder = () => createEntityBuilder('Asset', 'asset-1');
+const fragmentBuilder = () => createEntityBuilder('Fragment', 'fragment-1');
+const experienceBuilder = () => createEntityBuilder('Experience', 'experience-1');
 
 const createEntryBasedReleaseEntity = ({
   entityId,
@@ -132,7 +134,21 @@ const expectEntityStatus = (
   expect(result.releaseEntityStatus).toBe(expectedStatus);
 };
 
-const ENTITY_TYPES: EntityType[] = ['Entry', 'Asset'];
+const ENTITY_TYPES: EntityType[] = ['Entry', 'Asset', 'Fragment', 'Experience'];
+
+const ENTITY_ID_BY_TYPE: Record<EntityType, { default: string; different: string }> = {
+  Entry: { default: 'entry-1', different: 'entry-2' },
+  Asset: { default: 'asset-1', different: 'asset-2' },
+  Fragment: { default: 'fragment-1', different: 'fragment-2' },
+  Experience: { default: 'experience-1', different: 'experience-2' },
+};
+
+const BUILDER_BY_TYPE: Record<EntityType, () => EntityBuilder> = {
+  Entry: entryBuilder,
+  Asset: assetBuilder,
+  Fragment: fragmentBuilder,
+  Experience: experienceBuilder,
+};
 
 describe('useReleaseStatus', () => {
   const locales = createDefaultLocales();
@@ -445,13 +461,11 @@ describe('useReleaseStatus', () => {
     const locales = createDefaultLocales();
 
     ENTITY_TYPES.forEach((entityType) => {
-      const defaultEntityId = entityType === 'Entry' ? 'entry-1' : 'asset-1';
-      const differentEntityId = entityType === 'Entry' ? 'entry-2' : 'asset-2';
+      const { default: defaultEntityId, different: differentEntityId } =
+        ENTITY_ID_BY_TYPE[entityType];
 
-      const buildEntity = (status: PublishStatus) => {
-        const builder = entityType === 'Entry' ? entryBuilder() : assetBuilder();
-        return builder.withStatus(status);
-      };
+      const buildEntity = (status: PublishStatus) =>
+        BUILDER_BY_TYPE[entityType]().withStatus(status);
 
       const createRelease = (options: {
         entityId: string;

--- a/packages/_shared/src/hooks/useReleaseStatus.spec.ts
+++ b/packages/_shared/src/hooks/useReleaseStatus.spec.ts
@@ -449,6 +449,74 @@ describe('useReleaseStatus', () => {
     });
   });
 
+  describe('Flat array payload shape', () => {
+    const buildFlatShapeRelease = (verb: 'add' | 'remove', localeCodes: string[]): ReleaseV2Props =>
+      ({
+        title: 'Release 1',
+        sys: { id: 'release-1', type: 'Release', schemaVersion: 'Release.v2' },
+        entities: {
+          items: [
+            {
+              entity: { sys: { type: 'Link', linkType: 'Entry', id: 'entry-1' } },
+              [verb]: localeCodes,
+            } as unknown as ReleaseV2EntityWithLocales,
+          ],
+        },
+      }) as ReleaseV2Props;
+
+    it('treats flat-array add as willPublish', () => {
+      const { result } = renderHook(() =>
+        useReleaseStatus({
+          locales,
+          release: buildFlatShapeRelease('add', ['en-US']),
+          entity: entryBuilder().withStatus('draft'),
+        }),
+      );
+
+      expectLocaleStatus(result.current, 'en-US', {
+        variant: 'positive',
+        status: 'willPublish',
+        label: 'Will publish',
+        locale: { code: 'en-US' },
+      });
+    });
+
+    it('treats flat-array remove as becomesDraft', () => {
+      const { result } = renderHook(() =>
+        useReleaseStatus({
+          locales,
+          previousEntityOnTimeline: entryBuilder().withStatus('published'),
+          release: buildFlatShapeRelease('remove', ['en-US']),
+          entity: entryBuilder().withStatus('draft'),
+        }),
+      );
+
+      expectLocaleStatus(result.current, 'en-US', {
+        variant: 'warning',
+        status: 'becomesDraft',
+        label: 'Becomes draft',
+        locale: { code: 'en-US' },
+      });
+    });
+
+    it('treats empty flat-array remove as remainsDraft', () => {
+      const { result } = renderHook(() =>
+        useReleaseStatus({
+          locales,
+          release: buildFlatShapeRelease('remove', []),
+          entity: entryBuilder().withStatus('draft'),
+        }),
+      );
+
+      expectLocaleStatus(result.current, 'en-US', {
+        variant: 'warning',
+        status: 'remainsDraft',
+        label: 'Remains draft',
+        locale: { code: 'en-US' },
+      });
+    });
+  });
+
   // Primary organization: isReference (true vs false) - the key behavioral difference
   // Secondary: Publishing model (entry-based vs locale-based)
   // Tertiary: Entity type (Entry vs Asset) - behavior is identical

--- a/packages/_shared/src/hooks/useReleaseStatus.ts
+++ b/packages/_shared/src/hooks/useReleaseStatus.ts
@@ -11,6 +11,7 @@ import type {
   ReleaseV2EntityWithLocales,
   ReleaseV2Props,
 } from '../types';
+import { normalizeReleaseLocaleFields } from '../utils/determineReleaseAction';
 import { getEntityStatus } from '../utils/entityHelpers';
 import { getReleaseStatusBadgeConfig } from '../utils/getReleaseStatusBadgeConfig';
 import { sanitizeLocales } from '../utils/sanitizeLocales';
@@ -49,8 +50,12 @@ function getReleaseItemLocaleStatus(
   }
 
   // Locale based
-  const addedLocales = (releaseItem as ReleaseV2EntityWithLocales).add?.fields['*'] || [];
-  const removedLocales = (releaseItem as ReleaseV2EntityWithLocales).remove?.fields['*'] || [];
+  const addedLocales = normalizeReleaseLocaleFields(
+    (releaseItem as ReleaseV2EntityWithLocales).add,
+  );
+  const removedLocales = normalizeReleaseLocaleFields(
+    (releaseItem as ReleaseV2EntityWithLocales).remove,
+  );
 
   if (addedLocales.includes(locale.code)) {
     return 'willPublish';

--- a/packages/_shared/src/types.ts
+++ b/packages/_shared/src/types.ts
@@ -27,20 +27,14 @@ export type ReleaseV2Entity = {
   action: 'publish' | 'unpublish';
 };
 
+export type ReleaseV2LocaleFields = string[] | { fields: { '*': string[] } };
+
 export type ReleaseV2EntityWithLocales = {
   entity: {
     sys: { type: 'Link'; linkType: ReleaseV2EntityLinkType; id: string };
   };
-  add: {
-    fields: {
-      '*': string[];
-    };
-  };
-  remove: {
-    fields: {
-      '*': string[];
-    };
-  };
+  add: ReleaseV2LocaleFields;
+  remove: ReleaseV2LocaleFields;
 };
 
 export type ReleaseV2AnnotationType = 'Hidden' | 'Ideation';

--- a/packages/_shared/src/types.ts
+++ b/packages/_shared/src/types.ts
@@ -17,17 +17,19 @@ export type ValidationType =
       max: number;
     };
 
+export type ReleaseV2EntityLinkType = 'Entry' | 'Asset' | 'Fragment' | 'Experience';
+
 //@TODO: use Release types from contentful management once they are ready
 export type ReleaseV2Entity = {
   entity: {
-    sys: { type: 'Link'; linkType: 'Entry' | 'Asset'; id: string };
+    sys: { type: 'Link'; linkType: ReleaseV2EntityLinkType; id: string };
   };
   action: 'publish' | 'unpublish';
 };
 
 export type ReleaseV2EntityWithLocales = {
   entity: {
-    sys: { type: 'Link'; linkType: 'Entry' | 'Asset'; id: string };
+    sys: { type: 'Link'; linkType: ReleaseV2EntityLinkType; id: string };
   };
   add: {
     fields: {

--- a/packages/_shared/src/utils/determineReleaseAction.ts
+++ b/packages/_shared/src/utils/determineReleaseAction.ts
@@ -2,8 +2,19 @@ import type {
   ReleaseAction,
   ReleaseV2Entity,
   ReleaseV2EntityWithLocales,
+  ReleaseV2LocaleFields,
   ReleaseV2Props,
 } from '../types';
+
+export function normalizeReleaseLocaleFields(value?: ReleaseV2LocaleFields): string[] {
+  if (!value) {
+    return [];
+  }
+  if (Array.isArray(value)) {
+    return value;
+  }
+  return value.fields?.['*'] ?? [];
+}
 
 type DetermineActionResult = {
   releaseAction: ReleaseAction;
@@ -24,9 +35,10 @@ function getLocalesFromEntity(entityItem: ReleaseV2EntityWithLocales): {
   addLocales: string[];
   removeLocales: string[];
 } {
-  const addLocales = entityItem?.add?.fields?.['*'] ?? [];
-  const removeLocales = entityItem?.remove?.fields?.['*'] ?? [];
-  return { addLocales, removeLocales };
+  return {
+    addLocales: normalizeReleaseLocaleFields(entityItem?.add),
+    removeLocales: normalizeReleaseLocaleFields(entityItem?.remove),
+  };
 }
 
 function getLocaleBasedAction(addLocales: string[], removeLocales: string[]): ReleaseAction {


### PR DESCRIPTION
This PR updates the shared release status typing and test coverage to include Fragment and Experience entities