### PR TITLE
fix(date): default timepicker to 00:00 instead of 12:00 when no value

### DIFF
--- a/packages/date/src/TimepickerInput.spec.tsx
+++ b/packages/date/src/TimepickerInput.spec.tsx
@@ -28,6 +28,20 @@ describe('TimepickerInput', () => {
     expect(getByTestId('time-input')).toHaveValue('00:00');
   });
 
+  it('defaults to 00:00 in 24h mode when no time prop is provided', () => {
+    const { getByTestId } = render(
+      <TimepickerInput disabled={false} uses12hClock={false} onChange={jest.fn()} />,
+    );
+    expect(getByTestId('time-input')).toHaveValue('00:00');
+  });
+
+  it('defaults to 12:00 AM in 12h mode when no time prop is provided', () => {
+    const { getByTestId } = render(
+      <TimepickerInput disabled={false} uses12hClock={true} onChange={jest.fn()} />,
+    );
+    expect(getByTestId('time-input')).toHaveValue('12:00 AM');
+  });
+
   it('renders late-night hours (e.g. 23:00) in 24h mode without crashing', () => {
     const { getByTestId } = render(
       <TimepickerInput

--- a/packages/date/src/TimepickerInput.tsx
+++ b/packages/date/src/TimepickerInput.tsx
@@ -44,7 +44,7 @@ const formatToString = (uses12hClock: boolean, value: Date): string =>
 export const TimepickerInput = ({
   disabled,
   uses12hClock,
-  time = '12:00',
+  time = '00:00',
   ampm = 'AM',
   onChange,
 }: TimepickerProps) => {
@@ -56,7 +56,7 @@ export const TimepickerInput = ({
     const parsed = uses12hClock
       ? parse(`${time} ${ampm}`, 'hh:mm a', REF_DATE)
       : parse(time, 'HH:mm', REF_DATE);
-    setSelectedTime(formatToString(uses12hClock, parsed));
+    setSelectedTime(formatToString(uses12hClock, isValid(parsed) ? parsed : getDefaultTime()));
   }, [time, ampm, uses12hClock]);
 
   const handleChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {


### PR DESCRIPTION
## Summary

- When no date value is stored, `TimepickerInput` defaulted the `time` prop to `'12:00'`, which parsed as **noon** (12:00) in 24h mode instead of midnight (00:00)
- Changed default prop from `'12:00'` to `'00:00'`
- Added `isValid` guard in the `useEffect` so invalid parse combos (e.g. `'00:00 AM'` with `hh` format) fall back to midnight via `getDefaultTime()` instead of passing an invalid `Date` to `format()`
- Added two regression tests covering the no-prop-provided case for both 24h and 12h modes