### PR TITLE
fix: handle react-query v5 pending status in fetching cards [ES-262]

### DIFF
--- a/packages/reference/src/assets/WrappedAssetCard/FetchingWrappedAssetCard.tsx
+++ b/packages/reference/src/assets/WrappedAssetCard/FetchingWrappedAssetCard.tsx
@@ -134,7 +134,7 @@ export function FetchingWrappedAssetCard(props: FetchingWrappedAssetCardProps) {
       onAddToRelease,
     };
 
-    if (status === 'loading') {
+    if (status === 'loading' || (status as string) === 'pending') {
       return props.viewType === 'link' ? (
         <EntryCard size="small" isLoading />
       ) : (

--- a/packages/reference/src/entries/WrappedEntryCard/FetchingWrappedEntryCard.tsx
+++ b/packages/reference/src/entries/WrappedEntryCard/FetchingWrappedEntryCard.tsx
@@ -152,7 +152,7 @@ export function FetchingWrappedEntryCard(props: EntryCardReferenceEditorProps) {
       }
       return card;
     }
-    if (status === 'loading') {
+    if (status === 'loading' || (status as string) === 'pending') {
       return <EntryCard size={size} isLoading />;
     }
 

--- a/packages/rich-text-alpha/src/components/FetchingWrappedAssetCard.tsx
+++ b/packages/rich-text-alpha/src/components/FetchingWrappedAssetCard.tsx
@@ -116,7 +116,7 @@ export function FetchingWrappedAssetCard(props: FetchingWrappedAssetCardProps) {
     }
   }, [onEntityFetchComplete, status]);
 
-  if (status === 'loading' || status === 'idle') {
+  if (status === 'loading' || status === 'idle' || (status as string) === 'pending') {
     return <AssetCard size="default" isLoading />;
   }
 

--- a/packages/rich-text-alpha/src/components/FetchingWrappedEntryCard.tsx
+++ b/packages/rich-text-alpha/src/components/FetchingWrappedEntryCard.tsx
@@ -130,7 +130,7 @@ const InternalFetchingWrappedEntryCard = (props: FetchingWrappedEntryCardProps) 
     }
   }, [onEntityFetchComplete, status]);
 
-  if (status === 'loading' || status === 'idle') {
+  if (status === 'loading' || status === 'idle' || (status as string) === 'pending') {
     return <EntryCard isLoading />;
   }
 

--- a/packages/rich-text-alpha/src/components/FetchingWrappedResourceCard.tsx
+++ b/packages/rich-text-alpha/src/components/FetchingWrappedResourceCard.tsx
@@ -16,13 +16,13 @@ interface InternalEntryCard {
   isSelected: boolean;
   sdk: FieldAppSDK;
   data?: ResourceInfo<Entry>;
-  status: 'loading' | 'error' | 'success';
+  status: 'loading' | 'pending' | 'error' | 'success';
   onEdit?: VoidFunction;
   onRemove?: VoidFunction;
 }
 
 const InternalEntryCard = React.memo((props: InternalEntryCard) => {
-  if (props.data === undefined || props.status === 'loading') {
+  if (props.data === undefined || props.status === 'loading' || props.status === 'pending') {
     return <EntryCard isLoading />;
   }
 

--- a/packages/rich-text/src/plugins/Hyperlink/useResourceEntityInfo.ts
+++ b/packages/rich-text/src/plugins/Hyperlink/useResourceEntityInfo.ts
@@ -19,7 +19,7 @@ export function useResourceEntityInfo({ onEntityFetchComplete, target }: Resourc
     }
   }, [status, onEntityFetchComplete]);
 
-  if (status === 'loading') {
+  if (status === 'loading' || (status as string) === 'pending') {
     return `Loading entry...`;
   }
 
@@ -30,7 +30,7 @@ export function useResourceEntityInfo({ onEntityFetchComplete, target }: Resourc
   const title =
     truncateTitle(
       data.resource.fields[data.contentType.displayField]?.[data.defaultLocaleCode],
-      40
+      40,
     ) || 'Untitled';
 
   return `${data.contentType.name}: ${title} (Space: ${data.space.name} – Env.: ${data.resource.sys.environment.sys.id})`;

--- a/packages/rich-text/src/plugins/shared/FetchingWrappedAssetCard.tsx
+++ b/packages/rich-text/src/plugins/shared/FetchingWrappedAssetCard.tsx
@@ -116,7 +116,7 @@ export function FetchingWrappedAssetCard(props: FetchingWrappedAssetCardProps) {
     }
   }, [onEntityFetchComplete, status]);
 
-  if (status === 'loading' || status === 'idle') {
+  if (status === 'loading' || status === 'idle' || (status as string) === 'pending') {
     return <AssetCard size="default" isLoading />;
   }
 

--- a/packages/rich-text/src/plugins/shared/FetchingWrappedEntryCard.tsx
+++ b/packages/rich-text/src/plugins/shared/FetchingWrappedEntryCard.tsx
@@ -131,7 +131,7 @@ const InternalFetchingWrappedEntryCard = (props: FetchingWrappedEntryCardProps) 
     }
   }, [onEntityFetchComplete, status]);
 
-  if (status === 'loading' || status === 'idle') {
+  if (status === 'loading' || status === 'idle' || (status as string) === 'pending') {
     return <EntryCard isLoading />;
   }
 

--- a/packages/rich-text/src/plugins/shared/FetchingWrappedResourceCard.tsx
+++ b/packages/rich-text/src/plugins/shared/FetchingWrappedResourceCard.tsx
@@ -16,13 +16,13 @@ interface InternalEntryCard {
   isSelected: boolean;
   sdk: FieldAppSDK;
   data?: ResourceInfo<Entry>;
-  status: 'loading' | 'error' | 'success';
+  status: 'loading' | 'pending' | 'error' | 'success';
   onEdit?: VoidFunction;
   onRemove?: VoidFunction;
 }
 
 const InternalEntryCard = React.memo((props: InternalEntryCard) => {
-  if (props.data === undefined || props.status === 'loading') {
+  if (props.data === undefined || props.status === 'loading' || props.status === 'pending') {
     return <EntryCard isLoading />;
   }
 


### PR DESCRIPTION
## Summary

`FetchingWrapped*` components check `status === 'loading'` (react-query v4 terminology). When the host bundles react-query v5 — common in vite-bundled marketplace apps that hoist a v5 dependency over the v4 nested in `field-editor-reference` — `status` is `'pending'` instead. The loading branch is missed, the success branch renders with `data: undefined`, and `WrappedEntryCard` throws `Invalid entity metadata object`.

This builds on the existing v4/v5 compat work in `_shared/queryClient.tsx` (#2131, #2149), which handles client setup and query invocation but didn't update consumer-side status-string checks.

## Fix

Add `'pending'` to the existing `'loading'` (and where applicable `'idle'`) status checks in:

Where the local v4 type doesn't include `'pending'` in the `status` enum, the comparison uses `(status as string) === 'pending'` -- mirrors the existing `(IS_V5 ? ...)` pattern in `_shared/queryClient.tsx` that intentionally bypasses v4 types when the runtime is v5.

For the locally-typed `status: 'loading' | 'error' | 'success'` shape in `FetchingWrappedResourceCard`, `'pending'` is added to the union directly.

## What this PR does NOT do

- It does not consolidate the v4/v5 compat into a shared `isPendingStatus(status)` helper. That would be a larger refactor across `_shared` exports; this PR keeps the change localized to the affected components.
- It does not bump `@tanstack/react-query` version. Existing v4 pin in `_shared/package.json` stays.

## Test plan

- [x] All existing tests in affected packages still pass locally (no test failures introduced; pre-existing suite-level setup failures are unchanged).
- [x] Manual verification: in a marketplace app (rich-text-versioning) on a vite dev server with `@tanstack/react-query@5` hoisted, picking an entry from the picker no longer throws `Invalid entity metadata object`.

## Context

Surfaced while fixing a separate semantic-search bug in `entity-search`: contentful/experience-packages#3480. With that fix in place, suggested entries appear in the picker, and clicking one exercises this code path -- which was previously unreachable from the marketplace-app flow because the picker had no items to click on.
