### PR TITLE
feat: setup axe vitest [UFO-2309]

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,7 +128,7 @@ yarn tsc
 
 ### Tests
 
-We use [Jest](https://jestjs.io/) and [Testing Library](https://testing-library.com/) for writing unit tests.
+We use [Vitest](https://vitest.dev/) and [Testing Library](https://testing-library.com/) for writing unit tests.
 
 #### Run tests for concrete package
 
@@ -144,8 +144,71 @@ yarn test
 yarn test:ci
 ```
 
+#### Accessibility tests
+
+We use [`vitest-axe`](https://github.com/nicholasgasior/vitest-axe) for automated accessibility checks. The `toHaveNoViolations` matcher is globally available — no import needed.
+
+Every component needs axe coverage across its meaningful states. A single test on the default render is not sufficient: a component that passes in its default state can still have violations when disabled, in an error state, or with different content rendered. Cover each state where the DOM structure or ARIA attributes change.
+
+```tsx
+import { axe } from 'vitest-axe';
+import { render } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { createFakeFieldAPI, createFakeLocalesAPI } from '@contentful/field-editor-test-utils';
+
+import { SingleLineEditor } from './SingleLineEditor';
+
+describe('SingleLineEditor accessibility', () => {
+  it('has no violations in default state', async () => {
+    const [field] = createFakeFieldAPI((f) => ({ ...f, type: 'Symbol' }));
+    const { container } = render(
+      <SingleLineEditor
+        field={field}
+        isInitiallyDisabled={false}
+        locales={createFakeLocalesAPI()}
+      />,
+    );
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  it('has no violations when disabled', async () => {
+    const [field] = createFakeFieldAPI((f) => ({ ...f, type: 'Symbol' }));
+    const { container } = render(
+      <SingleLineEditor
+        field={field}
+        isInitiallyDisabled={true}
+        locales={createFakeLocalesAPI()}
+      />,
+    );
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  it('has no violations with a validation error', async () => {
+    const [field, mitt] = createFakeFieldAPI((f) => ({ ...f, type: 'Symbol' }));
+    const { container } = render(
+      <SingleLineEditor
+        field={field}
+        isInitiallyDisabled={false}
+        locales={createFakeLocalesAPI()}
+      />,
+    );
+    // trigger an error state before asserting
+    act(() => mitt.emit('schemaErrors', [{ message: 'Required' }]));
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});
+```
+
+What to cover per component:
+
+- **Default / empty** — baseline render with no value
+- **Filled** — rendered with actual content (especially relevant for rich text or media editors where content changes the DOM)
+- **Disabled** — `isInitiallyDisabled={true}`
+- **Error / validation state** — after schema errors are emitted
+- Any state that adds or removes interactive elements (e.g. dialogs, popovers, expanded panels)
+
 #### Links
 
 - [`@testing-library/react` documentation](https://testing-library.com/docs/react-testing-library/intro)
-- [`jest` documentation](https://testing-library.com/docs/react-testing-library/intro)
-- [`jest` cheat sheet](https://github.com/sapegin/jest-cheat-sheet)
+- [`vitest` documentation](https://vitest.dev/guide/)
+- [`vitest-axe` documentation](https://github.com/nicholasgasior/vitest-axe)

--- a/package.json
+++ b/package.json
@@ -126,6 +126,7 @@
     "typescript": "5.3.3",
     "vite": "^8.0.14",
     "vitest": "^4.1.7",
+    "vitest-axe": "^0.1.0",
     "webpack": "5.104.1"
   },
   "resolutions": {

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,7 +1,10 @@
 import { cleanup } from '@testing-library/react';
-import { afterEach, vi } from 'vitest';
+import { afterEach, vi, expect } from 'vitest';
 
 import '@testing-library/jest-dom/vitest';
+import * as matchers from 'vitest-axe/matchers';
+
+expect.extend(matchers);
 
 afterEach(() => {
   cleanup();

--- a/yarn.lock
+++ b/yarn.lock
@@ -10594,7 +10594,7 @@ axe-core@^4.10.0:
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.10.3.tgz#04145965ac7894faddbac30861e5d8f11bfd14fc"
   integrity sha512-Xm7bpRXnDSX2YE2YFfBk2FnF0ep6tmG7xPh8iHee8MIcrgq762Nkce856dYtJYLkuIoYZvGfTs/PbZhideTcEg==
 
-axe-core@^4.2.0:
+axe-core@^4.2.0, axe-core@^4.4.2:
   version "4.12.1"
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.12.1.tgz#69fe2bf6dfc0b24973af91b1d8e945f79e1b7c44"
   integrity sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==
@@ -13581,7 +13581,7 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
-dom-accessibility-api@^0.5.6, dom-accessibility-api@^0.5.9:
+dom-accessibility-api@^0.5.14, dom-accessibility-api@^0.5.6, dom-accessibility-api@^0.5.9:
   version "0.5.16"
   resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz#5a7429e6066eb3664d911e33fb0e45de8eb08453"
   integrity sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==
@@ -19005,7 +19005,7 @@ locate-path@^7.2.0:
   dependencies:
     p-locate "^6.0.0"
 
-lodash-es@^4.17.15:
+lodash-es@^4.17.15, lodash-es@^4.17.21:
   version "4.18.1"
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.18.1.tgz#b962eeb80d9d983a900bf342961fb7418ca10b1d"
   integrity sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==
@@ -26762,6 +26762,18 @@ vfile@^6.0.0:
     tinyglobby "^0.2.16"
   optionalDependencies:
     fsevents "~2.3.3"
+
+vitest-axe@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/vitest-axe/-/vitest-axe-0.1.0.tgz#34f714e5af31d579d7e2ca906d6b95207a1006ec"
+  integrity sha512-jvtXxeQPg8R/2ANTY8QicA5pvvdRP4F0FsVUAHANJ46YCDASie/cuhlSzu0DGcLmZvGBSBNsNuK3HqfaeknyvA==
+  dependencies:
+    aria-query "^5.0.0"
+    axe-core "^4.4.2"
+    chalk "^5.0.1"
+    dom-accessibility-api "^0.5.14"
+    lodash-es "^4.17.21"
+    redent "^3.0.0"
 
 vitest@^4.1.7:
   version "4.1.7"


### PR DESCRIPTION
## Purpose

this PR introduces the axe-plugin for vitest. It enables unit-test-based accessibility testing and extends the contribution guideline explaining the usage of the axe plugin.

## Example

```
import { describe, expect, it } from 'vitest';
import { axe } from 'vitest-axe';

describe('RadioEditor', () => {
  it('has no accessibility violations when rendering', async ()=> {
     const { container } = render(
      <RadioEditor field={field} locales={createFakeLocalesAPI()} isInitiallyDisabled={false} />,
    );
    expect(await axe(container)).toHaveNoViolations();
  }
}
```
