### PR TITLE
fix(shared): queryClient detects react-query v4/v5 using setLogger

### DIFF
--- a/packages/_shared/src/queryClient.tsx
+++ b/packages/_shared/src/queryClient.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 
-import * as ReactQuery from '@tanstack/react-query';
 import {
   QueryClient,
   QueryClientProvider,
@@ -12,10 +11,8 @@ import {
   type UseQueryResult,
 } from '@tanstack/react-query';
 
-// `version` is exported at runtime in v4.36+ and v5, but not typed in v4's type declarations.
-const rqVersion: string | undefined = (ReactQuery as any).version;
-const RQ_MAJOR = parseInt(rqVersion ?? '4', 10);
-const IS_V5 = RQ_MAJOR >= 5;
+// v4 exposed `getLogger()` on QueryClient.prototype; it was removed in v5.
+const IS_V5 = typeof (QueryClient.prototype as any).setLogger !== 'function';
 
 /**
  * A custom client context ensures zero conflict with host apps also using


### PR DESCRIPTION
### Description:
Fix a [build error](https://app.circleci.com/pipelines/github/contentful/user_interface/153835/workflows/a1a41572-c249-4544-bd52-3c6801b75d61/jobs/1407685) in `user_interface`:
```
 => ERROR [production built 1/4] RUN NODE_ENV=production node --max_old  334.9s
------
 > [production built 1/4] RUN NODE_ENV=production node --max_old_space_size=4096 
  ./tools/bin/build-app.js:
334.4 {
334.4   moduleIdentifier: '/app/node_modules/swc-loader/src/index.js??
  ruleSet[1].rules[3].use!/app/node_modules/@contentful/field-editor-shared/dist/esm/queryClient.js',
334.4   moduleName: './node_modules/@contentful/field-editor-shared/dist/esm/queryClient.js',
334.4   loc: '4:18-36',
334.4   message: "export 'version' (imported as 'ReactQuery') was not found in '@tanstack/react-query' 
  (possible exports: CancelledError, Hydrate, InfiniteQueryObserver, IsRestoringProvider, MutationCache,
   MutationObserver, QueriesObserver, Query, QueryCache, QueryClient, QueryClientProvider, 
  QueryErrorResetBoundary, QueryObserver, defaultContext, defaultShouldDehydrateMutation, 
  defaultShouldDehydrateQuery, dehydrate, focusManager, hashQueryKey, hydrate, infiniteQueryOptions, 
  isCancelledError, isError, isServer, matchQuery, notifyManager, onlineManager, parseFilterArgs, 
  parseMutationArgs, parseMutationFilterArgs, parseQueryArgs, queryOptions, replaceEqualDeep, 
  useHydrate, useInfiniteQuery, useIsFetching, useIsMutating, useIsRestoring, useMutation, useQueries,
  useQuery, useQueryClient, useQueryErrorResetBoundary, useSuspenseInfiniteQuery, 
  useSuspenseQueries, useSuspenseQuery)",
334.4   moduleId: null,
334.4   moduleTrace: [
  ...
```

### Root cause:
User_interface's Webpack's static analysis validates every named export access on a namespace import against the actual exports of the target module. `version` is not a named export in @tanstack/react-query's ESM module —
  it's a property on the CJS module.exports object at runtime, but it was never declared as an explicit export const version in the ESM entry point.

Check `(QueryClient.prototype as any).setLogger` to detect where runtime library is v4 or v5.

### Solution:
instead of relying on `version` property, check presence of `getLogger` function, that was [**removed** in v5](https://tanstack.com/query/latest/docs/framework/react/guides/migrating-to-v5#the-deprecated-custom-logger-has-been-removed).

> The deprecated custom logger has been removed
> Custom loggers were already deprecated in 4 and have been removed in this version. Logging only had an effect in development mode, where passing a custom logger is not necessary.

## V4
```
// package.json
{
  ...
  "dependencies": {
    "@tanstack/react-query": "^4.44.0",
    "react": "^18.3.1",
    "react-dom": "^18.3.1"
  }
}

// main.tsx
import { QueryClient } from "@tanstack/react-query";

const IS_V5 = typeof QueryClient.prototype.getLogger !== 'function';
console.log(`QueryClient.prototype.getLogger => `, QueryClient.prototype.getLogger)
console.log(`IS_V5 => `, IS_V5)

// result:
npx tsx main.ts
QueryClient.prototype.getLogger =>  [Function: getLogger]
IS_V5 =>  false
```

## V5
```
{
  ...
  "dependencies": {
    "@tanstack/react-query": "^5.100.0",
    "react": "^18.3.1",
    "react-dom": "^18.3.1"
  }
}

// main.tsx - same as v4
import { QueryClient } from "@tanstack/react-query";

const IS_V5 = typeof QueryClient.prototype.getLogger !== 'function';
console.log(`QueryClient.prototype.getLogger => `, QueryClient.prototype.getLogger)
console.log(`IS_V5 => `, IS_V5)

// result:
npx tsx main.ts
QueryClient.prototype.getLogger =>  undefined
IS_V5 =>  true
```