### PR TITLE
fix(rich-text): list indentation in RTL [ES-319]

### DIFF
--- a/packages/rich-text/src/plugins/List/components/List.tsx
+++ b/packages/rich-text/src/plugins/List/components/List.tsx
@@ -7,7 +7,8 @@ import * as Slate from 'slate-react';
 
 const baseStyle = css`
   padding: 0;
-  margin: 0 0 1.25rem 1.25rem;
+  margin: 0 0 1.25rem 0;
+  margin-inline-start: 1.25rem;
   direction: inherit;
 
   div:first-child {

--- a/packages/rich-text/src/plugins/List/components/ListItem.tsx
+++ b/packages/rich-text/src/plugins/List/components/ListItem.tsx
@@ -12,7 +12,8 @@ const style = css`
 
   ol,
   ul {
-    margin: 0 0 0 ${tokens.spacingL};
+    margin: 0;
+    margin-inline-start: ${tokens.spacingL};
   }
 `;
 


### PR DESCRIPTION
## Summary

Lists in the rich text editor were indented from the left in both LTR and RTL. With `direction: rtl`, bullets/numbers correctly flipped to the right edge of text but the list itself was still pushed in from the left, so first-level lists looked flush against the right margin and nested lists compounded the misalignment.

Replace physical `margin-left` declarations with logical `margin-inline-start` in `List` and `ListItem`, so indentation follows the writing direction.

- `packages/rich-text/src/plugins/List/components/List.tsx`: outer `ul`/`ol` margin
- `packages/rich-text/src/plugins/List/components/ListItem.tsx`: nested `ul`/`ol` margin

Fixes [ES-319](https://contentful.atlassian.net/browse/ES-319).

## Test plan

- [x] `yarn jest src/plugins/List` in `packages/rich-text` — 40 tests pass
- [x] Manual: rich text field on an RTL locale (e.g. Arabic) — first-level UL/OL indent from the right edge
- [x] Manual: nested lists indent further to the right at each level
- [x] Manual: LTR locale unchanged (regression check)

[ES-319]: https://contentful.atlassian.net/browse/ES-319?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ