### PR TITLE
fix(rich-text): preserve cursor position on external value updates [ES-346]

### DIFF
--- a/packages/rich-text/src/internal/__tests__/transforms.test.ts
+++ b/packages/rich-text/src/internal/__tests__/transforms.test.ts
@@ -1,0 +1,71 @@
+import { createEditor as createSlateEditor } from '@udecode/plate-test-utils';
+import { describe, expect, it } from 'vitest';
+
+import { select } from '../transforms';
+import { setEditorValue } from '../transforms';
+import { PlateEditor, Element } from '../types';
+
+const paragraph = (text: string): Element => ({
+  type: 'paragraph',
+  data: {},
+  isVoid: false,
+  children: [{ text }],
+});
+
+const createEditor = (children: Element[]) =>
+  createSlateEditor('test-editor', {}, children) as PlateEditor;
+
+describe('setEditorValue', () => {
+  it('preserves cursor position when incoming value has the same structure', () => {
+    const initial = [paragraph('hello world')];
+    const editor = createEditor(initial);
+
+    // Place cursor at offset 5 (after "hello")
+    select(editor, { path: [0, 0], offset: 5 });
+    expect(editor.selection).toEqual({
+      anchor: { path: [0, 0], offset: 5 },
+      focus: { path: [0, 0], offset: 5 },
+    });
+
+    // Incoming value is identical content (simulates autosave round-trip)
+    const incoming = [paragraph('hello world')];
+    setEditorValue(editor, incoming);
+
+    expect(editor.selection).toEqual({
+      anchor: { path: [0, 0], offset: 5 },
+      focus: { path: [0, 0], offset: 5 },
+    });
+  });
+
+  it('clamps cursor to end when incoming value is shorter than current selection', () => {
+    const initial = [paragraph('hello world')];
+    const editor = createEditor(initial);
+
+    // Place cursor at offset 11 (end of "hello world")
+    select(editor, { path: [0, 0], offset: 11 });
+
+    // Incoming value is shorter — cursor path/offset is now out of bounds
+    const incoming = [paragraph('hi')];
+    setEditorValue(editor, incoming);
+
+    // Should clamp to end of "hi" (offset 2), not crash or jump arbitrarily
+    expect(editor.selection).toEqual({
+      anchor: { path: [0, 0], offset: 2 },
+      focus: { path: [0, 0], offset: 2 },
+    });
+  });
+
+  it('moves cursor to end when there is no prior selection', () => {
+    const initial = [paragraph('hello')];
+    const editor = createEditor(initial);
+    // No explicit selection set — editor.selection is null
+
+    const incoming = [paragraph('hello')];
+    setEditorValue(editor, incoming);
+
+    expect(editor.selection).toEqual({
+      anchor: { path: [0, 0], offset: 5 },
+      focus: { path: [0, 0], offset: 5 },
+    });
+  });
+});

--- a/packages/rich-text/src/internal/transforms.ts
+++ b/packages/rich-text/src/internal/transforms.ts
@@ -2,7 +2,7 @@ import * as p from '@udecode/plate-common';
 import * as s from 'slate';
 import { Except } from 'type-fest';
 
-import { getEndPoint, isNode } from './queries';
+import { getEndPoint, getNodeEntry, isNode, isText } from './queries';
 import {
   PlateEditor,
   Node,
@@ -181,12 +181,9 @@ export const setEditorValue = (editor: PlateEditor, nodes?: Node[]): void => {
 
     if (savedSelection && endPoint) {
       const clampPoint = (point: BasePoint): BasePoint => {
-        if (!s.Editor.hasPath(editor, point.path)) {
-          return endPoint;
-        }
-        const [node] = s.Editor.node(editor, point.path);
-        if (s.Text.isText(node)) {
-          return { path: point.path, offset: Math.min(point.offset, node.text.length) };
+        const entry = getNodeEntry(editor, point.path);
+        if (entry && isText(entry[0])) {
+          return { path: point.path, offset: Math.min(point.offset, entry[0].text.length) };
         }
         return endPoint;
       };

--- a/packages/rich-text/src/internal/transforms.ts
+++ b/packages/rich-text/src/internal/transforms.ts
@@ -160,6 +160,8 @@ export const deleteFragment = (
  * https://github.com/udecode/plate/issues/1269#issuecomment-1057643622
  */
 export const setEditorValue = (editor: PlateEditor, nodes?: Node[]): void => {
+  const savedSelection = editor.selection;
+
   // Replaces editor content while keeping change history
   withoutNormalizing(editor, () => {
     const children = [...editor.children];
@@ -172,9 +174,25 @@ export const setEditorValue = (editor: PlateEditor, nodes?: Node[]): void => {
       });
     }
 
-    const point = getEndPoint(editor, []);
-    if (point) {
-      select(editor, point);
+    // Restore the prior selection, clamping to valid bounds in the new content.
+    // Without this, every external value update (e.g. autosave round-trip) moves the
+    // cursor to the end of the document, interrupting the user mid-type.
+    const endPoint = getEndPoint(editor, []);
+
+    if (savedSelection && endPoint) {
+      const clampPoint = (point: BasePoint): BasePoint => {
+        if (!s.Editor.hasPath(editor, point.path)) {
+          return endPoint;
+        }
+        const [node] = s.Editor.node(editor, point.path);
+        if (s.Text.isText(node)) {
+          return { path: point.path, offset: Math.min(point.offset, node.text.length) };
+        }
+        return endPoint;
+      };
+      select(editor, { anchor: clampPoint(savedSelection.anchor), focus: clampPoint(savedSelection.focus) });
+    } else if (endPoint) {
+      select(editor, endPoint);
     }
   });
 };


### PR DESCRIPTION
## Summary

Preserve the editor cursor position when `setEditorValue` is called with an incoming value (e.g. after an autosave round-trip). Previously the function always moved the cursor to the end of the document after replacing nodes, causing visible cursor jumps while typing.

The fix captures `editor.selection` before the node replacement and restores it afterward, clamping anchor/focus offsets to valid bounds if the incoming content is shorter than what was previously selected.

## Ticket

https://contentful.atlassian.net/browse/ES-346

## Why

When autosave fires, `CmaDocument` calls `field.onValueChanged` with the server-returned value. `FieldConnector` classifies this as a remote change (because the server value lags one or more local keystrokes), which causes `SyncEditorChanges` → `setEditorValue` to run. The unconditional `select(editor, getEndPoint(...))` at the end of `setEditorValue` then jumps the cursor to end-of-document, interrupting the user mid-type.

## Risk and Rollout

Low risk. The change is confined to `setEditorValue` in `internal/transforms.ts`. Behaviour is unchanged when there is no prior selection (cursor goes to end as before). Three new unit tests cover: cursor preserved on same-shape content, offset clamped when content is shorter, and end-of-doc fallback when no prior selection exists.
