### PR TITLE
feat: support new all locales spec [TOL-3944]

### DIFF
--- a/packages/_shared/src/types.ts
+++ b/packages/_shared/src/types.ts
@@ -27,7 +27,14 @@ export type ReleaseV2Entity = {
   action: 'publish' | 'unpublish';
 };
 
-export type ReleaseV2LocaleFields = string[] | { fields: { '*': string[] } };
+export type ReleaseV2LocaleFields =
+  | '*'
+  | string[]
+  | {
+      fields: {
+        '*': string[];
+      };
+    };
 
 export type ReleaseV2EntityWithLocales = {
   entity: {

--- a/packages/_shared/src/utils/determineReleaseAction.ts
+++ b/packages/_shared/src/utils/determineReleaseAction.ts
@@ -13,7 +13,10 @@ export function normalizeReleaseLocaleFields(value?: ReleaseV2LocaleFields): str
   if (Array.isArray(value)) {
     return value;
   }
-  return value.fields?.['*'] ?? [];
+  if (value === '*') {
+    return ['*'];
+  }
+  return value.fields['*'] ?? [];
 }
 
 type DetermineActionResult = {


### PR DESCRIPTION
## Description
Adding `*` to the `ReleaseV2LocaleFields` union

## Explanation
A `ReleaseV2Props.entities.items` entry is either a `ReleaseV2Entity` (entry-based) or a `ReleaseV2EntityWithLocales` (locale-based):

### 1. Entry-based (`ReleaseV2Entity`)
```
{
  "entity": { "sys": { "type": "Link", "linkType": "Entry", "id": "abc" } },
  "action": "publish" | "unpublish"
}
```

### 2. Locale-based (`ReleaseV2EntityWithLocales`)
Each of add and remove can independently be one of three shapes:

#### a) All locales (wildcard)
```
{
  "entity": { "sys": { "type": "Link", "linkType": "Entry", "id": "abc" } },
  "add": "*",
  "remove": "*"
}
```

#### b) Explicit locale list
```
{
  "entity": { "sys": { "type": "Link", "linkType": "Entry", "id": "abc" } },
  "add": ["en-US", "de-DE"],
  "remove": ["fr-FR"]
}
```

#### c) Fields object (locales for all fields)
```
{
  "entity": { "sys": { "type": "Link", "linkType": "Entry", "id": "abc" } },
  "add": { "fields": { "*": ["en-US", "de-DE"] } },
  "remove": { "fields": { "*": ["fr-FR"] } }
}
```

The linkType can be `"Entry" | "Asset" | "Fragment" | "Experience"` in all cases.