### PR TITLE
feat: migrate from ReactDOM.render to createRoot API [TOL-2866]

### DIFF
--- a/packages/_shared/src/ModalDialogLauncher.tsx
+++ b/packages/_shared/src/ModalDialogLauncher.tsx
@@ -1,42 +1,49 @@
 /* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-use-before-define */
 
 import * as React from 'react';
-import ReactDOM from 'react-dom';
+import { flushSync } from 'react-dom';
+import { createRoot, Root } from 'react-dom/client';
 
 import { OpenCustomWidgetOptions } from '@contentful/app-sdk';
 import { Modal, ModalHeader } from '@contentful/f36-components';
 import isNumber from 'lodash/isNumber';
 
+const CLOSE_DELAY = 300;
+
 export function open(componentRenderer: (params: { onClose: Function; isShown: boolean }) => any) {
-  let rootDom: any = null;
+  let rootDom: HTMLDivElement | null = null;
+  let reactRoot: Root | null = null;
 
   const getRoot = () => {
     if (rootDom === null) {
       rootDom = document.createElement('div');
       rootDom.setAttribute('id', 'field-editor-modal-root');
       document.body.appendChild(rootDom);
+      reactRoot = createRoot(rootDom);
     }
-    return rootDom;
+    return reactRoot!;
   };
 
   return new Promise((resolve) => {
     let currentConfig = { onClose, isShown: true };
 
     function render({ onClose, isShown }: { onClose: Function; isShown: boolean }) {
-      // eslint-disable-next-line -- TODO: use createRoot instead here
-      ReactDOM.render(componentRenderer({ onClose, isShown }), getRoot());
+      flushSync(() => {
+        getRoot().render(componentRenderer({ onClose, isShown }));
+      });
     }
 
-    function onClose(...args: any[]) {
+    async function onClose(...args: any[]) {
       currentConfig = {
         ...currentConfig,
         isShown: false,
       };
       render(currentConfig);
-      // eslint-disable-next-line -- TODO: describe this disable  @typescript-eslint/ban-ts-comment
-      // @ts-ignore
+      // @ts-expect-error -- resolve is called with variadic args from onClose
       resolve(...args);
-      getRoot().remove();
+      await new Promise((r) => setTimeout(r, CLOSE_DELAY));
+      reactRoot?.unmount();
+      rootDom?.remove();
     }
 
     render(currentConfig);
@@ -45,7 +52,7 @@ export function open(componentRenderer: (params: { onClose: Function; isShown: b
 
 export function openDialog<T>(
   options: OpenCustomWidgetOptions,
-  Component: React.FC<{ onClose: (result: T) => void }>
+  Component: React.FC<{ onClose: (result: T) => void }>,
 ) {
   const key = Date.now();
   const size = isNumber(options.width) ? `${options.width}px` : options.width;

--- a/packages/_test/package.json
+++ b/packages/_test/package.json
@@ -46,7 +46,8 @@
   },
   "peerDependencies": {
     "@contentful/app-sdk": "^4.29.0",
-    "react": ">=18.3.1"
+    "react": ">=18.3.1",
+    "react-dom": ">=18.3.1"
   },
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/"

--- a/packages/boolean/package.json
+++ b/packages/boolean/package.json
@@ -47,7 +47,8 @@
   },
   "peerDependencies": {
     "@lingui/core": "^5.3.0",
-    "react": ">=18.3.1"
+    "react": ">=18.3.1",
+    "react-dom": ">=18.3.1"
   },
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/"

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -49,7 +49,8 @@
   },
   "peerDependencies": {
     "@lingui/core": "^5.3.0",
-    "react": ">=18.3.1"
+    "react": ">=18.3.1",
+    "react-dom": ">=18.3.1"
   },
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/"

--- a/packages/date/package.json
+++ b/packages/date/package.json
@@ -52,7 +52,8 @@
   },
   "peerDependencies": {
     "@lingui/core": "^5.3.0",
-    "react": ">=18.3.1"
+    "react": ">=18.3.1",
+    "react-dom": ">=18.3.1"
   },
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/"

--- a/packages/default-field-editors/package.json
+++ b/packages/default-field-editors/package.json
@@ -66,7 +66,8 @@
     "@contentful/field-editor-test-utils": "^3.0.0"
   },
   "peerDependencies": {
-    "react": ">=18.3.1"
+    "react": ">=18.3.1",
+    "react-dom": ">=18.3.1"
   },
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/"

--- a/packages/default-field-editors/src/FieldWrapper.tsx
+++ b/packages/default-field-editors/src/FieldWrapper.tsx
@@ -71,7 +71,7 @@ export const FieldWrapper: React.FC<FieldWrapperProps> = function (props: FieldW
 
       <ValidationErrors
         field={field}
-        cma={sdk.cma as PlainClientAPI}
+        cma={sdk.cma as unknown as PlainClientAPI}
         locales={sdk.locales}
         getEntryURL={getEntryURL || defaultGetEntryUrl}
       />

--- a/packages/dropdown/package.json
+++ b/packages/dropdown/package.json
@@ -48,7 +48,8 @@
   },
   "peerDependencies": {
     "@lingui/core": "^5.3.0",
-    "react": ">=18.3.1"
+    "react": ">=18.3.1",
+    "react-dom": ">=18.3.1"
   },
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/"

--- a/packages/json/package.json
+++ b/packages/json/package.json
@@ -52,7 +52,8 @@
   },
   "peerDependencies": {
     "@lingui/core": "^5.3.0",
-    "react": ">=18.3.1"
+    "react": ">=18.3.1",
+    "react-dom": ">=18.3.1"
   },
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/"

--- a/packages/list/package.json
+++ b/packages/list/package.json
@@ -45,7 +45,8 @@
     "@contentful/field-editor-test-utils": "^3.0.0"
   },
   "peerDependencies": {
-    "react": ">=18.3.1"
+    "react": ">=18.3.1",
+    "react-dom": ">=18.3.1"
   },
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/"

--- a/packages/location/package.json
+++ b/packages/location/package.json
@@ -48,7 +48,8 @@
   },
   "peerDependencies": {
     "@lingui/core": "^5.3.0",
-    "react": ">=18.3.1"
+    "react": ">=18.3.1",
+    "react-dom": ">=18.3.1"
   },
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/"

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -59,7 +59,8 @@
   "peerDependencies": {
     "@contentful/app-sdk": "^4.29.0",
     "@lingui/core": "^5.3.0",
-    "react": ">=18.3.1"
+    "react": ">=18.3.1",
+    "react-dom": ">=18.3.1"
   },
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/"

--- a/packages/multiple-line/package.json
+++ b/packages/multiple-line/package.json
@@ -45,7 +45,8 @@
     "@contentful/field-editor-test-utils": "^3.0.0"
   },
   "peerDependencies": {
-    "react": ">=18.3.1"
+    "react": ">=18.3.1",
+    "react-dom": ">=18.3.1"
   },
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/"

--- a/packages/number/package.json
+++ b/packages/number/package.json
@@ -49,7 +49,8 @@
     "@testing-library/user-event": "^13.1.9"
   },
   "peerDependencies": {
-    "react": ">=18.3.1"
+    "react": ">=18.3.1",
+    "react-dom": ">=18.3.1"
   },
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/"

--- a/packages/radio/package.json
+++ b/packages/radio/package.json
@@ -49,7 +49,8 @@
   },
   "peerDependencies": {
     "@lingui/core": "^5.3.0",
-    "react": ">=18.3.1"
+    "react": ">=18.3.1",
+    "react-dom": ">=18.3.1"
   },
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/"

--- a/packages/rating/package.json
+++ b/packages/rating/package.json
@@ -49,7 +49,8 @@
   },
   "peerDependencies": {
     "@lingui/core": "^5.3.0",
-    "react": ">=18.3.1"
+    "react": ">=18.3.1",
+    "react-dom": ">=18.3.1"
   },
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/"

--- a/packages/reference/package.json
+++ b/packages/reference/package.json
@@ -64,7 +64,8 @@
   "peerDependencies": {
     "@contentful/app-sdk": "^4.41.2",
     "@lingui/core": "^5.3.0",
-    "react": ">=18.3.1"
+    "react": ">=18.3.1",
+    "react-dom": ">=18.3.1"
   },
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/"

--- a/packages/single-line/package.json
+++ b/packages/single-line/package.json
@@ -47,7 +47,8 @@
   },
   "peerDependencies": {
     "@lingui/core": "^5.3.0",
-    "react": ">=18.3.1"
+    "react": ">=18.3.1",
+    "react-dom": ">=18.3.1"
   },
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/"

--- a/packages/slug/package.json
+++ b/packages/slug/package.json
@@ -54,7 +54,8 @@
   "peerDependencies": {
     "@contentful/app-sdk": "^4.45.0",
     "@lingui/core": "^5.3.0",
-    "react": ">=18.3.1"
+    "react": ">=18.3.1",
+    "react-dom": ">=18.3.1"
   },
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/"

--- a/packages/tags/package.json
+++ b/packages/tags/package.json
@@ -53,7 +53,8 @@
   },
   "peerDependencies": {
     "@lingui/core": "^5.3.0",
-    "react": ">=18.3.1"
+    "react": ">=18.3.1",
+    "react-dom": ">=18.3.1"
   },
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/"

--- a/packages/url/package.json
+++ b/packages/url/package.json
@@ -43,7 +43,8 @@
     "@contentful/field-editor-test-utils": "^3.0.0"
   },
   "peerDependencies": {
-    "react": ">=18.3.1"
+    "react": ">=18.3.1",
+    "react-dom": ">=18.3.1"
   },
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/"

--- a/packages/validation-errors/package.json
+++ b/packages/validation-errors/package.json
@@ -49,7 +49,8 @@
   "peerDependencies": {
     "@lingui/core": "^5.3.0",
     "@tanstack/react-query": "^4.3.9 || ^5.0.0",
-    "react": ">=18.3.1"
+    "react": ">=18.3.1",
+    "react-dom": ">=18.3.1"
   },
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/"


### PR DESCRIPTION
## Description
- Replace all `ReactDOM.render()` calls with React 18's `createRoot` API from `react-dom/client`
- Update `ModalDialogLauncher` (shared package) to use `createRoot/unmount` lifecycle
- Add `react-dom: >=18.3.1` as explicit peer dependency to all 20 field editor packages

Fixes https://github.com/contentful/field-editors/issues/1723


## Testing
- [x] Rich text editor still renders in storybook when opening the hyperlink modal