### PR TITLE
feat(shared): widen entity-shaped sys params

### DIFF
--- a/packages/_shared/src/LocalePublishingEntityStatusBadge/LocalePublishingPopover.tsx
+++ b/packages/_shared/src/LocalePublishingEntityStatusBadge/LocalePublishingPopover.tsx
@@ -4,12 +4,7 @@ import { EntityStatus, EntityStatusBadge, Flex, Popover } from '@contentful/f36-
 import { CaretDownIcon } from '@contentful/f36-icons';
 import tokens from '@contentful/f36-tokens';
 import { cx, css } from '@emotion/css';
-import type {
-  LocaleProps,
-  EntryProps,
-  AssetProps,
-  ScheduledActionProps,
-} from 'contentful-management';
+import type { LocaleProps, ScheduledActionProps } from 'contentful-management';
 
 import { LocalePublishStatusMap } from '../hooks/useLocalePublishStatus';
 import * as entityHelpers from '../utils/entityHelpers';
@@ -148,7 +143,7 @@ const determineBadgeStatus = (
 };
 
 type LocalePublishingPopoverProps = {
-  entity: Pick<EntryProps | AssetProps, 'sys'>;
+  entity: { sys: entityHelpers.EntitySys };
   jobs: ScheduledActionProps[];
   isScheduled: boolean;
   activeLocales?: Pick<LocaleProps, 'code'>[];

--- a/packages/_shared/src/LocalePublishingEntityStatusBadge/LocalePublishingPopover.tsx
+++ b/packages/_shared/src/LocalePublishingEntityStatusBadge/LocalePublishingPopover.tsx
@@ -7,7 +7,7 @@ import { cx, css } from '@emotion/css';
 import type { LocaleProps, ScheduledActionProps } from 'contentful-management';
 
 import { LocalePublishStatusMap } from '../hooks/useLocalePublishStatus';
-import * as entityHelpers from '../utils/entityHelpers';
+import { getEntityStatus, type EntitySys } from '../utils/entityHelpers';
 import { LocalePublishingStatusList } from './LocalePublishingStatusList';
 import { ScheduledBanner } from './ScheduledBanner';
 
@@ -143,7 +143,7 @@ const determineBadgeStatus = (
 };
 
 type LocalePublishingPopoverProps = {
-  entity: { sys: entityHelpers.EntitySys };
+  entity: { sys: EntitySys };
   jobs: ScheduledActionProps[];
   isScheduled: boolean;
   activeLocales?: Pick<LocaleProps, 'code'>[];
@@ -174,7 +174,7 @@ export function LocalePublishingPopover({
     }, 300);
   }, []);
 
-  const entityStatus = entityHelpers.getEntityStatus(
+  const entityStatus = getEntityStatus(
     entity.sys,
     activeLocales?.map((locale) => locale.code),
   );

--- a/packages/_shared/src/hooks/useLocalePublishStatus.ts
+++ b/packages/_shared/src/hooks/useLocalePublishStatus.ts
@@ -3,7 +3,7 @@ import { useMemo } from 'react';
 import type { LocalesAPI } from '@contentful/app-sdk';
 import type { LocaleProps } from 'contentful-management';
 
-import * as entityHelpers from '../utils/entityHelpers';
+import { getEntityStatus, type EntitySys } from '../utils/entityHelpers';
 import { sanitizeLocales, type SanitizedLocale } from '../utils/sanitizeLocales';
 
 export type PublishStatus = 'draft' | 'published' | 'changed';
@@ -14,11 +14,8 @@ export type LocalePublishStatus = {
 };
 export type LocalePublishStatusMap = Map<string, LocalePublishStatus>;
 
-function getLocalePublishStatusMap(
-  entity: { sys: entityHelpers.EntitySys },
-  locales: SanitizedLocale[],
-) {
-  const entityStatus = entityHelpers.getEntityStatus(entity.sys);
+function getLocalePublishStatusMap(entity: { sys: EntitySys }, locales: SanitizedLocale[]) {
+  const entityStatus = getEntityStatus(entity.sys);
 
   if (['archived', 'deleted'].includes(entityStatus)) {
     return;
@@ -29,10 +26,7 @@ function getLocalePublishStatusMap(
       locale.code,
       {
         // save to cast as archived and deleted are already handled before
-        status: entityHelpers.getEntityStatus(entity.sys, locale.code) as
-          | 'draft'
-          | 'published'
-          | 'changed',
+        status: getEntityStatus(entity.sys, locale.code) as 'draft' | 'published' | 'changed',
         locale,
       },
     ]),
@@ -45,7 +39,7 @@ function getLocalePublishStatusMap(
  * Get the publish status for each locale
  */
 export function useLocalePublishStatus(
-  entity?: { sys: entityHelpers.EntitySys },
+  entity?: { sys: EntitySys },
   locales?: Pick<LocalesAPI, 'available' | 'default' | 'names'> | LocaleProps[] | null,
 ): LocalePublishStatusMap | undefined {
   return useMemo(() => {

--- a/packages/_shared/src/hooks/useLocalePublishStatus.ts
+++ b/packages/_shared/src/hooks/useLocalePublishStatus.ts
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 
 import type { LocalesAPI } from '@contentful/app-sdk';
-import type { AssetProps, EntryProps, LocaleProps } from 'contentful-management';
+import type { LocaleProps } from 'contentful-management';
 
 import * as entityHelpers from '../utils/entityHelpers';
 import { sanitizeLocales, type SanitizedLocale } from '../utils/sanitizeLocales';
@@ -15,7 +15,7 @@ export type LocalePublishStatus = {
 export type LocalePublishStatusMap = Map<string, LocalePublishStatus>;
 
 function getLocalePublishStatusMap(
-  entity: Pick<AssetProps | EntryProps, 'sys'>,
+  entity: { sys: entityHelpers.EntitySys },
   locales: SanitizedLocale[],
 ) {
   const entityStatus = entityHelpers.getEntityStatus(entity.sys);
@@ -45,7 +45,7 @@ function getLocalePublishStatusMap(
  * Get the publish status for each locale
  */
 export function useLocalePublishStatus(
-  entity?: AssetProps | EntryProps,
+  entity?: { sys: entityHelpers.EntitySys },
   locales?: Pick<LocalesAPI, 'available' | 'default' | 'names'> | LocaleProps[] | null,
 ): LocalePublishStatusMap | undefined {
   return useMemo(() => {

--- a/packages/_shared/src/hooks/useReleaseStatus.ts
+++ b/packages/_shared/src/hooks/useReleaseStatus.ts
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 
 import type { LocalesAPI } from '@contentful/app-sdk';
-import type { AssetProps, EntryProps, LocaleProps, ReleaseProps } from 'contentful-management';
+import type { LocaleProps, ReleaseProps } from 'contentful-management';
 
 import type {
   ReleaseEntityStatus,
@@ -12,7 +12,7 @@ import type {
   ReleaseV2Props,
 } from '../types';
 import { normalizeReleaseLocaleFields } from '../utils/determineReleaseAction';
-import { getEntityStatus } from '../utils/entityHelpers';
+import { getEntityStatus, type EntitySys } from '../utils/entityHelpers';
 import { getReleaseStatusBadgeConfig } from '../utils/getReleaseStatusBadgeConfig';
 import { sanitizeLocales } from '../utils/sanitizeLocales';
 
@@ -32,7 +32,7 @@ function createReleaseLocaleStatus(
 function getReleaseItemLocaleStatus(
   releaseItem: ReleaseV2Entity | ReleaseV2EntityWithLocales,
   locale: Pick<LocaleProps, 'code' | 'default' | 'name'>,
-  previousEntityOnTimeline?: Pick<EntryProps | AssetProps, 'sys'>,
+  previousEntityOnTimeline?: { sys: EntitySys },
 ): ReleaseEntityStatus {
   // Entry based
   if ('action' in releaseItem) {
@@ -72,10 +72,10 @@ function getReleaseItemLocaleStatus(
 }
 
 type UseActiveReleaseLocalesStatuses = {
-  entity?: Pick<EntryProps | AssetProps, 'sys'>;
+  entity?: { sys: EntitySys };
   locales: LocaleProps[] | LocalesAPI;
   release?: ReleaseProps | ReleaseV2Props;
-  previousEntityOnTimeline?: Pick<EntryProps | AssetProps, 'sys'>;
+  previousEntityOnTimeline?: { sys: EntitySys };
   isReference?: boolean;
 };
 

--- a/packages/_shared/src/utils/entityHelpers.ts
+++ b/packages/_shared/src/utils/entityHelpers.ts
@@ -199,8 +199,20 @@ export function getEntryTitle({
   return titleOrDefault(title, defaultTitle);
 }
 
-export type EntitySys = Entry['sys'] | Asset['sys'];
 type FieldStatus = 'draft' | 'published' | 'changed';
+
+// @TODO - use general type instead once Experience and Fragment types are public
+// export type EntitySys = Entry['sys'] | Asset['sys'] | Experience['sys'] | Fragment['sys'];
+export type EntitySys = {
+  type: string;
+  id: string;
+  version: number;
+  publishedVersion?: number;
+  archivedVersion?: number;
+  deletedVersion?: number;
+  localeStatus?: Record<string, FieldStatus>;
+  fieldStatus?: Record<string, Record<string, FieldStatus>>;
+};
 
 function getLocaleStatusObject(sys: EntitySys): Record<string, FieldStatus> | undefined {
   if ('localeStatus' in sys) {


### PR DESCRIPTION
Widen the entity-shaped `sys` parameters in `_shared/` from entry / asset-specific types to the structural `EntitySys` shape.
The goal is to make shared helpers work across all supported entity types, including `Entry`, `Asset`, `Experience`, and `Fragment`.