### PR TITLE
feat: [UFO-2426] enable axe for cypress

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -144,11 +144,34 @@ yarn test
 yarn test:ci
 ```
 
-#### Accessibility tests
+#### Links
 
-We use [`vitest-axe`](https://github.com/nicholasgasior/vitest-axe) for automated accessibility checks. The `toHaveNoViolations` matcher is globally available — no import needed.
+- [`@testing-library/react` documentation](https://testing-library.com/docs/react-testing-library/intro)
+- [`vitest` documentation](https://vitest.dev/guide/)
+
+## Accessibility
+
+The repo has three complementary layers of accessibility tooling, active at different points in the development workflow.
+
+### Storybook (`@storybook/addon-a11y`)
+
+The accessibility addon is pre-configured. Run `yarn start` and open any story — the **Accessibility** panel shows live axe results as you develop.
+
+### Unit tests (`vitest-axe`)
+
+We use [`vitest-axe`](https://github.com/nicholasgasior/vitest-axe) for automated accessibility checks in unit tests. The `toHaveNoViolations` matcher is globally available.
 
 Every component needs axe coverage across its meaningful states. A single test on the default render is not sufficient: a component that passes in its default state can still have violations when disabled, in an error state, or with different content rendered. Cover each state where the DOM structure or ARIA attributes change.
+
+What to cover per component:
+
+- **Default / empty** — baseline render with no value
+- **Filled** — rendered with actual content (especially relevant for rich text or media editors where content changes the DOM)
+- **Disabled** — if element can be rendered in a disabled state
+- **Error / validation state** — after errors are emitted
+- Any state that adds or removes interactive elements (e.g. dialogs, popovers, expanded panels)
+
+#### Example unit test
 
 ```tsx
 import { axe } from 'vitest-axe';
@@ -199,16 +222,33 @@ describe('SingleLineEditor accessibility', () => {
 });
 ```
 
-What to cover per component:
+### Component tests (`cypress-axe`)
 
-- **Default / empty** — baseline render with no value
-- **Filled** — rendered with actual content (especially relevant for rich text or media editors where content changes the DOM)
-- **Disabled** — `isInitiallyDisabled={true}`
-- **Error / validation state** — after schema errors are emitted
-- Any state that adds or removes interactive elements (e.g. dialogs, popovers, expanded panels)
+Component tests have `cypress-axe` wired up via `cypress/support/component.ts`. Use `cy.checkA11y()` to assert no violations after mounting a component.
 
-#### Links
+Axe is injected lazily on the first `cy.checkA11y()` call. Four structural rules are globally disabled as they do not apply to isolated component tests: `html-has-lang`, `landmark-one-main`, `page-has-heading-one`, `region`. Violations are printed to the terminal for readable CI output.
 
-- [`@testing-library/react` documentation](https://testing-library.com/docs/react-testing-library/intro)
-- [`vitest` documentation](https://vitest.dev/guide/)
+To scope the check or disable a rule for one test:
+
+```ts
+// Check only a specific element
+cy.checkA11y('[role="dialog"]');
+
+// Disable a rule for one test
+cy.checkA11y(undefined, { rules: { 'color-contrast': { enabled: false } } });
+```
+
+#### Example component test
+
+```ts
+it('has no a11y violations', () => {
+  cy.mount(<MyComponent />);
+  cy.checkA11y();
+});
+```
+
+### Further reading
+
 - [`vitest-axe` documentation](https://github.com/nicholasgasior/vitest-axe)
+- [`cypress-axe` documentation](https://github.com/component-driven/cypress-axe)
+- [`@storybook/addon-a11y` documentation](https://storybook.js.org/docs/writing-tests/accessibility-testing)

--- a/cypress/component/markdown/MarkdownEditorHistory.spec.ts
+++ b/cypress/component/markdown/MarkdownEditorHistory.spec.ts
@@ -7,6 +7,10 @@ import {
 } from './utils';
 
 describe('Markdown Editor / History', () => {
+  beforeEach(() => {
+    cy.viewport(1280, 720);
+  });
+
   const selectors = {
     getToggleAdditionalActionsButton: () => {
       return cy.findByRole('button', { name: 'More actions' });
@@ -40,6 +44,8 @@ describe('Markdown Editor / History', () => {
 
     clickVisibleButtonByName('Undo');
     cy.get('@removeValue').should('be.calledOnce');
+
+    selectors.getRedoButton().should('be.visible');
 
     clickVisibleButtonByName('Redo');
     checkValue('Hello!\n');

--- a/cypress/component/rich-text/RichTextEditor.Commands.spec.ts
+++ b/cypress/component/rich-text/RichTextEditor.Commands.spec.ts
@@ -126,7 +126,7 @@ describe('Rich Text Editor - Commands', { viewportHeight: 2000, viewportWidth: 1
       getCommandList().findByText('Embed Example Content Type').should('exist');
       richText.editor.type('{enter}');
       richText.editor.type('{enter}');
-      richText.editor.type('{downarrow}');
+      cy.realPress('ArrowDown');
 
       cy.findByRole('article').should('exist');
 
@@ -140,8 +140,8 @@ describe('Rich Text Editor - Commands', { viewportHeight: 2000, viewportWidth: 1
       getCommandList().findByText('Embed Example Content Type').should('exist');
       richText.editor.type('{enter}');
       richText.editor.type('{enter}');
-      richText.editor.type('{downarrow}');
-      richText.editor.type('{uparrow}');
+      cy.realPress('ArrowDown');
+      cy.realPress('ArrowUp');
       cy.findByRole('article').should('exist');
 
       //check for the CSS style that indicates it is not selected

--- a/cypress/component/rich-text/RichTextEditor.EmbeddedAssetBlocks.spec.ts
+++ b/cypress/component/rich-text/RichTextEditor.EmbeddedAssetBlocks.spec.ts
@@ -68,7 +68,7 @@ describe(
           richText.editor.trigger('keydown', KEYS.enter);
 
           richText.expectValue(
-            doc(emptyParagraph(), assetBlock(), emptyParagraph(), assetBlock(), emptyParagraph())
+            doc(emptyParagraph(), assetBlock(), emptyParagraph(), assetBlock(), emptyParagraph()),
           );
         });
 
@@ -96,17 +96,18 @@ describe(
         });
 
         it('adds embedded assets between words', () => {
-          richText.editor
-            .click()
-            .type('foobar{leftarrow}{leftarrow}{leftarrow}')
-            .then(triggerEmbeddedAsset);
+          richText.editor.click().type('foobar');
+          cy.realPress('ArrowLeft');
+          cy.realPress('ArrowLeft');
+          cy.realPress('ArrowLeft');
+          richText.editor.then(triggerEmbeddedAsset);
 
           richText.expectValue(
             doc(
               block(BLOCKS.PARAGRAPH, {}, text('foo')),
               assetBlock(),
-              block(BLOCKS.PARAGRAPH, {}, text('bar'))
-            )
+              block(BLOCKS.PARAGRAPH, {}, text('bar')),
+            ),
           );
         });
 
@@ -114,7 +115,8 @@ describe(
           richText.editor.click();
           triggerEmbeddedAsset();
 
-          richText.editor.type('{downarrow}X');
+          cy.realPress('ArrowDown');
+          richText.editor.type('X');
 
           richText.expectValue(doc(assetBlock(), paragraphWithText('X')));
 
@@ -128,5 +130,5 @@ describe(
         });
       });
     }
-  }
+  },
 );

--- a/cypress/component/rich-text/RichTextEditor.EmbeddedEntryBlocks.spec.ts
+++ b/cypress/component/rich-text/RichTextEditor.EmbeddedEntryBlocks.spec.ts
@@ -108,10 +108,11 @@ describe(
           });
 
           it('adds embedded entries between words', () => {
-            richText.editor
-              .click()
-              .type('foobar{leftarrow}{leftarrow}{leftarrow}')
-              .then(triggerEmbeddedEntry);
+            richText.editor.click().type('foobar');
+            cy.realPress('ArrowLeft');
+            cy.realPress('ArrowLeft');
+            cy.realPress('ArrowLeft');
+            richText.editor.then(triggerEmbeddedEntry);
 
             richText.expectValue(
               doc(
@@ -126,7 +127,8 @@ describe(
             richText.editor.click();
             triggerEmbeddedEntry();
 
-            richText.editor.type('{downarrow}X');
+            cy.realPress('ArrowDown');
+            richText.editor.type('X');
 
             richText.expectValue(doc(entryBlock(), paragraphWithText('X')));
 

--- a/cypress/component/rich-text/RichTextEditor.EmbeddedResourceBlocks.spec.ts
+++ b/cypress/component/rich-text/RichTextEditor.EmbeddedResourceBlocks.spec.ts
@@ -55,7 +55,7 @@ describe(
 
           richText.editor
             .find(
-              '[data-entity-id="crn:contentful:::content:spaces/indifferent/entries/published-entry"]'
+              '[data-entity-id="crn:contentful:::content:spaces/indifferent/entries/published-entry"]',
             )
             .click();
 
@@ -76,7 +76,7 @@ describe(
           // Inserts paragraph before embed because it's in the first line.
           richText.editor
             .find(
-              '[data-entity-id="crn:contentful:::content:spaces/indifferent/entries/published-entry"]'
+              '[data-entity-id="crn:contentful:::content:spaces/indifferent/entries/published-entry"]',
             )
             .first()
             .click();
@@ -85,7 +85,7 @@ describe(
           // inserts paragraph in-between embeds.
           richText.editor
             .find(
-              '[data-entity-id="crn:contentful:::content:spaces/indifferent/entries/published-entry"]'
+              '[data-entity-id="crn:contentful:::content:spaces/indifferent/entries/published-entry"]',
             )
             .first()
             .click();
@@ -97,8 +97,8 @@ describe(
               resourceBlock(),
               emptyParagraph(),
               resourceBlock(),
-              emptyParagraph()
-            )
+              emptyParagraph(),
+            ),
           );
         });
 
@@ -126,17 +126,18 @@ describe(
         });
 
         it('adds embedded resource between words', () => {
-          richText.editor
-            .click()
-            .type('foobar{leftarrow}{leftarrow}{leftarrow}')
-            .then(triggerEmbeddedResource);
+          richText.editor.click().type('foobar');
+          cy.realPress('ArrowLeft');
+          cy.realPress('ArrowLeft');
+          cy.realPress('ArrowLeft');
+          richText.editor.then(triggerEmbeddedResource);
 
           richText.expectValue(
             doc(
               block(BLOCKS.PARAGRAPH, {}, text('foo')),
               resourceBlock(),
-              block(BLOCKS.PARAGRAPH, {}, text('bar'))
-            )
+              block(BLOCKS.PARAGRAPH, {}, text('bar')),
+            ),
           );
         });
 
@@ -144,7 +145,8 @@ describe(
           richText.editor.click();
           triggerEmbeddedResource();
 
-          richText.editor.type('{downarrow}X');
+          cy.realPress('ArrowDown');
+          richText.editor.type('X');
 
           richText.expectValue(doc(resourceBlock(), paragraphWithText('X')));
 
@@ -168,5 +170,5 @@ describe(
 
       richText.expectValue(doc(resourceBlock(), resourceBlock(), emptyParagraph()));
     });
-  }
+  },
 );

--- a/cypress/component/rich-text/RichTextEditor.HR.spec.ts
+++ b/cypress/component/rich-text/RichTextEditor.HR.spec.ts
@@ -20,7 +20,7 @@ describe('Rich Text Editor - HR', { viewportHeight: 2000, viewportWidth: 1000 },
 
     const expectedValue = doc(
       block(BLOCKS.QUOTE, {}, block(BLOCKS.PARAGRAPH, {}, text(content, []))),
-      block(BLOCKS.PARAGRAPH, {}, text('', []))
+      block(BLOCKS.PARAGRAPH, {}, text('', [])),
     );
 
     richText.expectValue(expectedValue);
@@ -48,7 +48,7 @@ describe('Rich Text Editor - HR', { viewportHeight: 2000, viewportWidth: 1000 },
       const expectedValue = doc(
         block(BLOCKS.PARAGRAPH, {}, text('some text', [])),
         block(BLOCKS.HR, {}),
-        block(BLOCKS.PARAGRAPH, {}, text('', []))
+        block(BLOCKS.PARAGRAPH, {}, text('', [])),
       );
 
       richText.expectValue(expectedValue);
@@ -74,7 +74,7 @@ describe('Rich Text Editor - HR', { viewportHeight: 2000, viewportWidth: 1000 },
         block(BLOCKS.HR, {}),
         block(BLOCKS.HR, {}),
         block(BLOCKS.HR, {}),
-        block(BLOCKS.PARAGRAPH, {}, text('', []))
+        block(BLOCKS.PARAGRAPH, {}, text('', [])),
       );
 
       richText.expectValue(expectedValue);
@@ -83,7 +83,8 @@ describe('Rich Text Editor - HR', { viewportHeight: 2000, viewportWidth: 1000 },
     it('should split blockquote', () => {
       addBlockquote('some text');
 
-      richText.editor.type('{enter}some text{uparrow}');
+      richText.editor.type('{enter}some text');
+      cy.realPress('ArrowUp');
 
       richText.editor.should('be.focused');
       richText.toolbar.hr.click();
@@ -93,7 +94,7 @@ describe('Rich Text Editor - HR', { viewportHeight: 2000, viewportWidth: 1000 },
         block(BLOCKS.QUOTE, {}, block(BLOCKS.PARAGRAPH, {}, text('some text', []))),
         block(BLOCKS.HR, {}),
         block(BLOCKS.QUOTE, {}, block(BLOCKS.PARAGRAPH, {}, text('some text', []))),
-        block(BLOCKS.PARAGRAPH, {}, text('', []))
+        block(BLOCKS.PARAGRAPH, {}, text('', [])),
       );
 
       richText.expectValue(expectedValue);
@@ -111,12 +112,13 @@ describe('Rich Text Editor - HR', { viewportHeight: 2000, viewportWidth: 1000 },
       richText.expectValue(doc(block(BLOCKS.HR, {}), block(BLOCKS.PARAGRAPH, {}, text('', []))));
 
       // Move arrow up to select the HR then press ENTER
-      focusEditorAndType(richText, '{uparrow}{enter}');
+      cy.realPress('ArrowUp');
+      richText.editor.type('{enter}');
 
       const expectedValue = doc(
         block(BLOCKS.PARAGRAPH, {}, text('', [])),
         block(BLOCKS.HR, {}),
-        block(BLOCKS.PARAGRAPH, {}, text('', []))
+        block(BLOCKS.PARAGRAPH, {}, text('', [])),
       );
 
       richText.expectValue(expectedValue);

--- a/cypress/component/rich-text/RichTextEditor.Headings.spec.ts
+++ b/cypress/component/rich-text/RichTextEditor.Headings.spec.ts
@@ -45,7 +45,7 @@ describe('Rich Text Editor - Headings', { viewportHeight: 2000, viewportWidth: 1
 
     const expectedValue = doc(
       block(BLOCKS.QUOTE, {}, block(BLOCKS.PARAGRAPH, {}, text(content, []))),
-      block(BLOCKS.PARAGRAPH, {}, text('', []))
+      block(BLOCKS.PARAGRAPH, {}, text('', [])),
     );
 
     richText.expectValue(expectedValue);
@@ -104,7 +104,7 @@ describe('Rich Text Editor - Headings', { viewportHeight: 2000, viewportWidth: 1
 
           const expectedHeadingValue = doc(
             block(type, {}, text('some text', [])),
-            block(BLOCKS.PARAGRAPH, {}, text('', []))
+            block(BLOCKS.PARAGRAPH, {}, text('', [])),
           );
 
           richText.expectValue(expectedHeadingValue);
@@ -131,10 +131,12 @@ describe('Rich Text Editor - Headings', { viewportHeight: 2000, viewportWidth: 1
         // To make sure paragraph/heading is present
         richText.expectValue(doc(block(type, {}, text('x')), entryBlock(), emptyParagraph()));
 
-        richText.editor
-          .click('bottom')
-          // Using `delay` to avoid flakiness, cypress triggers a keypress every 10ms and the editor was not responding correctly
-          .type('{uparrow}{uparrow}{uparrow}{del}{del}', { delay: 100 });
+        // Using `delay` to avoid flakiness, cypress triggers a keypress every 10ms and the editor was not responding correctly
+        richText.editor.click('bottom');
+        cy.realPress('ArrowUp');
+        cy.realPress('ArrowUp');
+        cy.realPress('ArrowUp');
+        richText.editor.type('{del}{del}', { delay: 100 });
 
         richText.expectValue(doc(entryBlock(), emptyParagraph()));
       });
@@ -148,7 +150,8 @@ describe('Rich Text Editor - Headings', { viewportHeight: 2000, viewportWidth: 1
         richText.toolbar.embed('entry-block');
 
         // Using `delay` to avoid flakiness, cypress triggers a keypress every 10ms and the editor was not responding correcrly
-        richText.editor.type('{leftarrow}{del}', { delay: 100 });
+        cy.realPress('ArrowLeft');
+        richText.editor.type('{del}', { delay: 100 });
 
         richText.expectValue(doc(block(type, {}, text(value)), emptyParagraph()));
       });

--- a/cypress/component/rich-text/RichTextEditor.Marks.spec.ts
+++ b/cypress/component/rich-text/RichTextEditor.Marks.spec.ts
@@ -73,6 +73,8 @@ describe('Rich Text Editor - Marks', { viewportHeight: 2000, viewportWidth: 1000
       it('allows writing marked text by selecting text', () => {
         richText.editor.click().type('some text{selectall}');
 
+        cy.wait(100); // eslint-disable-line cypress/no-unnecessary-waiting
+
         toggleMarkViaToolbar(mark);
 
         const expectedValue = doc(block(BLOCKS.PARAGRAPH, {}, text('some text', [{ type: mark }])));
@@ -96,6 +98,8 @@ describe('Rich Text Editor - Marks', { viewportHeight: 2000, viewportWidth: 1000
       it('allows writing unmarked text by selecting text', () => {
         richText.editor.click().type('some text{selectall}');
 
+        cy.wait(100); // eslint-disable-line cypress/no-unnecessary-waiting
+
         toggleMarkViaToolbar(mark);
 
         // Wait until the mark is applied
@@ -117,7 +121,7 @@ describe('Rich Text Editor - Marks', { viewportHeight: 2000, viewportWidth: 1000
           richText.editor.click().type(shortcut).type('some text');
 
           const expectedValue = doc(
-            block(BLOCKS.PARAGRAPH, {}, text('some text', [{ type: mark }]))
+            block(BLOCKS.PARAGRAPH, {}, text('some text', [{ type: mark }])),
           );
 
           richText.expectValue(expectedValue);
@@ -131,7 +135,7 @@ describe('Rich Text Editor - Marks', { viewportHeight: 2000, viewportWidth: 1000
           richText.editor.type('{selectall}').type(shortcut);
 
           const expectedValue = doc(
-            block(BLOCKS.PARAGRAPH, {}, text('some text', [{ type: mark }]))
+            block(BLOCKS.PARAGRAPH, {}, text('some text', [{ type: mark }])),
           );
 
           richText.expectValue(expectedValue);
@@ -167,7 +171,11 @@ describe('Rich Text Editor - Marks', { viewportHeight: 2000, viewportWidth: 1000
     toggleMarkViaToolbar(MARKS.SUPERSCRIPT);
 
     const expectedValue = doc(
-      block(BLOCKS.PARAGRAPH, {}, text('should only be superscript', [{ type: MARKS.SUPERSCRIPT }]))
+      block(
+        BLOCKS.PARAGRAPH,
+        {},
+        text('should only be superscript', [{ type: MARKS.SUPERSCRIPT }]),
+      ),
     );
     richText.expectValue(expectedValue);
   });
@@ -179,7 +187,7 @@ describe('Rich Text Editor - Marks', { viewportHeight: 2000, viewportWidth: 1000
     toggleMarkViaToolbar(MARKS.SUBSCRIPT);
 
     const expectedValue = doc(
-      block(BLOCKS.PARAGRAPH, {}, text('should only be subscript', [{ type: MARKS.SUBSCRIPT }]))
+      block(BLOCKS.PARAGRAPH, {}, text('should only be subscript', [{ type: MARKS.SUBSCRIPT }])),
     );
     richText.expectValue(expectedValue);
   });

--- a/cypress/component/rich-text/RichTextEditor.Pasting.spec.ts
+++ b/cypress/component/rich-text/RichTextEditor.Pasting.spec.ts
@@ -60,17 +60,17 @@ describe(
             inline(
               'hyperlink',
               { uri: 'https://be.contentful.com' },
-              text('with link', [mark('underline')])
+              text('with link', [mark('underline')]),
             ),
             text(' and some more text'),
             inline(
               'hyperlink',
               { uri: 'https://be.contentful.com' },
               text(' '),
-              text('and another link', [mark('underline')])
+              text('and another link', [mark('underline')]),
             ),
-            text(' following.')
-          )
+            text(' following.'),
+          ),
         );
 
         richText.expectValue(expectedValue);
@@ -105,7 +105,7 @@ describe(
                 },
               },
             }),
-            text('')
+            text(''),
           ),
           block(
             BLOCKS.PARAGRAPH,
@@ -122,10 +122,10 @@ describe(
                   },
                 },
               },
-              text('resourceHyperlink')
+              text('resourceHyperlink'),
             ),
-            text('')
-          )
+            text(''),
+          ),
         );
 
         richText.expectValue(expectedValue);
@@ -144,9 +144,9 @@ describe(
             'unordered-list',
             {},
             block('list-item', {}, block('paragraph', {}, text('item #1'))),
-            block('list-item', {}, block('paragraph', {}, text('item #2')))
+            block('list-item', {}, block('paragraph', {}, text('item #2'))),
           ),
-          block('paragraph', {}, text())
+          block('paragraph', {}, text()),
         );
 
         richText.expectValue(expectedValue);
@@ -175,13 +175,13 @@ describe(
                 inline(
                   'hyperlink',
                   { uri: 'https://www.google.com/' },
-                  text('item', [mark('underline')])
+                  text('item', [mark('underline')]),
                 ),
-                text(' with a background colors')
-              )
-            )
+                text(' with a background colors'),
+              ),
+            ),
           ),
-          block('paragraph', {}, text())
+          block('paragraph', {}, text()),
         );
 
         richText.expectValue(expectedValue);
@@ -201,9 +201,9 @@ describe(
           block(
             BLOCKS.UL_LIST,
             {},
-            block(BLOCKS.LIST_ITEM, {}, block(BLOCKS.PARAGRAPH, {}, text('Hello world!')))
+            block(BLOCKS.LIST_ITEM, {}, block(BLOCKS.PARAGRAPH, {}, text('Hello world!'))),
           ),
-          block(BLOCKS.PARAGRAPH, {}, text(''))
+          block(BLOCKS.PARAGRAPH, {}, text('')),
         );
 
         richText.expectValue(expectedValue);
@@ -240,11 +240,11 @@ describe(
                     },
                   },
                 }),
-                text('')
-              )
-            )
+                text(''),
+              ),
+            ),
           ),
-          block(BLOCKS.PARAGRAPH, {}, text(''))
+          block(BLOCKS.PARAGRAPH, {}, text('')),
         );
 
         richText.expectValue(expectedValue);
@@ -281,7 +281,7 @@ describe(
                       },
                     },
                   },
-                  text('resourceHyperlink')
+                  text('resourceHyperlink'),
                 ),
                 text(' '),
                 text('and an inline resource link: '),
@@ -294,11 +294,11 @@ describe(
                     },
                   },
                 }),
-                text('')
-              )
-            )
+                text(''),
+              ),
+            ),
           ),
-          block(BLOCKS.PARAGRAPH, {}, text(''))
+          block(BLOCKS.PARAGRAPH, {}, text('')),
         );
 
         richText.expectValue(expectedValue);
@@ -354,12 +354,12 @@ describe(
                 block(
                   BLOCKS.LIST_ITEM,
                   {},
-                  block(BLOCKS.PARAGRAPH, {}, text('world!', [mark(MARKS.BOLD)]))
-                )
-              )
-            )
+                  block(BLOCKS.PARAGRAPH, {}, text('world!', [mark(MARKS.BOLD)])),
+                ),
+              ),
+            ),
           ),
-          block(BLOCKS.PARAGRAPH, {}, text(''))
+          block(BLOCKS.PARAGRAPH, {}, text('')),
         );
 
         richText.expectValue(expectedValue);
@@ -394,13 +394,13 @@ describe(
                 {},
                 text('Header 2 ('),
                 inline(INLINES.HYPERLINK, { uri: 'https://example.com' }, text('with link')),
-                text(')')
+                text(')'),
               ),
               block(BLOCKS.PARAGRAPH, {}, text('Cell 1', [mark(MARKS.BOLD)])),
-              block(BLOCKS.PARAGRAPH, {}, text('Cell 2'))
-            )
+              block(BLOCKS.PARAGRAPH, {}, text('Cell 2')),
+            ),
           ),
-          block(BLOCKS.PARAGRAPH, {}, text(''))
+          block(BLOCKS.PARAGRAPH, {}, text('')),
         );
 
         richText.expectValue(expectedValue);
@@ -436,7 +436,7 @@ describe(
               'table-row',
               {},
               block('table-header-cell', {}, block('paragraph', {}, text('Property'))),
-              block('table-header-cell', {}, block('paragraph', {}, text('Supported')))
+              block('table-header-cell', {}, block('paragraph', {}, text('Supported'))),
             ),
             block(
               'table-row',
@@ -444,15 +444,15 @@ describe(
               block(
                 'table-cell',
                 {},
-                block('paragraph', {}, text('Adding and removing rows and columns'))
+                block('paragraph', {}, text('Adding and removing rows and columns')),
               ),
-              block('table-cell', {}, block('paragraph', {}, text('Yes')))
+              block('table-cell', {}, block('paragraph', {}, text('Yes'))),
             ),
             block(
               'table-row',
               {},
               block('table-cell', {}, block('paragraph', {}, text('Table header'))),
-              block('table-cell', {}, block('paragraph', {}, text('Yes, for rows and columns')))
+              block('table-cell', {}, block('paragraph', {}, text('Yes, for rows and columns'))),
             ),
             block(
               'table-row',
@@ -470,9 +470,9 @@ describe(
                   text(','),
                   text('underline', [mark('underline')]),
                   text(','),
-                  text('code', [mark('code')])
-                )
-              )
+                  text('code', [mark('code')]),
+                ),
+              ),
             ),
             block(
               'table-row',
@@ -492,7 +492,7 @@ describe(
                     {
                       target: { sys: { id: 'published_asset', type: 'Link', linkType: 'Asset' } },
                     },
-                    text('asset')
+                    text('asset'),
                   ),
                   text(' and '),
                   inline(
@@ -500,11 +500,11 @@ describe(
                     {
                       target: { sys: { id: 'published-entry', type: 'Link', linkType: 'Entry' } },
                     },
-                    text('entry')
+                    text('entry'),
                   ),
-                  text('')
-                )
-              )
+                  text(''),
+                ),
+              ),
             ),
             block(
               'table-row',
@@ -520,9 +520,9 @@ describe(
                   inline('embedded-entry-inline', {
                     target: { sys: { id: 'published-entry', type: 'Link', linkType: 'Entry' } },
                   }),
-                  text('')
-                )
-              )
+                  text(''),
+                ),
+              ),
             ),
             block(
               'table-row',
@@ -530,16 +530,16 @@ describe(
               block(
                 'table-cell',
                 {},
-                block('paragraph', {}, text('Copy & paste from other documents'))
+                block('paragraph', {}, text('Copy & paste from other documents')),
               ),
               block(
                 'table-cell',
                 {},
-                block('paragraph', {}, text('Yes. Eg. Google Docs, Jira, Confluence'))
-              )
-            )
+                block('paragraph', {}, text('Yes. Eg. Google Docs, Jira, Confluence')),
+              ),
+            ),
           ),
-          block('paragraph', {}, text(''))
+          block('paragraph', {}, text('')),
         );
 
         richText.expectValue(expectedValue);
@@ -560,10 +560,10 @@ describe(
               {},
               block('table-cell', {}, block('paragraph', {}, text('Field'))),
               block('table-cell', {}, block('paragraph', {}, text('Type'))),
-              block('table-cell', {}, block('paragraph', {}, text('Description')))
-            )
+              block('table-cell', {}, block('paragraph', {}, text('Description'))),
+            ),
           ),
-          block('paragraph', {}, text(''))
+          block('paragraph', {}, text('')),
         );
 
         richText.expectValue(expectedValue);
@@ -615,16 +615,16 @@ describe(
               'table-row',
               {},
               block('table-cell', {}, block('paragraph', {}, text('Cell 1'))),
-              block('table-cell', {}, block('paragraph', {}, text('Cell 2')))
+              block('table-cell', {}, block('paragraph', {}, text('Cell 2'))),
             ),
             block(
               'table-row',
               {},
               block('table-cell', {}, block('paragraph', {}, text('Cell 3'))),
-              block('table-cell', {}, block('paragraph', {}, text('Cell 4')))
-            )
+              block('table-cell', {}, block('paragraph', {}, text('Cell 4'))),
+            ),
           ),
-          block('paragraph', {}, text(''))
+          block('paragraph', {}, text('')),
         );
 
         richText.expectValue(expectedValue);
@@ -644,8 +644,8 @@ describe(
             inline(INLINES.EMBEDDED_ENTRY, {
               target: { sys: { id: 'published-entry', type: 'Link', linkType: 'Entry' } },
             }),
-            text('.')
-          )
+            text('.'),
+          ),
         );
 
         richText.expectValue(expectedValue);
@@ -674,7 +674,7 @@ describe(
                   },
                 },
               },
-              text('resourceHyperlink')
+              text('resourceHyperlink'),
             ),
             text(' and a resource inline :'),
             inline(INLINES.EMBEDDED_RESOURCE, {
@@ -686,8 +686,8 @@ describe(
                 },
               },
             }),
-            text('')
-          )
+            text(''),
+          ),
         );
 
         richText.expectValue(expectedValue);
@@ -710,10 +710,10 @@ describe(
                 'table-row',
                 {},
                 block('table-cell', {}, block('paragraph', {}, text('Cell 1'))),
-                block('table-cell', {}, block('paragraph', {}, text('Cell 2')))
-              )
+                block('table-cell', {}, block('paragraph', {}, text('Cell 2'))),
+              ),
             ),
-            block('paragraph', {}, text(''))
+            block('paragraph', {}, text('')),
           );
 
           richText.expectValue(expectedValue);
@@ -733,10 +733,10 @@ describe(
                 'table-row',
                 {},
                 block('table-cell', {}, block('paragraph', {}, text('Cell 1'))),
-                block('table-cell', {}, block('paragraph', {}, text('Cell 2')))
-              )
+                block('table-cell', {}, block('paragraph', {}, text('Cell 2'))),
+              ),
             ),
-            block('paragraph', {}, text(''))
+            block('paragraph', {}, text('')),
           );
 
           richText.expectValue(expectedValue);
@@ -763,10 +763,10 @@ describe(
             inline(
               'hyperlink',
               { uri: 'https://contentful.com/' },
-              text('links', [mark('underline')])
+              text('links', [mark('underline')]),
             ),
-            text(' ')
-          )
+            text(' '),
+          ),
         );
 
         richText.expectValue(expectedValue);
@@ -823,9 +823,9 @@ describe(
             {},
             block(BLOCKS.LIST_ITEM, {}, block(BLOCKS.PARAGRAPH, {}, text('This'))),
             block(BLOCKS.LIST_ITEM, {}, block(BLOCKS.PARAGRAPH, {}, text('Is'))),
-            block(BLOCKS.LIST_ITEM, {}, block(BLOCKS.PARAGRAPH, {}, text('A list')))
+            block(BLOCKS.LIST_ITEM, {}, block(BLOCKS.PARAGRAPH, {}, text('A list'))),
           ),
-          block(BLOCKS.PARAGRAPH, {}, text(''))
+          block(BLOCKS.PARAGRAPH, {}, text('')),
         );
 
         richText.expectValue(expectedValue);
@@ -842,9 +842,9 @@ describe(
             BLOCKS.OL_LIST,
             {},
             block(BLOCKS.LIST_ITEM, {}, block(BLOCKS.PARAGRAPH, {}, text('This is'))),
-            block(BLOCKS.LIST_ITEM, {}, block(BLOCKS.PARAGRAPH, {}, text('An ordered list')))
+            block(BLOCKS.LIST_ITEM, {}, block(BLOCKS.PARAGRAPH, {}, text('An ordered list'))),
           ),
-          block(BLOCKS.PARAGRAPH, {}, text(''))
+          block(BLOCKS.PARAGRAPH, {}, text('')),
         );
 
         richText.expectValue(expectedValue);
@@ -866,7 +866,7 @@ describe(
               block(
                 BLOCKS.TABLE_CELL,
                 {},
-                block(BLOCKS.PARAGRAPH, {}, text('This is some', [{ type: MARKS.ITALIC }]))
+                block(BLOCKS.PARAGRAPH, {}, text('This is some', [{ type: MARKS.ITALIC }])),
               ),
               block(
                 BLOCKS.TABLE_CELL,
@@ -874,12 +874,12 @@ describe(
                 block(
                   BLOCKS.PARAGRAPH,
                   {},
-                  text('Content on tables', [{ type: MARKS.UNDERLINE }, { type: MARKS.BOLD }])
-                )
-              )
-            )
+                  text('Content on tables', [{ type: MARKS.UNDERLINE }, { type: MARKS.BOLD }]),
+                ),
+              ),
+            ),
           ),
-          block(BLOCKS.PARAGRAPH, {}, text(''))
+          block(BLOCKS.PARAGRAPH, {}, text('')),
         );
 
         richText.expectValue(expectedValue);
@@ -940,8 +940,8 @@ describe(
               { type: MARKS.ITALIC },
               { type: MARKS.UNDERLINE },
               { type: MARKS.CODE },
-            ])
-          )
+            ]),
+          ),
         );
 
         richText.expectValue(expectedValue);
@@ -965,8 +965,8 @@ describe(
             BLOCKS.PARAGRAPH,
             {},
             text('Hello', [mark(MARKS.SUPERSCRIPT)]),
-            text('World', [mark(MARKS.SUBSCRIPT)])
-          )
+            text('World', [mark(MARKS.SUBSCRIPT)]),
+          ),
         );
 
         richText.expectValue(expectedValue);
@@ -984,7 +984,7 @@ describe(
 
         const expectedValue = doc(
           block(BLOCKS.PARAGRAPH, {}, text('Hello world', [mark(MARKS.STRIKETHROUGH)])),
-          block(BLOCKS.PARAGRAPH, {}, text('\n'))
+          block(BLOCKS.PARAGRAPH, {}, text('\n')),
         );
 
         richText.expectValue(expectedValue);
@@ -1015,10 +1015,10 @@ describe(
                   },
                 },
               },
-              text('a')
+              text('a'),
             ),
-            text(' b')
-          )
+            text(' b'),
+          ),
         );
 
         richText.expectValue(expectedValue);
@@ -1047,10 +1047,10 @@ describe(
                   },
                 },
               },
-              text('a')
+              text('a'),
             ),
-            text(' b')
-          )
+            text(' b'),
+          ),
         );
 
         richText.expectValue(expectedValue);
@@ -1059,7 +1059,9 @@ describe(
 
     describe('blockquotes', () => {
       it('breaks a paragraph when pasting a blockquote in the middle', () => {
-        richText.editor.type('A paragraph{leftarrow}').paste({
+        richText.editor.type('A paragraph');
+        cy.realPress('ArrowLeft');
+        richText.editor.paste({
           'text/html':
             '<span data-slate-fragment="JTVCJTdCJTIydHlwZSUyMiUzQSUyMmJsb2NrcXVvdGUlMjIlMkMlMjJkYXRhJTIyJTNBJTdCJTdEJTJDJTIyY2hpbGRyZW4lMjIlM0ElNUIlN0IlMjJ0eXBlJTIyJTNBJTIycGFyYWdyYXBoJTIyJTJDJTIyY2hpbGRyZW4lMjIlM0ElNUIlN0IlMjJ0ZXh0JTIyJTNBJTIyYSUyMHF1b3RlJTIyJTdEJTVEJTdEJTVEJTdEJTVE" style="caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0); font-style: normal; font-variant-caps: normal; font-weight: normal; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; widows: auto; word-spacing: 0px; -webkit-text-size-adjust: auto; -webkit-text-stroke-width: 0px; text-decoration: none; white-space: pre;">a quote</span>',
           'text/plain': 'a blockquote',
@@ -1068,7 +1070,7 @@ describe(
         const expectedValue = doc(
           block(BLOCKS.PARAGRAPH, {}, text('A paragrap')),
           block(BLOCKS.QUOTE, {}, block(BLOCKS.PARAGRAPH, {}, text('a quote'))),
-          block(BLOCKS.PARAGRAPH, {}, text('h'))
+          block(BLOCKS.PARAGRAPH, {}, text('h')),
         );
 
         richText.expectValue(expectedValue);
@@ -1083,7 +1085,7 @@ describe(
 
         const expectedValue = doc(
           block(BLOCKS.QUOTE, {}, block(BLOCKS.PARAGRAPH, {}, text('a quote'))),
-          block(BLOCKS.PARAGRAPH, {}, text(''))
+          block(BLOCKS.PARAGRAPH, {}, text('')),
         );
 
         richText.expectValue(expectedValue);
@@ -1108,7 +1110,7 @@ describe(
 
         const expectedValue = doc(
           block(BLOCKS.QUOTE, {}, block(BLOCKS.PARAGRAPH, {}, text('a quote'))),
-          block(BLOCKS.PARAGRAPH, {}, text(''))
+          block(BLOCKS.PARAGRAPH, {}, text('')),
         );
 
         richText.expectValue(expectedValue);
@@ -1124,7 +1126,7 @@ describe(
         });
         const expectedValue = doc(
           block(BLOCKS.QUOTE, {}, block(BLOCKS.PARAGRAPH, {}, text('quote'))),
-          block(BLOCKS.PARAGRAPH, {}, text(''))
+          block(BLOCKS.PARAGRAPH, {}, text('')),
         );
 
         richText.expectValue(expectedValue);
@@ -1149,5 +1151,5 @@ describe(
         richText.expectValue(expectedValue);
       });
     });
-  }
+  },
 );

--- a/cypress/component/rich-text/RichTextEditor.Tables.spec.ts
+++ b/cypress/component/rich-text/RichTextEditor.Tables.spec.ts
@@ -41,14 +41,13 @@ describe('Rich Text Editor', { viewportHeight: 2000, viewportWidth: 1000 }, () =
       return richText.editor;
     };
     const insertTableWithExampleData = () => {
-      insertTable()
-        .type('foo')
-        .type('{rightarrow}')
-        .type('bar')
-        .type('{rightarrow}')
-        .type('baz')
-        .type('{rightarrow}')
-        .type('quux');
+      insertTable().type('foo');
+      cy.realPress('ArrowRight');
+      richText.editor.type('bar');
+      cy.realPress('ArrowRight');
+      richText.editor.type('baz');
+      cy.realPress('ArrowRight');
+      richText.editor.type('quux');
     };
     const expectDocumentStructure = (...elements) => {
       richText.expectValue(doc(...elements, emptyParagraph()));
@@ -62,7 +61,7 @@ describe('Rich Text Editor', { viewportHeight: 2000, viewportWidth: 1000 }, () =
         Cypress.on('uncaught:exception', (err) => {
           if (
             err.message.includes(
-              'Cannot resolve a Slate point from DOM point: [object HTMLDivElement],0'
+              'Cannot resolve a Slate point from DOM point: [object HTMLDivElement],0',
             )
           ) {
             return false;
@@ -74,15 +73,16 @@ describe('Rich Text Editor', { viewportHeight: 2000, viewportWidth: 1000 }, () =
 
         insertTable();
 
-        richText.editor.type('{uparrow}{enter}');
+        cy.realPress('ArrowUp');
+        richText.editor.type('{enter}');
 
         richText.expectValue(
           doc(
             emptyParagraph(),
 
             table(row(emptyHeader(), emptyHeader()), row(emptyCell(), emptyCell())),
-            emptyParagraph()
-          )
+            emptyParagraph(),
+          ),
         );
       });
     }
@@ -98,10 +98,10 @@ describe('Rich Text Editor', { viewportHeight: 2000, viewportWidth: 1000 }, () =
         doc(
           table(
             row(header(paragraphWithText('hey')), emptyHeader()),
-            row(emptyCell(), emptyCell())
+            row(emptyCell(), emptyCell()),
           ),
-          emptyParagraph()
-        )
+          emptyParagraph(),
+        ),
       );
     });
 
@@ -110,18 +110,15 @@ describe('Rich Text Editor', { viewportHeight: 2000, viewportWidth: 1000 }, () =
     it.skip('does not delete table header cells when selecting the whole header row', () => {
       insertTable();
 
-      richText.editor
-        .type(`hey`)
-        .type('{shift}{downarrow}', {
-          delay: 100,
-        })
-        .type('{backspace}');
+      richText.editor.type(`hey`);
+      cy.realPress(['Shift', 'ArrowDown']);
+      richText.editor.type('{backspace}');
 
       richText.expectValue(
         doc(
           table(row(emptyHeader(), emptyHeader()), row(emptyCell(), emptyCell())),
-          emptyParagraph()
-        )
+          emptyParagraph(),
+        ),
       );
     });
 
@@ -134,10 +131,10 @@ describe('Rich Text Editor', { viewportHeight: 2000, viewportWidth: 1000 }, () =
         doc(
           table(
             row(header(paragraphWithText('hey')), emptyHeader()),
-            row(emptyCell(), emptyCell())
+            row(emptyCell(), emptyCell()),
           ),
-          emptyParagraph()
-        )
+          emptyParagraph(),
+        ),
       );
     });
 
@@ -153,7 +150,9 @@ describe('Rich Text Editor', { viewportHeight: 2000, viewportWidth: 1000 }, () =
       richText.toolbar.headingsDropdown.should('be.disabled');
 
       // select outside the table
-      richText.editor.click().type('{downarrow}').wait(100);
+      richText.editor.click();
+      cy.realPress('ArrowDown');
+      cy.wait(100);
 
       blockElements.forEach((el) => {
         cy.findByTestId(`${el}-toolbar-button`).should('not.be.disabled');
@@ -178,8 +177,8 @@ describe('Rich Text Editor', { viewportHeight: 2000, viewportWidth: 1000 }, () =
         richText.expectValue(
           doc(
             table(row(emptyHeader(), emptyHeader()), row(emptyCell(), emptyCell())),
-            emptyParagraph()
-          )
+            emptyParagraph(),
+          ),
         );
       });
 
@@ -192,8 +191,8 @@ describe('Rich Text Editor', { viewportHeight: 2000, viewportWidth: 1000 }, () =
           doc(
             paragraphWithText('foo'),
             table(row(emptyHeader(), emptyHeader()), row(emptyCell(), emptyCell())),
-            emptyParagraph()
-          )
+            emptyParagraph(),
+          ),
         );
       });
 
@@ -201,7 +200,7 @@ describe('Rich Text Editor', { viewportHeight: 2000, viewportWidth: 1000 }, () =
         const buttonsToDisableTable = ['ul', 'ol', 'quote'];
 
         it(`should disable table button if ${buttonsToDisableTable.join(
-          ', '
+          ', ',
         )} elements are focused`, () => {
           buttonsToDisableTable.forEach((button) => {
             richText.editor.click();
@@ -226,7 +225,7 @@ describe('Rich Text Editor', { viewportHeight: 2000, viewportWidth: 1000 }, () =
 
           expectTable(
             row(headerWithText('foo'), headerWithText('bar')),
-            row(cellWithText('baz'), emptyCell())
+            row(cellWithText('baz'), emptyCell()),
           );
 
           // make sure it works for table header cells, too
@@ -238,7 +237,7 @@ describe('Rich Text Editor', { viewportHeight: 2000, viewportWidth: 1000 }, () =
 
           expectTable(
             row(emptyHeader(), headerWithText('bar')),
-            row(cellWithText('baz'), emptyCell())
+            row(cellWithText('baz'), emptyCell()),
           );
         });
       });
@@ -247,16 +246,19 @@ describe('Rich Text Editor', { viewportHeight: 2000, viewportWidth: 1000 }, () =
         it('removes the text, not the cell', () => {
           insertTableWithExampleData();
           richText.editor.find('table > tbody > tr:first-child > th:first-child').click();
+          cy.realPress('ArrowLeft');
+          cy.realPress('ArrowLeft');
+          cy.realPress('ArrowLeft');
           richText.editor
-            .type('{leftarrow}{leftarrow}{leftarrow}{del}{del}{del}{del}')
+            .type('{del}{del}{del}{del}')
             // .type('{backspace}') does not work on non-typable elements.(contentEditable=false)
-            .trigger('keydown', KEYS.delete) // 8 = delete/backspace
-            // try forward-deleting from outside the table for good measure
-            .type('{leftarrow}{del}')
-            .trigger('keydown', KEYS.delete);
+            .trigger('keydown', KEYS.delete); // 8 = delete/backspace
+          // try forward-deleting from outside the table for good measure
+          cy.realPress('ArrowLeft');
+          richText.editor.type('{del}').trigger('keydown', KEYS.delete);
           expectTable(
             row(headerWithText(''), headerWithText('bar')),
-            row(cellWithText('baz'), cellWithText('quux'))
+            row(cellWithText('baz'), cellWithText('quux')),
           );
         });
       });
@@ -294,7 +296,7 @@ describe('Rich Text Editor', { viewportHeight: 2000, viewportWidth: 1000 }, () =
           expectTable(
             row(headerWithText('foo'), headerWithText('bar')),
             row(emptyCell(), emptyCell()),
-            row(cellWithText('baz'), cellWithText('quux'))
+            row(cellWithText('baz'), cellWithText('quux')),
           );
         });
       });
@@ -306,7 +308,7 @@ describe('Rich Text Editor', { viewportHeight: 2000, viewportWidth: 1000 }, () =
           expectTable(
             row(headerWithText('foo'), headerWithText('bar')),
             row(cellWithText('baz'), cellWithText('quux')),
-            row(emptyCell(), emptyCell())
+            row(emptyCell(), emptyCell()),
           );
         });
 
@@ -316,7 +318,7 @@ describe('Rich Text Editor', { viewportHeight: 2000, viewportWidth: 1000 }, () =
           expectTable(
             row(headerWithText('foo'), headerWithText('bar')),
             row(cellWithText('baz'), cellWithText('quux')),
-            row(emptyCell(), emptyCell())
+            row(emptyCell(), emptyCell()),
           );
         });
       });
@@ -326,7 +328,7 @@ describe('Rich Text Editor', { viewportHeight: 2000, viewportWidth: 1000 }, () =
 
         expectTable(
           row(headerWithText('foo'), emptyHeader(), headerWithText('bar')),
-          row(cellWithText('baz'), emptyCell(), cellWithText('quux'))
+          row(cellWithText('baz'), emptyCell(), cellWithText('quux')),
         );
       });
 
@@ -335,7 +337,7 @@ describe('Rich Text Editor', { viewportHeight: 2000, viewportWidth: 1000 }, () =
 
         expectTable(
           row(headerWithText('foo'), headerWithText('bar'), emptyHeader()),
-          row(cellWithText('baz'), cellWithText('quux'), emptyCell())
+          row(cellWithText('baz'), cellWithText('quux'), emptyCell()),
         );
       });
 
@@ -344,14 +346,14 @@ describe('Rich Text Editor', { viewportHeight: 2000, viewportWidth: 1000 }, () =
 
         expectTable(
           row(cellWithText('foo'), cellWithText('bar')),
-          row(cellWithText('baz'), cellWithText('quux'))
+          row(cellWithText('baz'), cellWithText('quux')),
         );
 
         doAction('Enable table header');
 
         expectTable(
           row(headerWithText('foo'), headerWithText('bar')),
-          row(cellWithText('baz'), cellWithText('quux'))
+          row(cellWithText('baz'), cellWithText('quux')),
         );
       });
 

--- a/cypress/component/rich-text/RichTextEditor.Tracking.spec.ts
+++ b/cypress/component/rich-text/RichTextEditor.Tracking.spec.ts
@@ -313,14 +313,13 @@ describe('Rich Text Editor - Tracking', { viewportHeight: 2000, viewportWidth: 1
       return richText.editor;
     };
     const insertTableWithExampleData = () => {
-      insertTable()
-        .type('foo')
-        .type('{rightarrow}')
-        .type('bar')
-        .type('{rightarrow}')
-        .type('baz')
-        .type('{rightarrow}')
-        .type('quux');
+      insertTable().type('foo');
+      cy.realPress('ArrowRight');
+      richText.editor.type('bar');
+      cy.realPress('ArrowRight');
+      richText.editor.type('baz');
+      cy.realPress('ArrowRight');
+      richText.editor.type('quux');
     };
 
     const insertTableAction = () => action('insertTable', 'toolbar-icon');

--- a/cypress/component/rich-text/RichTextEditor.spec.ts
+++ b/cypress/component/rich-text/RichTextEditor.spec.ts
@@ -469,7 +469,9 @@ describe('Rich Text Editor', { viewportHeight: 2000, viewportWidth: 1000 }, () =
       richText.toolbar.embed('entry-block');
       richText.editor.type('hey');
       richText.toolbar.embed('entry-block');
-      richText.editor.type('{leftarrow}{leftarrow}{backspace}{backspace}{backspace}{backspace}');
+      cy.realPress('ArrowLeft');
+      cy.realPress('ArrowLeft');
+      richText.editor.type('{backspace}{backspace}{backspace}{backspace}');
 
       richText.expectValue(doc(entryBlock(), entryBlock(), emptyParagraph()));
     });
@@ -479,7 +481,9 @@ describe('Rich Text Editor', { viewportHeight: 2000, viewportWidth: 1000 }, () =
       richText.toolbar.embed('asset-block');
       richText.editor.type('hey');
       richText.toolbar.embed('asset-block');
-      richText.editor.type('{leftarrow}{leftarrow}{backspace}{backspace}{backspace}{backspace}');
+      cy.realPress('ArrowLeft');
+      cy.realPress('ArrowLeft');
+      richText.editor.type('{backspace}{backspace}{backspace}{backspace}');
 
       richText.expectValue(doc(assetBlock(), assetBlock(), emptyParagraph()));
     });
@@ -489,7 +493,9 @@ describe('Rich Text Editor', { viewportHeight: 2000, viewportWidth: 1000 }, () =
       richText.toolbar.hr.click();
       richText.editor.type('hey');
       richText.toolbar.hr.click();
-      richText.editor.type('{leftarrow}{leftarrow}{backspace}{backspace}{backspace}{backspace}');
+      cy.realPress('ArrowLeft');
+      cy.realPress('ArrowLeft');
+      richText.editor.type('{backspace}{backspace}{backspace}{backspace}');
 
       const hr = block(BLOCKS.HR, {});
       richText.expectValue(doc(hr, hr, emptyParagraph()));

--- a/cypress/component/rich-text/RichTextLists.spec.ts
+++ b/cypress/component/rich-text/RichTextLists.spec.ts
@@ -22,7 +22,7 @@ describe('Rich Text Lists', { viewportHeight: 1000, viewportWidth: 2000 }, () =>
 
     const expectedValue = doc(
       block(BLOCKS.QUOTE, {}, block(BLOCKS.PARAGRAPH, {}, text(content, []))),
-      block(BLOCKS.PARAGRAPH, {}, text('', []))
+      block(BLOCKS.PARAGRAPH, {}, text('', [])),
     );
 
     richText.expectValue(expectedValue);
@@ -73,7 +73,7 @@ describe('Rich Text Lists', { viewportHeight: 1000, viewportWidth: 2000 }, () =>
         },
       }),
       emptyParagraph(),
-      emptyParagraph()
+      emptyParagraph(),
     );
 
     richText.expectValue(expectedValue);
@@ -101,9 +101,9 @@ describe('Rich Text Lists', { viewportHeight: 1000, viewportWidth: 2000 }, () =>
           block(
             test.listType,
             {},
-            block(BLOCKS.LIST_ITEM, {}, block(BLOCKS.PARAGRAPH, {}, text('item 1', [])))
+            block(BLOCKS.LIST_ITEM, {}, block(BLOCKS.PARAGRAPH, {}, text('item 1', []))),
           ),
-          emptyParagraph()
+          emptyParagraph(),
         );
 
         richText.expectValue(expectedValue);
@@ -138,9 +138,9 @@ describe('Rich Text Lists', { viewportHeight: 1000, viewportWidth: 2000 }, () =>
           block(
             test.listType,
             {},
-            block(BLOCKS.LIST_ITEM, {}, block(BLOCKS.PARAGRAPH, {}, text('abc', [])))
+            block(BLOCKS.LIST_ITEM, {}, block(BLOCKS.PARAGRAPH, {}, text('abc', []))),
           ),
-          emptyParagraph()
+          emptyParagraph(),
         );
 
         richText.expectValue(expectedValue);
@@ -174,7 +174,7 @@ describe('Rich Text Lists', { viewportHeight: 1000, viewportWidth: 2000 }, () =>
 
         const expectedValue = doc(
           block(BLOCKS.PARAGRAPH, {}, text('some text', [])),
-          emptyParagraph()
+          emptyParagraph(),
         );
 
         richText.expectValue(expectedValue);
@@ -189,9 +189,9 @@ describe('Rich Text Lists', { viewportHeight: 1000, viewportWidth: 2000 }, () =>
           block(
             test.listType,
             {},
-            block(BLOCKS.LIST_ITEM, {}, block(BLOCKS.PARAGRAPH, {}, text('some text', [])))
+            block(BLOCKS.LIST_ITEM, {}, block(BLOCKS.PARAGRAPH, {}, text('some text', []))),
           ),
-          emptyParagraph()
+          emptyParagraph(),
         );
 
         richText.expectValue(expectedValue);
@@ -208,9 +208,9 @@ describe('Rich Text Lists', { viewportHeight: 1000, viewportWidth: 2000 }, () =>
           block(
             test.listType,
             {},
-            block(BLOCKS.LIST_ITEM, {}, block(BLOCKS.HEADING_1, {}, text('heading')))
+            block(BLOCKS.LIST_ITEM, {}, block(BLOCKS.HEADING_1, {}, text('heading'))),
           ),
-          emptyParagraph()
+          emptyParagraph(),
         );
 
         richText.expectValue(expectedValue);
@@ -224,7 +224,7 @@ describe('Rich Text Lists', { viewportHeight: 1000, viewportWidth: 2000 }, () =>
 
         const expectedValue = doc(
           block(test.listType, {}, block(BLOCKS.LIST_ITEM, {}, block(BLOCKS.HR, {}))),
-          emptyParagraph()
+          emptyParagraph(),
         );
 
         richText.expectValue(expectedValue);
@@ -238,7 +238,7 @@ describe('Rich Text Lists', { viewportHeight: 1000, viewportWidth: 2000 }, () =>
 
         const expectedValue = doc(
           block(test.listType, {}, block(BLOCKS.LIST_ITEM, {}, entryBlock(), emptyParagraph())),
-          emptyParagraph()
+          emptyParagraph(),
         );
 
         richText.expectValue(expectedValue);
@@ -252,7 +252,7 @@ describe('Rich Text Lists', { viewportHeight: 1000, viewportWidth: 2000 }, () =>
 
         const expectedValue = doc(
           block(test.listType, {}, block(BLOCKS.LIST_ITEM, {}, assetBlock(), emptyParagraph())),
-          emptyParagraph()
+          emptyParagraph(),
         );
 
         richText.expectValue(expectedValue);
@@ -269,9 +269,9 @@ describe('Rich Text Lists', { viewportHeight: 1000, viewportWidth: 2000 }, () =>
           block(
             test.listType,
             {},
-            block(BLOCKS.LIST_ITEM, {}, block(BLOCKS.QUOTE, {}, paragraphWithText('quote')))
+            block(BLOCKS.LIST_ITEM, {}, block(BLOCKS.QUOTE, {}, paragraphWithText('quote'))),
           ),
-          emptyParagraph()
+          emptyParagraph(),
         );
 
         richText.expectValue(expectedValue);
@@ -304,16 +304,16 @@ describe('Rich Text Lists', { viewportHeight: 1000, viewportWidth: 2000 }, () =>
                 BLOCKS.PARAGRAPH,
                 {},
                 text('bold ', [mark(MARKS.BOLD)]),
-                text('italic', [mark(MARKS.ITALIC)])
-              )
+                text('italic', [mark(MARKS.ITALIC)]),
+              ),
             ),
             block(
               BLOCKS.LIST_ITEM,
               {},
-              block(BLOCKS.PARAGRAPH, {}, text('more italic text', [mark(MARKS.ITALIC)]))
-            )
+              block(BLOCKS.PARAGRAPH, {}, text('more italic text', [mark(MARKS.ITALIC)])),
+            ),
           ),
-          emptyParagraph()
+          emptyParagraph(),
         );
 
         richText.expectValue(expectedValue);
@@ -323,18 +323,12 @@ describe('Rich Text Lists', { viewportHeight: 1000, viewportWidth: 2000 }, () =>
         richText.editor.click();
         test.getList().click();
 
-        richText.editor
-          .type('1{enter}2{enter}3{enter}4')
-          .trigger('keydown', KEYS.tab)
-          .type('{uparrow}')
-          .wait(50)
-          .type('{uparrow}')
-          .trigger('keydown', KEYS.tab)
-          .type('{downarrow}')
-          .wait(50)
-          .type('{backspace}')
-          .wait(50)
-          .type('{backspace}');
+        richText.editor.type('1{enter}2{enter}3{enter}4').trigger('keydown', KEYS.tab);
+        cy.realPress('ArrowUp').wait(50);
+        cy.realPress('ArrowUp');
+        richText.editor.trigger('keydown', KEYS.tab);
+        cy.realPress('ArrowDown').wait(50);
+        richText.editor.type('{backspace}').wait(50).type('{backspace}');
 
         const expectedValue = doc(
           block(
@@ -347,12 +341,12 @@ describe('Rich Text Lists', { viewportHeight: 1000, viewportWidth: 2000 }, () =>
               block(
                 test.listType,
                 {},
-                block(BLOCKS.LIST_ITEM, {}, block(BLOCKS.PARAGRAPH, {}, text('2')))
-              )
+                block(BLOCKS.LIST_ITEM, {}, block(BLOCKS.PARAGRAPH, {}, text('2'))),
+              ),
             ),
-            block(BLOCKS.LIST_ITEM, {}, block(BLOCKS.PARAGRAPH, {}, text('4')))
+            block(BLOCKS.LIST_ITEM, {}, block(BLOCKS.PARAGRAPH, {}, text('4'))),
           ),
-          emptyParagraph()
+          emptyParagraph(),
         );
 
         richText.expectValue(expectedValue);
@@ -364,7 +358,7 @@ describe('Rich Text Lists', { viewportHeight: 1000, viewportWidth: 2000 }, () =>
           test.getList().click();
           richText.editor.type('A paragraph');
           richText.toolbar.embed('entry-block');
-          richText.editor.type('{uparrow}');
+          cy.realPress('ArrowUp');
 
           // switch the list off
           test.getList().click();
@@ -373,7 +367,7 @@ describe('Rich Text Lists', { viewportHeight: 1000, viewportWidth: 2000 }, () =>
             block(BLOCKS.PARAGRAPH, {}, text('A paragraph')),
             entryBlock(),
             emptyParagraph(),
-            emptyParagraph()
+            emptyParagraph(),
           );
 
           richText.expectValue(expectedValue);
@@ -389,7 +383,8 @@ describe('Rich Text Lists', { viewportHeight: 1000, viewportWidth: 2000 }, () =>
           richText.editor.type('{enter}Another paragraph');
           richText.toolbar.embed('entry-block');
           richText.editor.type('{enter}Another paragraph again');
-          richText.editor.type('{uparrow}').wait(50).type('{uparrow}');
+          cy.realPress('ArrowUp').wait(50);
+          cy.realPress('ArrowUp');
 
           // switch the list off
           test.getList().click();
@@ -402,8 +397,8 @@ describe('Rich Text Lists', { viewportHeight: 1000, viewportWidth: 2000 }, () =>
                 BLOCKS.LIST_ITEM,
                 {},
                 block(BLOCKS.PARAGRAPH, {}, text('A paragraph')),
-                entryBlock()
-              )
+                entryBlock(),
+              ),
             ),
             block(BLOCKS.PARAGRAPH, {}, text('Another paragraph')),
             entryBlock(),
@@ -414,10 +409,10 @@ describe('Rich Text Lists', { viewportHeight: 1000, viewportWidth: 2000 }, () =>
                 BLOCKS.LIST_ITEM,
                 {},
                 block(BLOCKS.PARAGRAPH, {}, text('Another paragraph again')),
-                emptyParagraph()
-              )
+                emptyParagraph(),
+              ),
             ),
-            emptyParagraph()
+            emptyParagraph(),
           );
 
           richText.expectValue(expectedValue);

--- a/cypress/support/check-a11y.ts
+++ b/cypress/support/check-a11y.ts
@@ -1,0 +1,27 @@
+Cypress.Commands.overwrite('checkA11y', (originalFn, ...args) => {
+  const [context, options, violationCallback, skipFailures] = args;
+
+  // Inject and configure axe lazily — doing this in cy.mount() interferes with async
+  // React context provider trees and breaks tests that rely on context values.
+  cy.window({ log: false }).then((win) => {
+    if (!win.axe) {
+      cy.injectAxe({ axeCorePath: 'node_modules/axe-core/axe.min.js' });
+      cy.configureAxe({
+        rules: [
+          { id: 'html-has-lang', enabled: false },
+          { id: 'landmark-one-main', enabled: false },
+          { id: 'page-has-heading-one', enabled: false },
+          { id: 'region', enabled: false },
+        ],
+      });
+    }
+  });
+
+  const logViolations: typeof violationCallback = (violations) => {
+    const summary = violations.map((v) => `  [${v.impact}] ${v.id}: ${v.description}`).join('\n');
+    cy.task('log', `\n${violations.length} accessibility violation(s) detected:\n${summary}\n`);
+    violationCallback?.(violations);
+  };
+
+  return originalFn(context, options, logViolations, skipFailures);
+});

--- a/cypress/support/component.ts
+++ b/cypress/support/component.ts
@@ -16,6 +16,7 @@
 // Import commands.js using ES2015 syntax:
 import './commands';
 import 'cypress-axe';
+import 'cypress-real-events';
 import './check-a11y';
 
 // Alternatively you can use CommonJS syntax:

--- a/cypress/support/component.ts
+++ b/cypress/support/component.ts
@@ -15,6 +15,8 @@
 
 // Import commands.js using ES2015 syntax:
 import './commands';
+import 'cypress-axe';
+import './check-a11y';
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')

--- a/package.json
+++ b/package.json
@@ -75,10 +75,12 @@
     "@vitejs/plugin-react-swc": "^3.7.0",
     "@vitest/eslint-plugin": "^1.6.18",
     "ajv": "8.17.1",
+    "axe-core": "^4.12.1",
     "concurrently": "8.0.1",
     "contentful-cli": "3.3.8",
     "contentful-management": "12.3.0",
-    "cypress": "13.4.0",
+    "cypress": "^15.18.0",
+    "cypress-axe": "^1.7.0",
     "cypress-plugin-tab": "1.0.5",
     "cz-lerna-changelog": "2.0.2",
     "emotion": "10.0.27",
@@ -127,7 +129,8 @@
     "vite": "^8.0.14",
     "vitest": "^4.1.7",
     "vitest-axe": "^0.1.0",
-    "webpack": "5.104.1"
+    "webpack": "5.104.1",
+    "webpack-dev-server": "^5"
   },
   "resolutions": {
     "@types/react": "18.3.1",

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "cypress": "^15.18.0",
     "cypress-axe": "^1.7.0",
     "cypress-plugin-tab": "1.0.5",
+    "cypress-real-events": "^1.15.0",
     "cz-lerna-changelog": "2.0.2",
     "emotion": "10.0.27",
     "eslint": "8.56.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13401,6 +13401,11 @@ cypress-plugin-tab@1.0.5:
   dependencies:
     ally.js "^1.4.1"
 
+cypress-real-events@^1.15.0:
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/cypress-real-events/-/cypress-real-events-1.15.0.tgz#b84ed97455238139ac3d0c8f803991b30f22fc8a"
+  integrity sha512-in98xxTnnM9Z7lZBvvVozm99PBT2eEOjXRG5LKWyYvQnj9mGWXMiPNpfw7e7WiraBFh7XlXIxnE9Cu5o+52kQQ==
+
 cypress@*:
   version "13.7.3"
   resolved "https://registry.yarnpkg.com/cypress/-/cypress-13.7.3.tgz#3e7dcd32e007676a6c8e972293c50d6ef329d991"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5351,6 +5351,29 @@
     tunnel-agent "^0.6.0"
     uuid "^8.3.2"
 
+"@cypress/request@^4.0.0":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@cypress/request/-/request-4.0.1.tgz#c3f0eec41834e7590d21cd740a4c6f7e0326368d"
+  integrity sha512-y20e+e6dFYkOUUJLVUZTsJRuTiXZaUQ32WD+R/ux/HBybbTx4ge7cNINcua0pU8+SNkKuRbOF12mBmzuzM8n5w==
+  dependencies:
+    aws-sign2 "~0.7.0"
+    aws4 "^1.8.0"
+    caseless "~0.12.0"
+    combined-stream "~1.0.6"
+    extend "~3.0.2"
+    forever-agent "~0.6.1"
+    form-data "~4.0.4"
+    http-signature "~1.4.0"
+    is-typedarray "~1.0.0"
+    isstream "~0.1.2"
+    json-stringify-safe "~5.0.1"
+    mime-types "~2.1.19"
+    performance-now "^2.1.0"
+    qs "^6.15.2"
+    safe-buffer "^5.1.2"
+    tough-cookie "^5.0.0"
+    tunnel-agent "^0.6.0"
+
 "@cypress/xvfb@^1.2.4":
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/@cypress/xvfb/-/xvfb-1.2.4.tgz#2daf42e8275b39f4aa53c14214e557bd14e7748a"
@@ -6417,6 +6440,166 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
+"@jsonjoy.com/base64@17.67.0":
+  version "17.67.0"
+  resolved "https://registry.yarnpkg.com/@jsonjoy.com/base64/-/base64-17.67.0.tgz#7eeda3cb41138d77a90408fd2e42b2aba10576d7"
+  integrity sha512-5SEsJGsm15aP8TQGkDfJvz9axgPwAEm98S5DxOuYe8e1EbfajcDmgeXXzccEjh+mLnjqEKrkBdjHWS5vFNwDdw==
+
+"@jsonjoy.com/base64@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@jsonjoy.com/base64/-/base64-1.1.2.tgz#cf8ea9dcb849b81c95f14fc0aaa151c6b54d2578"
+  integrity sha512-q6XAnWQDIMA3+FTiOYajoYqySkO+JSat0ytXGSuRdq9uXE7o92gzuQwQM14xaCRlBLGq3v5miDGC4vkVTn54xA==
+
+"@jsonjoy.com/buffers@17.67.0", "@jsonjoy.com/buffers@^17.65.0":
+  version "17.67.0"
+  resolved "https://registry.yarnpkg.com/@jsonjoy.com/buffers/-/buffers-17.67.0.tgz#5c58dbcdeea8824ce296bd1cfce006c2eb167b3d"
+  integrity sha512-tfExRpYxBvi32vPs9ZHaTjSP4fHAfzSmcahOfNxtvGHcyJel+aibkPlGeBB+7AoC6hL7lXIE++8okecBxx7lcw==
+
+"@jsonjoy.com/buffers@^1.0.0", "@jsonjoy.com/buffers@^1.2.0":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@jsonjoy.com/buffers/-/buffers-1.2.1.tgz#8d99c7f67eaf724d3428dfd9826c6455266a5c83"
+  integrity sha512-12cdlDwX4RUM3QxmUbVJWqZ/mrK6dFQH4Zxq6+r1YXKXYBNgZXndx2qbCJwh3+WWkCSn67IjnlG3XYTvmvYtgA==
+
+"@jsonjoy.com/codegen@17.67.0":
+  version "17.67.0"
+  resolved "https://registry.yarnpkg.com/@jsonjoy.com/codegen/-/codegen-17.67.0.tgz#3635fd8769d77e19b75dc5574bc9756019b2e591"
+  integrity sha512-idnkUplROpdBOV0HMcwhsCUS5TRUi9poagdGs70A6S4ux9+/aPuKbh8+UYRTLYQHtXvAdNfQWXDqZEx5k4Dj2Q==
+
+"@jsonjoy.com/codegen@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@jsonjoy.com/codegen/-/codegen-1.0.0.tgz#5c23f796c47675f166d23b948cdb889184b93207"
+  integrity sha512-E8Oy+08cmCf0EK/NMxpaJZmOxPqM+6iSe2S4nlSBrPZOORoDJILxtbSUEDKQyTamm/BVAhIGllOBNU79/dwf0g==
+
+"@jsonjoy.com/fs-core@4.57.8":
+  version "4.57.8"
+  resolved "https://registry.yarnpkg.com/@jsonjoy.com/fs-core/-/fs-core-4.57.8.tgz#3e399ca856968194b0be73aa4b6fc943bf313bb8"
+  integrity sha512-YzVbwggV9452VCeHgo0bjsTaUt1O7JE0XpEsPar93nn/+RAwXk0mb1Y+f5EDJ3TRtRCFe+Ck5RuojdfB4jeHVw==
+  dependencies:
+    "@jsonjoy.com/fs-node-builtins" "4.57.8"
+    "@jsonjoy.com/fs-node-utils" "4.57.8"
+    thingies "^2.5.0"
+
+"@jsonjoy.com/fs-fsa@4.57.8":
+  version "4.57.8"
+  resolved "https://registry.yarnpkg.com/@jsonjoy.com/fs-fsa/-/fs-fsa-4.57.8.tgz#26a1688ff5c8d1189d32e76bfe2364e0763b6737"
+  integrity sha512-vmClyvCQMxgqz7uamDiGtRfp4MjzOznk3pcQjCxlIwJcw7TWeyr+bF30hI0x8NxdtNOGMg1pHM74VDIXOeyjuw==
+  dependencies:
+    "@jsonjoy.com/fs-core" "4.57.8"
+    "@jsonjoy.com/fs-node-builtins" "4.57.8"
+    "@jsonjoy.com/fs-node-utils" "4.57.8"
+    thingies "^2.5.0"
+
+"@jsonjoy.com/fs-node-builtins@4.57.8":
+  version "4.57.8"
+  resolved "https://registry.yarnpkg.com/@jsonjoy.com/fs-node-builtins/-/fs-node-builtins-4.57.8.tgz#ba350bf262571e38d3c195f5346eddec07c1d053"
+  integrity sha512-mxXSXw8zZwRVakcjLqR2I/psy4gURFSASZS10kKJ2kJw05GC2nXGroGrWVHxwgkxXgQLsFQnB74QaLzsxzdL/w==
+
+"@jsonjoy.com/fs-node-to-fsa@4.57.8":
+  version "4.57.8"
+  resolved "https://registry.yarnpkg.com/@jsonjoy.com/fs-node-to-fsa/-/fs-node-to-fsa-4.57.8.tgz#4372e75e7a6a76b4d8ac91dc2d93edfa8587599f"
+  integrity sha512-AWZcT/4+H+iDl4XCukbXrarvwEgOrf/prFI5/7eg4ix9FxqVsZysIDJd1Kjd+AjlCeHKHJOaRqjLd5HiGSCJEw==
+  dependencies:
+    "@jsonjoy.com/fs-fsa" "4.57.8"
+    "@jsonjoy.com/fs-node-builtins" "4.57.8"
+    "@jsonjoy.com/fs-node-utils" "4.57.8"
+
+"@jsonjoy.com/fs-node-utils@4.57.8":
+  version "4.57.8"
+  resolved "https://registry.yarnpkg.com/@jsonjoy.com/fs-node-utils/-/fs-node-utils-4.57.8.tgz#a1a15d587fff235b616d5ea775e0f9a88f387a56"
+  integrity sha512-E/bJ7sQAb4pu9nbeJhbULU3WnqWrswte4N9Js/oHt7aHB746S8/XBqKlcbrqIgnD3095XluovNEZuu5ONT230g==
+  dependencies:
+    "@jsonjoy.com/fs-node-builtins" "4.57.8"
+
+"@jsonjoy.com/fs-node@4.57.8":
+  version "4.57.8"
+  resolved "https://registry.yarnpkg.com/@jsonjoy.com/fs-node/-/fs-node-4.57.8.tgz#d16b418d2179f7092f9fe5daeb18d31a5835a19b"
+  integrity sha512-IPEOlDYSnTDYpjQlQg2F8h+eqxKQN3sdbroI0WrteRiQZ462HzVpBo9ZZX485njz4nAacoe3fd4iDiIhk+k5Hg==
+  dependencies:
+    "@jsonjoy.com/fs-core" "4.57.8"
+    "@jsonjoy.com/fs-node-builtins" "4.57.8"
+    "@jsonjoy.com/fs-node-utils" "4.57.8"
+    "@jsonjoy.com/fs-print" "4.57.8"
+    "@jsonjoy.com/fs-snapshot" "4.57.8"
+    glob-to-regex.js "^1.0.0"
+    thingies "^2.5.0"
+
+"@jsonjoy.com/fs-print@4.57.8":
+  version "4.57.8"
+  resolved "https://registry.yarnpkg.com/@jsonjoy.com/fs-print/-/fs-print-4.57.8.tgz#5ff6b2e0dd3f85aa7563f66cd36b4de1f0ce89a3"
+  integrity sha512-DfzhOBpmvNu5P/KSe4NNQaOnvNliTdcf0qrh/4EReErF/XUQXYkd0vZl/OiJCm/qjEEo8DWRstliw2/JNS84dA==
+  dependencies:
+    "@jsonjoy.com/fs-node-utils" "4.57.8"
+    tree-dump "^1.1.0"
+
+"@jsonjoy.com/fs-snapshot@4.57.8":
+  version "4.57.8"
+  resolved "https://registry.yarnpkg.com/@jsonjoy.com/fs-snapshot/-/fs-snapshot-4.57.8.tgz#65b317f7698816c7196dbebc73e9d43e06f143be"
+  integrity sha512-L+eqKaWOHLDaiMv1dh/EWQ4hA+o6xAhWSumTo3Teg7OM18jU/KE13/e8Mfal+eAZ/pSl4wIhKHcDiwapJzC8Wg==
+  dependencies:
+    "@jsonjoy.com/buffers" "^17.65.0"
+    "@jsonjoy.com/fs-node-utils" "4.57.8"
+    "@jsonjoy.com/json-pack" "^17.65.0"
+    "@jsonjoy.com/util" "^17.65.0"
+
+"@jsonjoy.com/json-pack@^1.11.0":
+  version "1.21.0"
+  resolved "https://registry.yarnpkg.com/@jsonjoy.com/json-pack/-/json-pack-1.21.0.tgz#93f8dd57fe3a3a92132b33d1eb182dcd9e7629fa"
+  integrity sha512-+AKG+R2cfZMShzrF2uQw34v3zbeDYUqnQ+jg7ORic3BGtfw9p/+N6RJbq/kkV8JmYZaINknaEQ2m0/f693ZPpg==
+  dependencies:
+    "@jsonjoy.com/base64" "^1.1.2"
+    "@jsonjoy.com/buffers" "^1.2.0"
+    "@jsonjoy.com/codegen" "^1.0.0"
+    "@jsonjoy.com/json-pointer" "^1.0.2"
+    "@jsonjoy.com/util" "^1.9.0"
+    hyperdyperid "^1.2.0"
+    thingies "^2.5.0"
+    tree-dump "^1.1.0"
+
+"@jsonjoy.com/json-pack@^17.65.0":
+  version "17.67.0"
+  resolved "https://registry.yarnpkg.com/@jsonjoy.com/json-pack/-/json-pack-17.67.0.tgz#8dd8ff65dd999c5d4d26df46c63915c7bdec093a"
+  integrity sha512-t0ejURcGaZsn1ClbJ/3kFqSOjlryd92eQY465IYrezsXmPcfHPE/av4twRSxf6WE+TkZgLY+71vCZbiIiFKA/w==
+  dependencies:
+    "@jsonjoy.com/base64" "17.67.0"
+    "@jsonjoy.com/buffers" "17.67.0"
+    "@jsonjoy.com/codegen" "17.67.0"
+    "@jsonjoy.com/json-pointer" "17.67.0"
+    "@jsonjoy.com/util" "17.67.0"
+    hyperdyperid "^1.2.0"
+    thingies "^2.5.0"
+    tree-dump "^1.1.0"
+
+"@jsonjoy.com/json-pointer@17.67.0":
+  version "17.67.0"
+  resolved "https://registry.yarnpkg.com/@jsonjoy.com/json-pointer/-/json-pointer-17.67.0.tgz#74439573dc046e0c9a3a552fb94b391bc75313b8"
+  integrity sha512-+iqOFInH+QZGmSuaybBUNdh7yvNrXvqR+h3wjXm0N/3JK1EyyFAeGJvqnmQL61d1ARLlk/wJdFKSL+LHJ1eaUA==
+  dependencies:
+    "@jsonjoy.com/util" "17.67.0"
+
+"@jsonjoy.com/json-pointer@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@jsonjoy.com/json-pointer/-/json-pointer-1.0.2.tgz#049cb530ac24e84cba08590c5e36b431c4843408"
+  integrity sha512-Fsn6wM2zlDzY1U+v4Nc8bo3bVqgfNTGcn6dMgs6FjrEnt4ZCe60o6ByKRjOGlI2gow0aE/Q41QOigdTqkyK5fg==
+  dependencies:
+    "@jsonjoy.com/codegen" "^1.0.0"
+    "@jsonjoy.com/util" "^1.9.0"
+
+"@jsonjoy.com/util@17.67.0", "@jsonjoy.com/util@^17.65.0":
+  version "17.67.0"
+  resolved "https://registry.yarnpkg.com/@jsonjoy.com/util/-/util-17.67.0.tgz#7c4288fc3808233e55c7610101e7bb4590cddd3f"
+  integrity sha512-6+8xBaz1rLSohlGh68D1pdw3AwDi9xydm8QNlAFkvnavCJYSze+pxoW2VKP8p308jtlMRLs5NTHfPlZLd4w7ew==
+  dependencies:
+    "@jsonjoy.com/buffers" "17.67.0"
+    "@jsonjoy.com/codegen" "17.67.0"
+
+"@jsonjoy.com/util@^1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@jsonjoy.com/util/-/util-1.9.0.tgz#7ee95586aed0a766b746cd8d8363e336c3c47c46"
+  integrity sha512-pLuQo+VPRnN8hfPqUTLTHk126wuYdXVxE6aDmjSeV4NCAgyxWbiOIeNJVtID3h1Vzpoi9m4jXezf73I6LgabgQ==
+  dependencies:
+    "@jsonjoy.com/buffers" "^1.0.0"
+    "@jsonjoy.com/codegen" "^1.0.0"
+
 "@juggle/resize-observer@^3.4.0":
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/@juggle/resize-observer/-/resize-observer-3.4.0.tgz#08d6c5e20cf7e4cc02fd181c4b0c225cd31dbb60"
@@ -6731,6 +6914,11 @@
   integrity sha512-54/JRvkLIzzDWshCWfuhadfrfZVPiElY8Fcgmg1HroEly/EDSszzhBAsarCux+D/kOslTRquNzuyGSmUSTTHGg==
   dependencies:
     eslint-scope "5.1.1"
+
+"@noble/hashes@1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.4.0.tgz#45814aa329f30e4fe0ba49426f49dfccdd066426"
+  integrity sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -7282,6 +7470,136 @@
   version "11.21.3"
   resolved "https://registry.yarnpkg.com/@oxc-resolver/binding-win32-x64-msvc/-/binding-win32-x64-msvc-11.21.3.tgz#d0da31fce46d6b85672fa1e7515400fafce45e1a"
   integrity sha512-H7BCt/VnS9hnmMp42eGhZ99izSCRvlnWwy/N71K1/J8QoExwY4262Z8QiEkMDtduRJrztayDxETTckmUuAVL9Q==
+
+"@peculiar/asn1-cms@^2.6.0", "@peculiar/asn1-cms@^2.8.0":
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/@peculiar/asn1-cms/-/asn1-cms-2.8.0.tgz#b48a8389319228f929e9acd8cee8da6c858738de"
+  integrity sha512-NgekZOrSJFSBFLFoLfwePguAWAx7z1+f2TEsWFUMyiqqfntZ4+S/S5hzqME3q4pCA0iOsFKdwiQ35dwY24eVqA==
+  dependencies:
+    "@peculiar/asn1-schema" "^2.8.0"
+    "@peculiar/asn1-x509" "^2.8.0"
+    "@peculiar/asn1-x509-attr" "^2.8.0"
+    asn1js "^3.0.10"
+    tslib "^2.8.1"
+
+"@peculiar/asn1-csr@^2.6.0":
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/@peculiar/asn1-csr/-/asn1-csr-2.8.0.tgz#c9bb5dec2eaff824a705e82a4a58d45e6d2c35d0"
+  integrity sha512-akbF8+uvleHs8sejNPQxwmVFuInAg6FMNHOwMILXfP518YfFJwdR3jr6oNUPOaEJfuEhn/vkNOCIT6ASUd4mbg==
+  dependencies:
+    "@peculiar/asn1-schema" "^2.8.0"
+    "@peculiar/asn1-x509" "^2.8.0"
+    asn1js "^3.0.10"
+    tslib "^2.8.1"
+
+"@peculiar/asn1-ecc@^2.6.0":
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/@peculiar/asn1-ecc/-/asn1-ecc-2.8.0.tgz#d51ab2b07eca98e0cf492d051e98bbd0a071305a"
+  integrity sha512-ohwlk+u9Rv2NOAY1c6MfHj45ATVF8R1DUN/WCgABiRtLi2ZftlZWZX7KvpAbU8v9xPcmoILfELeEABj/rn18AQ==
+  dependencies:
+    "@peculiar/asn1-schema" "^2.8.0"
+    "@peculiar/asn1-x509" "^2.8.0"
+    asn1js "^3.0.10"
+    tslib "^2.8.1"
+
+"@peculiar/asn1-pfx@^2.8.0":
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/@peculiar/asn1-pfx/-/asn1-pfx-2.8.0.tgz#8e189b6455e2bf9e5f921bb150ea86d7e7d1875d"
+  integrity sha512-5yof1ytoB++RQtaFbqSUJ8pxDJtZT6vbVqZ8XoJ61ph7UjNVvfFwAilnCodqkNsAodpy13gDhoxZXw00pghnyg==
+  dependencies:
+    "@peculiar/asn1-cms" "^2.8.0"
+    "@peculiar/asn1-pkcs8" "^2.8.0"
+    "@peculiar/asn1-rsa" "^2.8.0"
+    "@peculiar/asn1-schema" "^2.8.0"
+    asn1js "^3.0.10"
+    tslib "^2.8.1"
+
+"@peculiar/asn1-pkcs8@^2.8.0":
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/@peculiar/asn1-pkcs8/-/asn1-pkcs8-2.8.0.tgz#a46cf8857b9b063896afa41d2b8b2aa6a07a70a2"
+  integrity sha512-qAKXtLpBEw9LqhKpjw3ajZSXlBur+ipW+y2ivVBQAG6F6qRx94yO+1ZR4mvw+YaCfKSaOzLeYEzsPaBp4SJELA==
+  dependencies:
+    "@peculiar/asn1-schema" "^2.8.0"
+    "@peculiar/asn1-x509" "^2.8.0"
+    asn1js "^3.0.10"
+    tslib "^2.8.1"
+
+"@peculiar/asn1-pkcs9@^2.6.0":
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/@peculiar/asn1-pkcs9/-/asn1-pkcs9-2.8.0.tgz#6d62697af0bbd4f30fdf0d23b4018f3f09620de3"
+  integrity sha512-b5nDWCnkV60+cQ141D6sVVwK9nz64R5n3zSVnklGd+ECdkW2Ol3U1a6yYFlalpSOaD557yuJB64A+q42jG7lUQ==
+  dependencies:
+    "@peculiar/asn1-cms" "^2.8.0"
+    "@peculiar/asn1-pfx" "^2.8.0"
+    "@peculiar/asn1-pkcs8" "^2.8.0"
+    "@peculiar/asn1-schema" "^2.8.0"
+    "@peculiar/asn1-x509" "^2.8.0"
+    "@peculiar/asn1-x509-attr" "^2.8.0"
+    asn1js "^3.0.10"
+    tslib "^2.8.1"
+
+"@peculiar/asn1-rsa@^2.6.0", "@peculiar/asn1-rsa@^2.8.0":
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/@peculiar/asn1-rsa/-/asn1-rsa-2.8.0.tgz#9d98d0fc42fec50119d2881b8a9925d36daaea73"
+  integrity sha512-zHEUlCqB2mk7x2lxDwHHJy7hWZOPdGHVlsmITWKB5/PbQo61atbu9PJ/0r9dQNMwFzbKPXZ8uK8/91eUhRznSg==
+  dependencies:
+    "@peculiar/asn1-schema" "^2.8.0"
+    "@peculiar/asn1-x509" "^2.8.0"
+    asn1js "^3.0.10"
+    tslib "^2.8.1"
+
+"@peculiar/asn1-schema@^2.6.0", "@peculiar/asn1-schema@^2.8.0":
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/@peculiar/asn1-schema/-/asn1-schema-2.8.0.tgz#69699f84259b2161607cabfc34e512a4023dbef9"
+  integrity sha512-7YT0U/ze0tF2QOBbE15gKZwy5tvgGyLRiRHLzhlbOpf7BT032oBSd0haZqXn5W6l26WLlu3dyxzjM+2638/z2Q==
+  dependencies:
+    "@peculiar/utils" "^2.0.2"
+    asn1js "^3.0.10"
+    tslib "^2.8.1"
+
+"@peculiar/asn1-x509-attr@^2.8.0":
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/@peculiar/asn1-x509-attr/-/asn1-x509-attr-2.8.0.tgz#bd168e3f5e8bc23e56b1a97891f9f2fb7f730204"
+  integrity sha512-tHjkfS/qhMnmrlB2J9NhflQlQ7In3khO3CfmVrriOlpTeErY9ZIKOso1hQ5JQiyrJ7ShvqVPk7E5fQmbclkSKA==
+  dependencies:
+    "@peculiar/asn1-schema" "^2.8.0"
+    "@peculiar/asn1-x509" "^2.8.0"
+    asn1js "^3.0.10"
+    tslib "^2.8.1"
+
+"@peculiar/asn1-x509@^2.6.0", "@peculiar/asn1-x509@^2.8.0":
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/@peculiar/asn1-x509/-/asn1-x509-2.8.0.tgz#9958a9ef35dec8426aabad78ffe8798e318b06e2"
+  integrity sha512-N0CMuhWUzsWEVq6F1q9X6+VKUnWzSW+cSVg+aPaGGwDdbFoFWTYgin5MHwXgpWd6y9COMBxnfy/Qc+Xc7F0Zwg==
+  dependencies:
+    "@peculiar/asn1-schema" "^2.8.0"
+    "@peculiar/utils" "^2.0.2"
+    asn1js "^3.0.10"
+    tslib "^2.8.1"
+
+"@peculiar/utils@^2.0.2":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@peculiar/utils/-/utils-2.0.3.tgz#a27ca4c4b73652e110f19a7d16d664f458a5528e"
+  integrity sha512-+oL3HPFRIZ1St2K50lWCXiioIgSoxzz7R1J3uF6neO2yl1sgmpgY6XXJH4BdpoDkMWznQTeYF6oWNDZLCdQ4eQ==
+  dependencies:
+    tslib "^2.8.1"
+
+"@peculiar/x509@^1.14.2":
+  version "1.14.3"
+  resolved "https://registry.yarnpkg.com/@peculiar/x509/-/x509-1.14.3.tgz#2c44c2b89474346afec38a0c2803ec4fb8ce959e"
+  integrity sha512-C2Xj8FZ0uHWeCXXqX5B4/gVFQmtSkiuOolzAgutjTfseNOHT3pUjljDZsTSxXFGgio54bCzVFqmEOUrIVk8RDA==
+  dependencies:
+    "@peculiar/asn1-cms" "^2.6.0"
+    "@peculiar/asn1-csr" "^2.6.0"
+    "@peculiar/asn1-ecc" "^2.6.0"
+    "@peculiar/asn1-pkcs9" "^2.6.0"
+    "@peculiar/asn1-rsa" "^2.6.0"
+    "@peculiar/asn1-schema" "^2.6.0"
+    "@peculiar/asn1-x509" "^2.6.0"
+    pvtsutils "^1.3.6"
+    reflect-metadata "^0.2.2"
+    tslib "^2.8.1"
+    tsyringe "^4.10.0"
 
 "@phosphor-icons/react@2.1.8":
   version "2.1.8"
@@ -8529,7 +8847,7 @@
     "@types/connect" "*"
     "@types/node" "*"
 
-"@types/bonjour@^3.5.9":
+"@types/bonjour@^3.5.13", "@types/bonjour@^3.5.9":
   version "3.5.13"
   resolved "https://registry.yarnpkg.com/@types/bonjour/-/bonjour-3.5.13.tgz#adf90ce1a105e81dd1f9c61fdc5afda1bfb92956"
   integrity sha512-z9fJ5Im06zvUL548KvYNecEVlA7cVDkGUi6kZusb04mpyEFKCIZJvloCcmpmLaIahDpOQGHaHmG6imtPMmPXGQ==
@@ -8575,7 +8893,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/connect-history-api-fallback@^1.3.5":
+"@types/connect-history-api-fallback@^1.3.5", "@types/connect-history-api-fallback@^1.5.4":
   version "1.5.4"
   resolved "https://registry.yarnpkg.com/@types/connect-history-api-fallback/-/connect-history-api-fallback-1.5.4.tgz#7de71645a103056b48ac3ce07b3520b819c1d5b3"
   integrity sha512-n6Cr2xS1h4uAulPRdlw6Jl6s1oG8KrVilPN2yUITEs+K48EzMJJ3W1xy8K5eWuFvjp3R74AOIGSmp2UfBJ8HFw==
@@ -8670,6 +8988,16 @@
     "@types/range-parser" "*"
     "@types/send" "*"
 
+"@types/express-serve-static-core@^4.17.21":
+  version "4.19.8"
+  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.19.8.tgz#99b960322a4d576b239a640ab52ef191989b036f"
+  integrity sha512-02S5fmqeoKzVZCHPZid4b8JH2eM5HzQLZWN2FohQEy/0eXTq8VXZfSN6Pcr3F6N9R/vNrj7cpgbhjie6m/1tCA==
+  dependencies:
+    "@types/node" "*"
+    "@types/qs" "*"
+    "@types/range-parser" "*"
+    "@types/send" "*"
+
 "@types/express@*", "@types/express@^4.17.13":
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.21.tgz#c26d4a151e60efe0084b23dc3369ebc631ed192d"
@@ -8679,6 +9007,16 @@
     "@types/express-serve-static-core" "^4.17.33"
     "@types/qs" "*"
     "@types/serve-static" "*"
+
+"@types/express@^4.17.25":
+  version "4.17.25"
+  resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.25.tgz#070c8c73a6fee6936d65c195dbbfb7da5026649b"
+  integrity sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==
+  dependencies:
+    "@types/body-parser" "*"
+    "@types/express-serve-static-core" "^4.17.33"
+    "@types/qs" "*"
+    "@types/serve-static" "^1"
 
 "@types/google-map-react@2.1.10":
   version "2.1.10"
@@ -8851,13 +9189,6 @@
   dependencies:
     undici-types "~5.26.4"
 
-"@types/node@^18.17.5":
-  version "18.19.31"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.19.31.tgz#b7d4a00f7cb826b60a543cebdbda5d189aaecdcd"
-  integrity sha512-ArgCD39YpyyrtFKIqMDvjz79jto5fcI/SVUs2HwB+f0dAzq68yqOdyaSivLiLugSziTpNXLQrVb7RZFmdZzbhA==
-  dependencies:
-    undici-types "~5.26.4"
-
 "@types/normalize-package-data@^2.4.0":
   version "2.4.4"
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz#56e2cc26c397c038fab0e3a917a12d5c5909e901"
@@ -8959,6 +9290,11 @@
   resolved "https://registry.yarnpkg.com/@types/retry/-/retry-0.12.0.tgz#2b35eccfcee7d38cd72ad99232fbd58bffb3c84d"
   integrity sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==
 
+"@types/retry@0.12.2":
+  version "0.12.2"
+  resolved "https://registry.yarnpkg.com/@types/retry/-/retry-0.12.2.tgz#ed279a64fa438bb69f2480eda44937912bb7480a"
+  integrity sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow==
+
 "@types/semver@^7.3.12", "@types/semver@^7.5.0":
   version "7.5.8"
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.5.8.tgz#8268a8c57a3e4abd25c165ecd36237db7948a55e"
@@ -8977,7 +9313,15 @@
     "@types/mime" "^1"
     "@types/node" "*"
 
-"@types/serve-index@^1.9.1":
+"@types/send@<1":
+  version "0.17.6"
+  resolved "https://registry.yarnpkg.com/@types/send/-/send-0.17.6.tgz#aeb5385be62ff58a52cd5459daa509ae91651d25"
+  integrity sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==
+  dependencies:
+    "@types/mime" "^1"
+    "@types/node" "*"
+
+"@types/serve-index@^1.9.1", "@types/serve-index@^1.9.4":
   version "1.9.4"
   resolved "https://registry.yarnpkg.com/@types/serve-index/-/serve-index-1.9.4.tgz#e6ae13d5053cb06ed36392110b4f9a49ac4ec898"
   integrity sha512-qLpGZ/c2fhSs5gnYsQxtDEq3Oy8SXPClIXkW5ghvAvsNuVSA8k+gCONcUCS/UjLEYvYps+e8uBtfgXgvhwfNug==
@@ -8993,6 +9337,15 @@
     "@types/node" "*"
     "@types/send" "*"
 
+"@types/serve-static@^1", "@types/serve-static@^1.15.5":
+  version "1.15.10"
+  resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.15.10.tgz#768169145a778f8f5dfcb6360aead414a3994fee"
+  integrity sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw==
+  dependencies:
+    "@types/http-errors" "*"
+    "@types/node" "*"
+    "@types/send" "<1"
+
 "@types/sinonjs__fake-timers@8.1.1":
   version "8.1.1"
   resolved "https://registry.yarnpkg.com/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.1.tgz#b49c2c70150141a15e0fa7e79cf1f92a72934ce3"
@@ -9003,7 +9356,7 @@
   resolved "https://registry.yarnpkg.com/@types/sizzle/-/sizzle-2.3.8.tgz#518609aefb797da19bf222feb199e8f653ff7627"
   integrity sha512-0vWLNK2D5MT9dg0iOo8GlKguPAU02QjmZitPEsXRuJXU/OGIOt9vT9Fc26wtYuavLxtO45v9PGleoL9Z0k1LHg==
 
-"@types/sockjs@^0.3.33":
+"@types/sockjs@^0.3.33", "@types/sockjs@^0.3.36":
   version "0.3.36"
   resolved "https://registry.yarnpkg.com/@types/sockjs/-/sockjs-0.3.36.tgz#ce322cf07bcc119d4cbf7f88954f3a3bd0f67535"
   integrity sha512-MK9V6NzAS1+Ud7JV9lJLFqW85VbC9dq3LmwZCuBe4wBDgKC0Kj/jd8Xl+nSviU+Qc3+m7umHHyHg//2KSa0a0Q==
@@ -9057,6 +9410,11 @@
   resolved "https://registry.yarnpkg.com/@types/timezoned-date/-/timezoned-date-3.0.2.tgz#178e0f4d08638d7280754f381cedebc1f0c95853"
   integrity sha512-4V1tq5c8dFO8msP+uQ4KWvBGM5k0GguyFzSYXSu+Y9jotpqqLwRZDarYhn9Ld6zhmUz8v6h7FFtWO7EjISMBmQ==
 
+"@types/tmp@^0.2.3":
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/@types/tmp/-/tmp-0.2.6.tgz#d785ee90c52d7cc020e249c948c36f7b32d1e217"
+  integrity sha512-chhaNf2oKHlRkDGt+tiKE2Z5aJ6qalm7Z9rlLdBwmOiAAf09YQvvoLXjWK4HWPF1xU/fqvMgfNfpVoBscA/tKA==
+
 "@types/trusted-types@^2.0.2":
   version "2.0.7"
   resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-2.0.7.tgz#baccb07a970b91707df3a3e8ba6896c57ead2d11"
@@ -9076,6 +9434,13 @@
   version "1.18.4"
   resolved "https://registry.yarnpkg.com/@types/webpack-env/-/webpack-env-1.18.4.tgz#62879b0a9c653f9b1172d403b882f2045ecce032"
   integrity sha512-I6e+9+HtWADAWeeJWDFQtdk4EVSAbj6Rtz4q8fJ7mSr1M0jzlFcs8/HZ+Xb5SHzVm1dxH7aUiI+A8kA8Gcrm0A==
+
+"@types/ws@^8.5.10":
+  version "8.18.1"
+  resolved "https://registry.yarnpkg.com/@types/ws/-/ws-8.18.1.tgz#48464e4bf2ddfd17db13d845467f6070ffea4aa9"
+  integrity sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==
+  dependencies:
+    "@types/node" "*"
 
 "@types/ws@^8.5.5":
   version "8.5.10"
@@ -10214,6 +10579,11 @@ ansi-regex@^6.0.1:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-6.0.1.tgz#3183e38fae9a65d7cb5e53945cd5897d0260a06a"
   integrity sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==
 
+ansi-regex@^6.2.2:
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-6.2.2.tgz#60216eea464d864597ce2832000738a0589650c1"
+  integrity sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==
+
 ansi-styles@^2.1.0, ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
@@ -10242,6 +10612,11 @@ ansi-styles@^6.0.0, ansi-styles@^6.1.0, ansi-styles@^6.2.1:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-6.2.1.tgz#0e62320cf99c21afff3b3012192546aacbfb05c5"
   integrity sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==
+
+ansi-styles@^6.2.3:
+  version "6.2.3"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-6.2.3.tgz#c044d5dcc521a076413472597a1acb1f103c4041"
+  integrity sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==
 
 ansicolors@~0.3.2:
   version "0.3.2"
@@ -10501,6 +10876,15 @@ asn1@~0.2.3:
   dependencies:
     safer-buffer "~2.1.0"
 
+asn1js@^3.0.10, asn1js@^3.0.6:
+  version "3.0.10"
+  resolved "https://registry.yarnpkg.com/asn1js/-/asn1js-3.0.10.tgz#df26c874c8a8b41ca605efea47b2ad07551013dd"
+  integrity sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==
+  dependencies:
+    pvtsutils "^1.3.6"
+    pvutils "^1.1.5"
+    tslib "^2.8.1"
+
 assert-plus@1.0.0, assert-plus@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525"
@@ -10594,7 +10978,7 @@ axe-core@^4.10.0:
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.10.3.tgz#04145965ac7894faddbac30861e5d8f11bfd14fc"
   integrity sha512-Xm7bpRXnDSX2YE2YFfBk2FnF0ep6tmG7xPh8iHee8MIcrgq762Nkce856dYtJYLkuIoYZvGfTs/PbZhideTcEg==
 
-axe-core@^4.2.0, axe-core@^4.4.2:
+axe-core@^4.12.1, axe-core@^4.2.0:
   version "4.12.1"
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.12.1.tgz#69fe2bf6dfc0b24973af91b1d8e945f79e1b7c44"
   integrity sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==
@@ -11001,10 +11385,36 @@ body-parser@~1.20.3:
     type-is "~1.6.18"
     unpipe "~1.0.0"
 
+body-parser@~1.20.5:
+  version "1.20.5"
+  resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.20.5.tgz#303c8c34423d1d6fa799bc764e93c1e4dc6ebf64"
+  integrity sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==
+  dependencies:
+    bytes "~3.1.2"
+    content-type "~1.0.5"
+    debug "2.6.9"
+    depd "2.0.0"
+    destroy "~1.2.0"
+    http-errors "~2.0.1"
+    iconv-lite "~0.4.24"
+    on-finished "~2.4.1"
+    qs "~6.15.1"
+    raw-body "~2.5.3"
+    type-is "~1.6.18"
+    unpipe "~1.0.0"
+
 bonjour-service@^1.0.11:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/bonjour-service/-/bonjour-service-1.2.1.tgz#eb41b3085183df3321da1264719fbada12478d02"
   integrity sha512-oSzCS2zV14bh2kji6vNe7vrpJYCHGvcZnlffFQ1MEoX/WOeQ/teD8SYWKR942OI3INjq8OMNJlbPK5LLLUxFDw==
+  dependencies:
+    fast-deep-equal "^3.1.3"
+    multicast-dns "^7.2.5"
+
+bonjour-service@^1.2.1:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/bonjour-service/-/bonjour-service-1.4.2.tgz#33ce18eddf13047e5eeb08939018b20bae1a1473"
+  integrity sha512-lMskhnsW70yWHr4PhPeh2rvaIkLSaDpp+nmtbXBZaNKTXwxL73QOkW6HhbzqTImXjevn9TreGT4GACGBCGP9nQ==
   dependencies:
     fast-deep-equal "^3.1.3"
     multicast-dns "^7.2.5"
@@ -11130,7 +11540,7 @@ buffer-from@^1.0.0:
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
   integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
 
-buffer@^5.5.0, buffer@^5.6.0, buffer@^5.7.1:
+buffer@^5.5.0, buffer@^5.7.1:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.7.1.tgz#ba62e7c13133053582197160851a8f648e99eed0"
   integrity sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==
@@ -11176,6 +11586,11 @@ bytes@3.1.2, bytes@~3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.2.tgz#8b0beeb98605adf1b128fa4386403c009e0221a5"
   integrity sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==
+
+bytestreamjs@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/bytestreamjs/-/bytestreamjs-2.0.1.tgz#a32947c7ce389a6fa11a09a9a563d0a45889535e"
+  integrity sha512-U1Z/ob71V/bXfVABvNr/Kumf5VyeQRBEm6Txb0PQ6S7V5GpBM3w4Cbqz/xPDicR5tN0uvDifng8C+5qECeGwyQ==
 
 cacache@^17.0.0:
   version "17.1.4"
@@ -11249,7 +11664,7 @@ cacheable-request@^7.0.2:
     normalize-url "^6.0.1"
     responselike "^2.0.0"
 
-cachedir@^2.3.0:
+cachedir@^2.3.0, cachedir@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/cachedir/-/cachedir-2.4.0.tgz#7fef9cf7367233d7c88068fe6e34ed0d355a610d"
   integrity sha512-9EtFOZR8g22CL7BWjJ9BUx1+A/djkofnyW3aOXZORNW2kxoUpx2h+uN2cOqwPmFhnpVmxg+KW2OjOSgChTEvsQ==
@@ -11563,7 +11978,7 @@ chokidar@3.5.1:
   optionalDependencies:
     fsevents "~2.3.1"
 
-chokidar@^3.0.0, chokidar@^3.4.2, chokidar@^3.5.3:
+chokidar@^3.0.0, chokidar@^3.4.2, chokidar@^3.5.3, chokidar@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.6.0.tgz#197c6cc669ef2a8dc5e7b4d97ee4e092c3eb0d5b"
   integrity sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==
@@ -11609,6 +12024,11 @@ ci-info@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-4.0.0.tgz#65466f8b280fc019b9f50a5388115d17a63a44f2"
   integrity sha512-TdHqgGf9odd8SXNuxtUBVx8Nv+qZOejE6qyqiy5NtbYYQOeFa6zmHkxlPzmaLxWWHsU6nJmB7AETdVPi+2NBUg==
+
+ci-info@^4.1.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-4.4.0.tgz#7d54eff9f54b45b62401c26032696eb59c8bd18c"
+  integrity sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==
 
 cjs-module-lexer@^1.0.0, cjs-module-lexer@^1.2.3:
   version "1.2.3"
@@ -11706,6 +12126,15 @@ cli-spinners@^2.5.0:
   resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-2.9.2.tgz#1773a8f4b9c4d6ac31563df53b3fc1d79462fe41"
   integrity sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==
 
+cli-table3@0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/cli-table3/-/cli-table3-0.6.1.tgz#36ce9b7af4847f288d3cdd081fbd09bf7bd237b8"
+  integrity sha512-w0q/enDHhPLq44ovMGdQeeDLvwxwavsJX7oQGYt/LrBlYsyaxyDnp6z3QzFut/6kLLKnlcUVJLrpB7KBfgG/RA==
+  dependencies:
+    string-width "^4.2.0"
+  optionalDependencies:
+    colors "1.4.0"
+
 cli-table3@^0.6.0, cli-table3@^0.6.5, cli-table3@~0.6.1:
   version "0.6.5"
   resolved "https://registry.yarnpkg.com/cli-table3/-/cli-table3-0.6.5.tgz#013b91351762739c16a9567c21a04632e449bf2f"
@@ -11745,6 +12174,14 @@ cli-truncate@^4.0.0:
   dependencies:
     slice-ansi "^5.0.0"
     string-width "^7.0.0"
+
+cli-truncate@^5.0.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/cli-truncate/-/cli-truncate-5.2.0.tgz#c8e72aaca8339c773d128c36e0a17c6315b694eb"
+  integrity sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==
+  dependencies:
+    slice-ansi "^8.0.0"
+    string-width "^8.2.0"
 
 cli-width@^2.0.0:
   version "2.2.1"
@@ -11940,6 +12377,11 @@ colors@1.0.3, colors@1.0.x:
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.0.3.tgz#0433f44d809680fdeb60ed260f1b0c262e82a40b"
   integrity sha512-pFGrxThWcWQ2MsAz6RtgeWe4NK2kUE1WfsrvvlctdII745EW9I0yflqhe7++M5LEc7bV2c/9/5zc8sFcpL0Drw==
 
+colors@1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
+  integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
+
 columnify@1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/columnify/-/columnify-1.6.0.tgz#6989531713c9008bb29735e61e37acf5bd553cf3"
@@ -12035,7 +12477,7 @@ compressible@~2.0.18:
   dependencies:
     mime-db ">= 1.43.0 < 2"
 
-compression@1.8.1, compression@^1.7.4:
+compression@1.8.1, compression@^1.7.4, compression@^1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/compression/-/compression-1.8.1.tgz#4a45d909ac16509195a9a28bd91094889c180d79"
   integrity sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==
@@ -12947,6 +13389,11 @@ cycle@1.0.x:
   resolved "https://registry.yarnpkg.com/cycle/-/cycle-1.0.3.tgz#21e80b2be8580f98b468f379430662b046c34ad2"
   integrity sha512-TVF6svNzeQCOpjCqsy0/CSy8VgObG3wXusJ73xW2GbG5rGx7lC8zxDSURicsXI2UsGdi2L0QNRCi745/wUDvsA==
 
+cypress-axe@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/cypress-axe/-/cypress-axe-1.7.0.tgz#258c007db13c637eaffec1cf2765090b521c07a0"
+  integrity sha512-zzJpvAAjauEB3GZl0KYXb8i3w6MztWAt2WM3czYTFyNVC30alDmqCm9E7GwZ4bgkldZJlmHakaVEyu73R5St4w==
+
 cypress-plugin-tab@1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/cypress-plugin-tab/-/cypress-plugin-tab-1.0.5.tgz#a40714148104004bb05ed62b1bf46bb544f8eb4a"
@@ -13002,42 +13449,36 @@ cypress@*:
     untildify "^4.0.0"
     yauzl "^2.10.0"
 
-cypress@13.4.0:
-  version "13.4.0"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-13.4.0.tgz#7d91069983ba7c664c505abde84d3e3e20484344"
-  integrity sha512-KeWNC9xSHG/ewZURVbaQsBQg2mOKw4XhjJZFKjWbEjgZCdxpPXLpJnfq5Jns1Gvnjp6AlnIfpZfWFlDgVKXdWQ==
+cypress@^15.18.0:
+  version "15.18.0"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-15.18.0.tgz#2d98799596c6a730090375c39c440b36726af7b8"
+  integrity sha512-aLfOYSLlVt1b6QSoVUjbCY27taZlYAT8ST47xQbwd9pvQrY/g5gXi12yItZTB+kxkkj+ZcvUYmRLUC95SlCJsw==
   dependencies:
-    "@cypress/request" "^3.0.0"
+    "@cypress/request" "^4.0.0"
     "@cypress/xvfb" "^1.2.4"
-    "@types/node" "^18.17.5"
     "@types/sinonjs__fake-timers" "8.1.1"
     "@types/sizzle" "^2.3.2"
+    "@types/tmp" "^0.2.3"
     arch "^2.2.0"
     blob-util "^2.0.2"
     bluebird "^3.7.2"
-    buffer "^5.6.0"
-    cachedir "^2.3.0"
+    buffer "^5.7.1"
+    cachedir "^2.4.0"
     chalk "^4.1.0"
-    check-more-types "^2.24.0"
-    cli-cursor "^3.1.0"
-    cli-table3 "~0.6.1"
+    ci-info "^4.1.0"
+    cli-table3 "0.6.1"
     commander "^6.2.1"
     common-tags "^1.8.0"
     dayjs "^1.10.4"
     debug "^4.3.4"
-    enquirer "^2.3.6"
     eventemitter2 "6.4.7"
     execa "4.1.0"
     executable "^4.1.1"
-    extract-zip "2.0.1"
-    figures "^3.2.0"
     fs-extra "^9.1.0"
-    getos "^3.2.1"
-    is-ci "^3.0.0"
+    hasha "5.2.2"
     is-installed-globally "~0.4.0"
-    lazy-ass "^1.6.0"
-    listr2 "^3.8.3"
-    lodash "^4.17.21"
+    listr2 "^9.0.5"
+    lodash "^4.17.23"
     log-symbols "^4.0.0"
     minimist "^1.2.8"
     ospath "^1.2.2"
@@ -13045,11 +13486,13 @@ cypress@13.4.0:
     process "^0.11.10"
     proxy-from-env "1.0.0"
     request-progress "^3.0.0"
-    semver "^7.5.3"
     supports-color "^8.1.1"
-    tmp "~0.2.1"
+    systeminformation "^5.31.1"
+    tmp "~0.2.4"
+    tree-kill "1.2.2"
+    tslib "1.14.1"
     untildify "^4.0.0"
-    yauzl "^2.10.0"
+    yauzl "^3.3.1"
 
 cz-customizable@^4.0.0:
   version "4.0.0"
@@ -14965,6 +15408,43 @@ express@^4.17.3:
     utils-merge "1.0.1"
     vary "~1.1.2"
 
+express@^4.22.1:
+  version "4.22.2"
+  resolved "https://registry.yarnpkg.com/express/-/express-4.22.2.tgz#c17ae0981e5efc24b22272f0e041c4662503b700"
+  integrity sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==
+  dependencies:
+    accepts "~1.3.8"
+    array-flatten "1.1.1"
+    body-parser "~1.20.5"
+    content-disposition "~0.5.4"
+    content-type "~1.0.4"
+    cookie "~0.7.1"
+    cookie-signature "~1.0.6"
+    debug "2.6.9"
+    depd "2.0.0"
+    encodeurl "~2.0.0"
+    escape-html "~1.0.3"
+    etag "~1.8.1"
+    finalhandler "~1.3.1"
+    fresh "~0.5.2"
+    http-errors "~2.0.0"
+    merge-descriptors "1.0.3"
+    methods "~1.1.2"
+    on-finished "~2.4.1"
+    parseurl "~1.3.3"
+    path-to-regexp "~0.1.12"
+    proxy-addr "~2.0.7"
+    qs "~6.15.1"
+    range-parser "~1.2.1"
+    safe-buffer "5.2.1"
+    send "~0.19.0"
+    serve-static "~1.16.2"
+    setprototypeof "1.2.0"
+    statuses "~2.0.1"
+    type-is "~1.6.18"
+    utils-merge "1.0.1"
+    vary "~1.1.2"
+
 ext-list@^2.0.0:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/ext-list/-/ext-list-2.2.2.tgz#0b98e64ed82f5acf0f2931babf69212ef52ddd37"
@@ -15410,7 +15890,7 @@ form-data-encoder@^2.1.2:
   resolved "https://registry.yarnpkg.com/form-data-encoder/-/form-data-encoder-2.1.4.tgz#261ea35d2a70d48d30ec7a9603130fa5515e9cd5"
   integrity sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==
 
-form-data@4.0.6, form-data@^3.0.0, form-data@^4.0.0, form-data@^4.0.4, form-data@^4.0.5, form-data@~2.3.2:
+form-data@4.0.6, form-data@^3.0.0, form-data@^4.0.0, form-data@^4.0.4, form-data@^4.0.5, form-data@~2.3.2, form-data@~4.0.4:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.6.tgz#28e864e1b786dbebb68db1f452f9635278665827"
   integrity sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==
@@ -15575,6 +16055,11 @@ get-east-asian-width@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/get-east-asian-width/-/get-east-asian-width-1.2.0.tgz#5e6ebd9baee6fb8b7b6bd505221065f0cd91f64e"
   integrity sha512-2nk+7SIVb14QrgXFHcm84tD4bKQz0RxPuMT8Ag5KPOq7J5fEmAg0UbXdTOSHqNuHSU28k55qnceesxXRZGzKWA==
+
+get-east-asian-width@^1.3.1, get-east-asian-width@^1.5.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz#216900f91df11a8b2c198c3e1d93d6c035a776b9"
+  integrity sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==
 
 get-intrinsic@^1.0.1, get-intrinsic@^1.1.3, get-intrinsic@^1.2.1, get-intrinsic@^1.2.2, get-intrinsic@^1.2.3, get-intrinsic@^1.2.4:
   version "1.2.4"
@@ -15790,6 +16275,11 @@ glob-parent@^6.0.2:
   integrity sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==
   dependencies:
     is-glob "^4.0.3"
+
+glob-to-regex.js@^1.0.0, glob-to-regex.js@^1.0.1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/glob-to-regex.js/-/glob-to-regex.js-1.2.0.tgz#2b323728271d133830850e32311f40766c5f6413"
+  integrity sha512-QMwlOQKU/IzqMUOAZWubUOT8Qft+Y0KQWnX9nK3ch0CJg0tTp4TvGZsTfudYKv2NzoQSyPcnA6TYeIQ3jGichQ==
 
 glob-to-regexp@^0.4.1:
   version "0.4.1"
@@ -16100,6 +16590,14 @@ has-unicode@2.0.1, has-unicode@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
   integrity sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==
+
+hasha@5.2.2:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/hasha/-/hasha-5.2.2.tgz#a48477989b3b327aea3c04f53096d816d97522a1"
+  integrity sha512-Hrp5vIK/xr5SkeN2onO32H0MgNZ0f17HRNH39WfL0SYUNOTZ5Lz1TJ8Pajo/87dYGEFlLMm7mIc/k/s6Bvz9HQ==
+  dependencies:
+    is-stream "^2.0.0"
+    type-fest "^0.8.0"
 
 hasown@^2.0.0, hasown@^2.0.1, hasown@^2.0.2:
   version "2.0.2"
@@ -16524,6 +17022,17 @@ http-proxy-middleware@^2.0.3:
     is-plain-obj "^3.0.0"
     micromatch "^4.0.2"
 
+http-proxy-middleware@^2.0.9:
+  version "2.0.10"
+  resolved "https://registry.yarnpkg.com/http-proxy-middleware/-/http-proxy-middleware-2.0.10.tgz#b2df7b705203d7a8c269ac8450cf96b00c532f94"
+  integrity sha512-RKzRWNPxUZqbuk3BC5mGVJbBnWgr+diEnjJexIOytFbBzDy88Fbh/YvBr3DsNrl1jYAfjWfpATEv0NO35FDuPQ==
+  dependencies:
+    "@types/http-proxy" "^1.17.8"
+    http-proxy "^1.18.1"
+    is-glob "^4.0.1"
+    is-plain-obj "^3.0.0"
+    micromatch "^4.0.2"
+
 http-proxy@^1.18.1:
   version "1.18.1"
   resolved "https://registry.yarnpkg.com/http-proxy/-/http-proxy-1.18.1.tgz#401541f0534884bbf95260334e72f88ee3976549"
@@ -16541,6 +17050,15 @@ http-signature@~1.3.6:
     assert-plus "^1.0.0"
     jsprim "^2.0.2"
     sshpk "^1.14.1"
+
+http-signature@~1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.4.0.tgz#dee5a9ba2bf49416abc544abd6d967f6a94c8c3f"
+  integrity sha512-G5akfn7eKbpDN+8nPS/cb57YeA1jLTVxjpCj7tmm3QKPdyDy7T+qSC40e9ptydSWvkwjSXw1VbkpyEm39ukeAg==
+  dependencies:
+    assert-plus "^1.0.0"
+    jsprim "^2.0.2"
+    sshpk "^1.18.0"
 
 http2-wrapper@^1.0.0-beta.5.2:
   version "1.0.3"
@@ -16600,6 +17118,11 @@ husky@7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/husky/-/husky-7.0.0.tgz#3dbd5d28e76234689ee29bb41e048f28e3e46616"
   integrity sha512-xK7lO0EtSzfFPiw+oQncQVy/XqV7UVVjxBByc+Iv5iK3yhW9boDoWgvZy3OGo48QKg/hUtZkzz0hi2HXa0kn7w==
+
+hyperdyperid@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/hyperdyperid/-/hyperdyperid-1.2.0.tgz#59668d323ada92228d2a869d3e474d5a33b69e6b"
+  integrity sha512-Y93lCzHYgGWdrJ66yIktxiaGULYc6oGiABxhcO5AufBeOyoIdZF7bIfLaOrbM0iGIOXQQgxxRrFEnb+Y6w1n4A==
 
 iconv-lite@0.4.24, iconv-lite@^0.4.17, iconv-lite@^0.4.24, iconv-lite@~0.4.24:
   version "0.4.24"
@@ -16949,6 +17472,11 @@ ipaddr.js@^2.0.1:
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-2.1.0.tgz#2119bc447ff8c257753b196fc5f1ce08a4cdf39f"
   integrity sha512-LlbxQ7xKzfBusov6UMi4MFpEg0m+mAm9xyNGEduwXMEDuf4WfzB/RZwMVYEd7IKGvh4IUkEXYxtAVu9T3OelJQ==
 
+ipaddr.js@^2.1.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-2.4.0.tgz#038e9ceaf8219efc5bb76347b7eb787875d5095b"
+  integrity sha512-9VGk3HGanVE6JoZXHiCpnGy5X0jYDnN4EA4lntFPj+1vIWlFhIylq2CrrCOJH9EAhc5CYhq18F2Av2tgoAPsYQ==
+
 is-alphabetical@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/is-alphabetical/-/is-alphabetical-2.0.1.tgz#01072053ea7c1036df3c7d19a6daaec7f19e789b"
@@ -17041,7 +17569,7 @@ is-callable@^1.1.3, is-callable@^1.1.4, is-callable@^1.2.7:
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.7.tgz#3bc2a85ea742d9e36205dcacdd72ca1fdc51b055"
   integrity sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==
 
-is-ci@3.0.1, is-ci@^3.0.0, is-ci@^3.0.1:
+is-ci@3.0.1, is-ci@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-3.0.1.tgz#db6ecbed1bd659c43dac0f45661e7674103d1867"
   integrity sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==
@@ -17154,6 +17682,13 @@ is-fullwidth-code-point@^5.0.0:
   dependencies:
     get-east-asian-width "^1.0.0"
 
+is-fullwidth-code-point@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz#046b2a6d4f6b156b2233d3207d4b5a9783999b98"
+  integrity sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==
+  dependencies:
+    get-east-asian-width "^1.3.1"
+
 is-generator-fn@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-generator-fn/-/is-generator-fn-2.1.0.tgz#7d140adc389aaf3011a8f2a2a4cfa6faadffb118"
@@ -17230,6 +17765,11 @@ is-negative-zero@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/is-negative-zero/-/is-negative-zero-2.0.3.tgz#ced903a027aca6381b777a5743069d7376a49747"
   integrity sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==
+
+is-network-error@^1.0.0:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/is-network-error/-/is-network-error-1.3.2.tgz#9460bc30f8419a4bca77114f4de88a3ee5e0c519"
+  integrity sha512-PhBY86zaxNZUuWP6h13Vu5oFe0XY6/UlKzQnYFELzGVHygP3MxmvTfYSG7GN3aIab/iWudSMgjSnG9Dq+nHrgA==
 
 is-number-object@^1.0.4:
   version "1.0.7"
@@ -18594,6 +19134,14 @@ launch-editor@^2.6.0:
     picocolors "^1.0.0"
     shell-quote "^1.8.1"
 
+launch-editor@^2.6.1:
+  version "2.14.1"
+  resolved "https://registry.yarnpkg.com/launch-editor/-/launch-editor-2.14.1.tgz#f7e0da3f58aaea03fea01074d840b5f739ed7ddc"
+  integrity sha512-QWBrQsMpH7gPr965dsKD/3cKWiNoTjpATQf++Xq63N6sKRGMwlVXz41O1IZTMfZQgBctD/K5Zt06+/I6pP6+HA==
+  dependencies:
+    picocolors "^1.1.1"
+    shell-quote "^1.8.4"
+
 lazy-ass@1.6.0, lazy-ass@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/lazy-ass/-/lazy-ass-1.6.0.tgz#7999655e8646c17f089fdd187d150d3324d54513"
@@ -18900,6 +19448,18 @@ listr2@^8.2.5:
   integrity sha512-iyAZCeyD+c1gPyE9qpFu8af0Y+MRtmKOncdGoA2S5EY8iFq99dmmvkNnHiWo+pj0s7yH7l3KPIgee77tKpXPWQ==
   dependencies:
     cli-truncate "^4.0.0"
+    colorette "^2.0.20"
+    eventemitter3 "^5.0.1"
+    log-update "^6.1.0"
+    rfdc "^1.4.1"
+    wrap-ansi "^9.0.0"
+
+listr2@^9.0.5:
+  version "9.0.5"
+  resolved "https://registry.yarnpkg.com/listr2/-/listr2-9.0.5.tgz#92df7c4416a6da630eb9ef46da469b70de97b316"
+  integrity sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==
+  dependencies:
+    cli-truncate "^5.0.0"
     colorette "^2.0.20"
     eventemitter3 "^5.0.1"
     log-update "^6.1.0"
@@ -19613,6 +20173,26 @@ memfs@^3.1.2, memfs@^3.4.1, memfs@^3.4.12, memfs@^3.4.3:
   dependencies:
     fs-monkey "^1.0.4"
 
+memfs@^4.43.1:
+  version "4.57.8"
+  resolved "https://registry.yarnpkg.com/memfs/-/memfs-4.57.8.tgz#b9c1995040307c60a1503e65a3e5902ad3927628"
+  integrity sha512-bApYhn8BLpFAnAQmFfEl/NPN+8qx5Ar3V4Qt3ek23mVwBEElzV7c6XoPkb/PCG8ZFpowCEpHcPwMFTwHS7tSMA==
+  dependencies:
+    "@jsonjoy.com/fs-core" "4.57.8"
+    "@jsonjoy.com/fs-fsa" "4.57.8"
+    "@jsonjoy.com/fs-node" "4.57.8"
+    "@jsonjoy.com/fs-node-builtins" "4.57.8"
+    "@jsonjoy.com/fs-node-to-fsa" "4.57.8"
+    "@jsonjoy.com/fs-node-utils" "4.57.8"
+    "@jsonjoy.com/fs-print" "4.57.8"
+    "@jsonjoy.com/fs-snapshot" "4.57.8"
+    "@jsonjoy.com/json-pack" "^1.11.0"
+    "@jsonjoy.com/util" "^1.9.0"
+    glob-to-regex.js "^1.0.1"
+    thingies "^2.5.0"
+    tree-dump "^1.0.3"
+    tslib "^2.0.0"
+
 meow@^12.0.1:
   version "12.1.1"
   resolved "https://registry.yarnpkg.com/meow/-/meow-12.1.1.tgz#e558dddbab12477b69b2e9a2728c327f191bace6"
@@ -19941,6 +20521,11 @@ mime-db@1.52.0, "mime-db@>= 1.43.0 < 2", mime-db@^1.28.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
   integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
 
+mime-db@^1.54.0:
+  version "1.54.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.54.0.tgz#cddb3ee4f9c64530dff640236661d42cb6a314f5"
+  integrity sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==
+
 mime-db@~1.33.0:
   version "1.33.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.33.0.tgz#a3492050a5cb9b63450541e39d9788d2272783db"
@@ -19959,6 +20544,13 @@ mime-types@^2.1.27, mime-types@^2.1.31, mime-types@^2.1.35, mime-types@~2.1.17, 
   integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
   dependencies:
     mime-db "1.52.0"
+
+mime-types@^3.0.1:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-3.0.2.tgz#39002d4182575d5af036ffa118100f2524b2e2ab"
+  integrity sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==
+  dependencies:
+    mime-db "^1.54.0"
 
 mime@1.6.0:
   version "1.6.0"
@@ -20832,7 +21424,7 @@ obug@^2.1.1:
   resolved "https://registry.yarnpkg.com/obug/-/obug-2.1.1.tgz#2cba74ff241beb77d63055ddf4cd1e9f90b538be"
   integrity sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==
 
-on-finished@2.4.1, on-finished@~2.4.1:
+on-finished@2.4.1, on-finished@^2.4.1, on-finished@~2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/on-finished/-/on-finished-2.4.1.tgz#58c8c44116e54845ad57f14ab10b03533184ac3f"
   integrity sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==
@@ -20884,7 +21476,7 @@ onetime@^7.0.0:
   dependencies:
     mimic-function "^5.0.0"
 
-open@^10.2.0:
+open@^10.0.3, open@^10.2.0:
   version "10.2.0"
   resolved "https://registry.yarnpkg.com/open/-/open-10.2.0.tgz#b9d855be007620e80b6fb05fac98141fe62db73c"
   integrity sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==
@@ -21204,6 +21796,15 @@ p-retry@^4.5.0:
   integrity sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==
   dependencies:
     "@types/retry" "0.12.0"
+    retry "^0.13.1"
+
+p-retry@^6.2.0:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/p-retry/-/p-retry-6.2.1.tgz#81828f8dc61c6ef5a800585491572cc9892703af"
+  integrity sha512-hEt02O4hUct5wtwg4H4KcWgDdm+l1bOaEy/hWzd8xtXB9BqxTWBBhb+2ImAtH4Cv4rPjV76xN3Zumqk3k3AhhQ==
+  dependencies:
+    "@types/retry" "0.12.2"
+    is-network-error "^1.0.0"
     retry "^0.13.1"
 
 p-some@^6.0.0:
@@ -21640,6 +22241,18 @@ pkginfo@0.3.x:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/pkginfo/-/pkginfo-0.3.1.tgz#5b29f6a81f70717142e09e765bbeab97b4f81e21"
   integrity sha512-yO5feByMzAp96LtP58wvPKSbaKAi/1C4kV9XpTctr6EepnP6F33RBNOiVrdz9BrPA98U2BMFsTNHo44TWcbQ2A==
+
+pkijs@^3.3.3:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/pkijs/-/pkijs-3.4.0.tgz#d9164def30ff6d97be2d88966d5e36192499ca9c"
+  integrity sha512-emEcLuomt2j03vxD54giVB4SxTjnsqkU692xZOZXHDVoYyypEm+b3jpiTcc+Cf+myooc+/Ly0z01jqeNHVgJGw==
+  dependencies:
+    "@noble/hashes" "1.4.0"
+    asn1js "^3.0.6"
+    bytestreamjs "^2.0.1"
+    pvtsutils "^1.3.6"
+    pvutils "^1.1.3"
+    tslib "^2.8.1"
 
 platform@1.3.3:
   version "1.3.3"
@@ -22550,6 +23163,18 @@ punycode@^2.1.0, punycode@^2.1.1, punycode@^2.3.1:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.1.tgz#027422e2faec0b25e1549c3e1bd8309b9133b6e5"
   integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
 
+pvtsutils@^1.3.6:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/pvtsutils/-/pvtsutils-1.3.6.tgz#ec46e34db7422b9e4fdc5490578c1883657d6001"
+  integrity sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==
+  dependencies:
+    tslib "^2.8.1"
+
+pvutils@^1.1.3, pvutils@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/pvutils/-/pvutils-1.1.5.tgz#84b0dea4a5d670249aa9800511804ee0b7c2809c"
+  integrity sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==
+
 q@^1.1.2, q@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
@@ -22582,6 +23207,14 @@ qs@^6.15.0:
   integrity sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==
   dependencies:
     side-channel "^1.1.0"
+
+qs@^6.15.2, qs@~6.15.1:
+  version "6.15.3"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.15.3.tgz#76852132a58ed5c7c0ef67e4441b9bb5d6061b3b"
+  integrity sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==
+  dependencies:
+    es-define-property "^1.0.1"
+    side-channel "^1.1.1"
 
 querystringify@^2.1.1:
   version "2.2.0"
@@ -23184,6 +23817,11 @@ redeyed@~2.1.0:
   integrity sha512-FNpGGo1DycYAdnrKFxCMmKYgo/mILAqtRYbkdQD8Ep/Hk2PQ5+aEAEx+IU713RTDmuBaH0c8P5ZozurNu5ObRQ==
   dependencies:
     esprima "~4.0.0"
+
+reflect-metadata@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/reflect-metadata/-/reflect-metadata-0.2.2.tgz#400c845b6cba87a21f2c65c4aeb158f4fa4d9c5b"
+  integrity sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==
 
 reflect.getprototypeof@^1.0.4:
   version "1.0.6"
@@ -24108,7 +24746,7 @@ schema-utils@^3.0.0, schema-utils@^3.1.1:
     ajv "^6.12.5"
     ajv-keywords "^3.5.2"
 
-schema-utils@^4.0.0, schema-utils@^4.3.0, schema-utils@^4.3.3:
+schema-utils@^4.0.0, schema-utils@^4.2.0, schema-utils@^4.3.0, schema-utils@^4.3.3:
   version "4.3.3"
   resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-4.3.3.tgz#5b1850912fa31df90716963d45d9121fdfc09f46"
   integrity sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==
@@ -24137,6 +24775,14 @@ selfsigned@^2.1.1:
   dependencies:
     "@types/node-forge" "^1.3.0"
     node-forge "^1"
+
+selfsigned@^5.5.0:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/selfsigned/-/selfsigned-5.5.0.tgz#4c9ab7c7c9f35f18fb6a9882c253eb0e6bd6557b"
+  integrity sha512-ftnu3TW4+3eBfLRFnDEkzGxSF/10BJBkaLJuBHZX0kiPS7bRdlpZGu6YGt4KngMkdTwJE6MbjavFpqHvqVt+Ew==
+  dependencies:
+    "@peculiar/x509" "^1.14.2"
+    pkijs "^3.3.3"
 
 semver-regex@^4.0.5:
   version "4.0.5"
@@ -24367,6 +25013,11 @@ shell-quote@^1.7.3, shell-quote@^1.8.0, shell-quote@^1.8.1:
   resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.8.1.tgz#6dbf4db75515ad5bac63b4f1894c3a154c766680"
   integrity sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==
 
+shell-quote@^1.8.4:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.9.0.tgz#e108b1a136586d5964edb3300016d4bedba0fe57"
+  integrity sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==
+
 shelljs@0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.7.0.tgz#3f6f2e4965cec565f65ff3861d644f879281a576"
@@ -24383,6 +25034,14 @@ side-channel-list@^1.0.0:
   dependencies:
     es-errors "^1.3.0"
     object-inspect "^1.13.3"
+
+side-channel-list@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/side-channel-list/-/side-channel-list-1.0.1.tgz#c2e0b5a14a540aebee3bbc6c3f8666cc9b509127"
+  integrity sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==
+  dependencies:
+    es-errors "^1.3.0"
+    object-inspect "^1.13.4"
 
 side-channel-map@^1.0.1:
   version "1.0.1"
@@ -24423,6 +25082,17 @@ side-channel@^1.1.0:
     es-errors "^1.3.0"
     object-inspect "^1.13.3"
     side-channel-list "^1.0.0"
+    side-channel-map "^1.0.1"
+    side-channel-weakmap "^1.0.2"
+
+side-channel@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.1.1.tgz#ea02c62e05dc4bea67d4442f0fb71ee192f8e0ab"
+  integrity sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==
+  dependencies:
+    es-errors "^1.3.0"
+    object-inspect "^1.13.4"
+    side-channel-list "^1.0.1"
     side-channel-map "^1.0.1"
     side-channel-weakmap "^1.0.2"
 
@@ -24560,6 +25230,14 @@ slice-ansi@^7.1.0:
   dependencies:
     ansi-styles "^6.2.1"
     is-fullwidth-code-point "^5.0.0"
+
+slice-ansi@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-8.0.0.tgz#22d0b66d18bc5c57f488bfcf36cbde3bef731537"
+  integrity sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==
+  dependencies:
+    ansi-styles "^6.2.3"
+    is-fullwidth-code-point "^5.1.0"
 
 sliced@^1.0.1:
   version "1.0.1"
@@ -24794,7 +25472,7 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==
 
-sshpk@^1.14.1:
+sshpk@^1.14.1, sshpk@^1.18.0:
   version "1.18.0"
   resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.18.0.tgz#1663e55cddf4d688b86a46b77f0d5fe363aba028"
   integrity sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==
@@ -25040,6 +25718,14 @@ string-width@^7.0.0:
     get-east-asian-width "^1.0.0"
     strip-ansi "^7.1.0"
 
+string-width@^8.2.0:
+  version "8.2.1"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-8.2.1.tgz#165089cfa527cc88fbc23dd73313f5e334af1ea1"
+  integrity sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==
+  dependencies:
+    get-east-asian-width "^1.5.0"
+    strip-ansi "^7.1.2"
+
 string.prototype.includes@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/string.prototype.includes/-/string.prototype.includes-2.0.1.tgz#eceef21283640761a81dbe16d6c7171a4edf7d92"
@@ -25189,6 +25875,13 @@ strip-ansi@^7.0.0, strip-ansi@^7.0.1, strip-ansi@^7.1.0:
   integrity sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==
   dependencies:
     ansi-regex "^6.0.1"
+
+strip-ansi@^7.1.2:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-7.2.0.tgz#d22a269522836a627af8d04b5c3fd2c7fa3e32e3"
+  integrity sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==
+  dependencies:
+    ansi-regex "^6.2.2"
 
 strip-bom@^3.0.0:
   version "3.0.0"
@@ -25436,6 +26129,11 @@ symbol-tree@^3.2.4:
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
   integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
 
+systeminformation@^5.31.1:
+  version "5.31.11"
+  resolved "https://registry.yarnpkg.com/systeminformation/-/systeminformation-5.31.11.tgz#9c637ff3e8d19a482deff70a136330e1b2399f00"
+  integrity sha512-I6O7iaUj23AXRgCPDDnvi3xHvdOLp4+1YMbF+X194lJwY1NeWojgHJPhslVKcmTtrLTguRk3QJK+xEdTiI3P0w==
+
 tabbable@^6.0.0:
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-6.4.0.tgz#36eb7a06d80b3924a22095daf45740dea3bf5581"
@@ -25629,6 +26327,11 @@ thenify-all@^1.0.0:
   dependencies:
     any-promise "^1.0.0"
 
+thingies@^2.5.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/thingies/-/thingies-2.6.0.tgz#e09b98b9e6f6caf8a759eca8481fea1de974d2b1"
+  integrity sha512-rMHRjmlFLM1R96UYPvpmnc3LYtdFrT33JIB7L9hetGue1qAPfn1N2LJeEjxUSidu1Iku+haLZXDuEXUHNGO/lg==
+
 throat@^6.0.1:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/throat/-/throat-6.0.2.tgz#51a3fbb5e11ae72e2cf74861ed5c8020f89f29fe"
@@ -25729,10 +26432,22 @@ tinyspy@^4.0.3:
   resolved "https://registry.yarnpkg.com/tinyspy/-/tinyspy-4.0.4.tgz#d77a002fb53a88aa1429b419c1c92492e0c81f78"
   integrity sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==
 
+tldts-core@^6.1.86:
+  version "6.1.86"
+  resolved "https://registry.yarnpkg.com/tldts-core/-/tldts-core-6.1.86.tgz#a93e6ed9d505cb54c542ce43feb14c73913265d8"
+  integrity sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==
+
 tldts-core@^7.4.0:
   version "7.4.0"
   resolved "https://registry.yarnpkg.com/tldts-core/-/tldts-core-7.4.0.tgz#a169874d111f2b56f8bcaba1971de312feb586b8"
   integrity sha512-/mb9kRld+x1sIMXxWNOAp5m6C+D4GrAORWlJkOJ5dElvxdN1eutz/o7qHLp9gFvDF4Y3/L2xeScoxz6AbEo8rQ==
+
+tldts@^6.1.32:
+  version "6.1.86"
+  resolved "https://registry.yarnpkg.com/tldts/-/tldts-6.1.86.tgz#087e0555b31b9725ee48ca7e77edc56115cd82f7"
+  integrity sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==
+  dependencies:
+    tldts-core "^6.1.86"
 
 tldts@^7.0.5:
   version "7.4.0"
@@ -25759,6 +26474,11 @@ tmp@~0.2.1:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.3.tgz#eb783cc22bc1e8bebd0671476d46ea4eb32a79ae"
   integrity sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==
+
+tmp@~0.2.4:
+  version "0.2.7"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.7.tgz#26f4db11d1601ce8012dcb8a798ece1c06a99059"
+  integrity sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==
 
 tmpl@1.0.5:
   version "1.0.5"
@@ -25813,6 +26533,13 @@ tough-cookie@^4.0.0, tough-cookie@^4.1.3:
     universalify "^0.2.0"
     url-parse "^1.5.3"
 
+tough-cookie@^5.0.0:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-5.1.2.tgz#66d774b4a1d9e12dc75089725af3ac75ec31bed7"
+  integrity sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==
+  dependencies:
+    tldts "^6.1.32"
+
 tough-cookie@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-6.0.1.tgz#a495f833836609ed983c19bc65639cfbceb54c76"
@@ -25846,7 +26573,12 @@ tr46@~0.0.3:
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
   integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
 
-tree-kill@^1.2.2:
+tree-dump@^1.0.3, tree-dump@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/tree-dump/-/tree-dump-1.1.0.tgz#ab29129169dc46004414f5a9d4a3c6e89f13e8a4"
+  integrity sha512-rMuvhU4MCDbcbnleZTFezWsaZXRFemSqAM+7jPnzUl1fo9w3YEKOxAeui0fz3OI4EU4hf23iyA7uQRVko+UaBA==
+
+tree-kill@1.2.2, tree-kill@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/tree-kill/-/tree-kill-1.2.2.tgz#4ca09a9092c88b73a7cdc5e8a01b507b0790a0cc"
   integrity sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==
@@ -25938,15 +26670,15 @@ tsconfig-paths@^4.1.2, tsconfig-paths@^4.2.0:
     minimist "^1.2.6"
     strip-bom "^3.0.0"
 
+tslib@1.14.1, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
+  integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
+
 tslib@2.6.3, tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.0, tslib@^2.4.0:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.3.tgz#0438f810ad7a9edcde7a241c3d80db693c8cbfe0"
   integrity sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==
-
-tslib@^1.8.1, tslib@^1.9.0:
-  version "1.14.1"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
-  integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
 tslib@^2.8.1:
   version "2.8.1"
@@ -25959,6 +26691,13 @@ tsutils@^3.21.0:
   integrity sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==
   dependencies:
     tslib "^1.8.1"
+
+tsyringe@^4.10.0:
+  version "4.10.0"
+  resolved "https://registry.yarnpkg.com/tsyringe/-/tsyringe-4.10.0.tgz#d0c95815d584464214060285eaaadd94aa03299c"
+  integrity sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw==
+  dependencies:
+    tslib "^1.9.3"
 
 tuf-js@^1.1.7:
   version "1.1.7"
@@ -26037,7 +26776,7 @@ type-fest@^0.6.0:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.6.0.tgz#8d2a2370d3df886eb5c90ada1c5bf6188acf838b"
   integrity sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==
 
-type-fest@^0.8.1:
+type-fest@^0.8.0, type-fest@^0.8.1:
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
@@ -26936,6 +27675,18 @@ webpack-dev-middleware@^6.1.2:
     range-parser "^1.2.1"
     schema-utils "^4.0.0"
 
+webpack-dev-middleware@^7.4.2:
+  version "7.4.5"
+  resolved "https://registry.yarnpkg.com/webpack-dev-middleware/-/webpack-dev-middleware-7.4.5.tgz#d4e8720aa29cb03bc158084a94edb4594e3b7ac0"
+  integrity sha512-uxQ6YqGdE4hgDKNf7hUiPXOdtkXvBJXrfEGYSx7P7LC8hnUYGK70X6xQXUvXeNyBDDcsiQXpG2m3G9vxowaEuA==
+  dependencies:
+    colorette "^2.0.10"
+    memfs "^4.43.1"
+    mime-types "^3.0.1"
+    on-finished "^2.4.1"
+    range-parser "^1.2.1"
+    schema-utils "^4.0.0"
+
 webpack-dev-server@^4.6.0:
   version "4.15.2"
   resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-4.15.2.tgz#9e0c70a42a012560860adb186986da1248333173"
@@ -26971,6 +27722,40 @@ webpack-dev-server@^4.6.0:
     spdy "^4.0.2"
     webpack-dev-middleware "^5.3.4"
     ws "^8.13.0"
+
+webpack-dev-server@^5:
+  version "5.2.5"
+  resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-5.2.5.tgz#648fceaac6a5736b0935e5c1e55d6aa1d0626119"
+  integrity sha512-4wZtCquSuv9CKX8oybo+mqxtxZqWz47uM1Ch94lxowBztOhWCbhqvRbfC/mODOwxgV2brY+JGZpHq58/SuVFYg==
+  dependencies:
+    "@types/bonjour" "^3.5.13"
+    "@types/connect-history-api-fallback" "^1.5.4"
+    "@types/express" "^4.17.25"
+    "@types/express-serve-static-core" "^4.17.21"
+    "@types/serve-index" "^1.9.4"
+    "@types/serve-static" "^1.15.5"
+    "@types/sockjs" "^0.3.36"
+    "@types/ws" "^8.5.10"
+    ansi-html-community "^0.0.8"
+    bonjour-service "^1.2.1"
+    chokidar "^3.6.0"
+    colorette "^2.0.10"
+    compression "^1.8.1"
+    connect-history-api-fallback "^2.0.0"
+    express "^4.22.1"
+    graceful-fs "^4.2.6"
+    http-proxy-middleware "^2.0.9"
+    ipaddr.js "^2.1.0"
+    launch-editor "^2.6.1"
+    open "^10.0.3"
+    p-retry "^6.2.0"
+    schema-utils "^4.2.0"
+    selfsigned "^5.5.0"
+    serve-index "^1.9.1"
+    sockjs "^0.3.24"
+    spdy "^4.0.2"
+    webpack-dev-middleware "^7.4.2"
+    ws "^8.18.0"
 
 webpack-hot-middleware@^2.25.1:
   version "2.26.1"
@@ -27769,6 +28554,13 @@ yauzl@^2.10.0:
   dependencies:
     buffer-crc32 "~0.2.3"
     fd-slicer "~1.1.0"
+
+yauzl@^3.3.1:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/yauzl/-/yauzl-3.4.0.tgz#88b2a21455f37ca7dccf2eeb33bacb4392322719"
+  integrity sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==
+  dependencies:
+    pend "~1.2.0"
 
 yocto-queue@^0.1.0:
   version "0.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10978,7 +10978,7 @@ axe-core@^4.10.0:
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.10.3.tgz#04145965ac7894faddbac30861e5d8f11bfd14fc"
   integrity sha512-Xm7bpRXnDSX2YE2YFfBk2FnF0ep6tmG7xPh8iHee8MIcrgq762Nkce856dYtJYLkuIoYZvGfTs/PbZhideTcEg==
 
-axe-core@^4.12.1, axe-core@^4.2.0:
+axe-core@^4.12.1, axe-core@^4.2.0, axe-core@^4.4.2:
   version "4.12.1"
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.12.1.tgz#69fe2bf6dfc0b24973af91b1d8e945f79e1b7c44"
   integrity sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==


### PR DESCRIPTION
## Purpose
Installs and wires up cypress-axe so `cy.checkA11y()` is available in all component tests

* Adds cypress/support/check-a11y.ts — overwrites checkA11y with lazy axe injection, global suppression of four structural rules that don't apply to isolated components (html-has-lang, landmark-one-main, page-has-heading-one, region), and terminal-friendly violation output via cy.task('log')
* Updates CONTRIBUTING.md with a dedicated Accessibility section covering all three a11y layers now in the repo: Storybook addon, vitest-axe (unit), and cypress-axe (component)


### Context
This is the third piece of the accessibility testing setup, following the Storybook addon (#2179) and vitest-axe (#2180). The cypress-axe pattern and configuration are aligned with how it's set up in the user_interface repo.

### How to test
Add cy.checkA11y() to any existing component spec and run yarn cypress open --component to confirm violations are caught and reported in the terminal.