### PR TITLE
fix(date): parse am/pm without space separator in timepicker

### DIFF
--- a/packages/date/src/TimepickerInput.spec.tsx
+++ b/packages/date/src/TimepickerInput.spec.tsx
@@ -195,6 +195,59 @@ describe('TimepickerInput', () => {
     });
   });
 
+  describe('am/pm without space separator', () => {
+    it('parses 1:15pm (no space) correctly in 12h mode', () => {
+      const onChange = jest.fn();
+      const { getByTestId } = render(
+        <TimepickerInput
+          disabled={false}
+          uses12hClock={true}
+          time="12:00"
+          ampm="AM"
+          onChange={onChange}
+        />,
+      );
+      userEvent.clear(getByTestId('time-input'));
+      userEvent.type(getByTestId('time-input'), '1:15pm');
+      userEvent.tab();
+      expect(onChange).toHaveBeenCalledWith({ time: '01:15', ampm: 'PM' });
+    });
+
+    it('parses 1:15PM (no space, uppercase) correctly in 12h mode', () => {
+      const onChange = jest.fn();
+      const { getByTestId } = render(
+        <TimepickerInput
+          disabled={false}
+          uses12hClock={true}
+          time="12:00"
+          ampm="AM"
+          onChange={onChange}
+        />,
+      );
+      userEvent.clear(getByTestId('time-input'));
+      userEvent.type(getByTestId('time-input'), '1:15PM');
+      userEvent.tab();
+      expect(onChange).toHaveBeenCalledWith({ time: '01:15', ampm: 'PM' });
+    });
+
+    it('parses 1pm (no space, no minutes) correctly in 12h mode', () => {
+      const onChange = jest.fn();
+      const { getByTestId } = render(
+        <TimepickerInput
+          disabled={false}
+          uses12hClock={true}
+          time="12:00"
+          ampm="AM"
+          onChange={onChange}
+        />,
+      );
+      userEvent.clear(getByTestId('time-input'));
+      userEvent.type(getByTestId('time-input'), '1pm');
+      userEvent.tab();
+      expect(onChange).toHaveBeenCalledWith({ time: '01:00', ampm: 'PM' });
+    });
+  });
+
   describe('onChange on blur — 12h mode', () => {
     it('emits 07:00 AM correctly in 12h mode', () => {
       const onChange = jest.fn();

--- a/packages/date/src/TimepickerInput.tsx
+++ b/packages/date/src/TimepickerInput.tsx
@@ -28,9 +28,15 @@ const validInputFormats = [
 ];
 const REF_DATE = new Date(2000, 0, 1);
 
+function normalizeRawInput(raw: string): string {
+  // date-fns 'a' token requires a space before AM/PM; moment was lenient
+  return raw.replace(/(\d)(am|pm)$/i, '$1 $2');
+}
+
 function parseRawInput(raw: string): Date | null {
+  const normalized = normalizeRawInput(raw);
   for (const fmt of validInputFormats) {
-    const parsed = parse(raw, fmt, REF_DATE);
+    const parsed = parse(normalized, fmt, REF_DATE);
     if (isValid(parsed)) return parsed;
   }
   return null;


### PR DESCRIPTION
## Summary

- Fixes a regression where typing `1:15pm` (no space before am/pm) would reset the timepicker to `12:00` instead of `1:15 PM`
- Root cause: `date-fns` strictly requires a space before `AM`/`PM` in its format tokens, while the previous `moment.js` implementation was lenient
- Added `normalizeRawInput` to insert a space before trailing `am`/`pm` when directly attached to a digit

## Test plan

- [x] Added 3 new tests covering `1:15pm`, `1:15PM`, and `1pm` (no space, both cases, with and without minutes)
- [x] All 17 existing + new tests pass