### PR TITLE
fix: show max char count capped by technical limits, add missing translations [ES-443]

### DIFF
--- a/packages/_shared/src/CharCounter.tsx
+++ b/packages/_shared/src/CharCounter.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 
 import tokens from '@contentful/f36-tokens';
 import { css, cx } from '@emotion/css';
+import { plural, t } from '@lingui/core/macro';
 
 interface CharCounterProps {
   value?: string;
@@ -27,7 +28,13 @@ export function CharCounter(props: CharCounterProps) {
         [styles.invalid]: !valid,
       })}
     >
-      {count} characters
+      {t({
+        id: 'FieldEditors.Shared.CharCounter.Counter',
+        message: plural(count, {
+          one: '1 character',
+          other: '{count} characters',
+        }),
+      })}
     </span>
   );
 }

--- a/packages/_shared/src/CharValidation.tsx
+++ b/packages/_shared/src/CharValidation.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
 
+import { Trans } from '@lingui/react';
+
 import { ValidationType } from './types';
 
 interface CharValidationProps {
@@ -10,13 +12,33 @@ export function CharValidation(props: CharValidationProps) {
   const { constraints } = props;
 
   if (constraints.type === 'max') {
-    return <span>Maximum {constraints.max} characters</span>;
+    return (
+      <span>
+        <Trans
+          id="FieldEditors.Shared.CharValidation.MaxConstraint"
+          values={{ max: constraints.max }}
+          message="Maximum {max} characters"
+        />
+      </span>
+    );
   } else if (constraints.type === 'min') {
-    return <span>Requires at least {constraints.min} characters</span>;
+    return (
+      <span>
+        <Trans
+          id="FieldEditors.Shared.CharValidation.MinConstraint"
+          values={{ min: constraints.min }}
+          message="Requires at least {min} characters"
+        />
+      </span>
+    );
   } else {
     return (
       <span>
-        Requires between {constraints.min} and {constraints.max} characters
+        <Trans
+          id="FieldEditors.Shared.CharValidation.MinMaxConstraint"
+          values={{ max: constraints.max, min: constraints.min }}
+          message="Requires between {min} and {max} characters"
+        />
       </span>
     );
   }

--- a/packages/_shared/src/CharValidation.tsx
+++ b/packages/_shared/src/CharValidation.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { Trans } from '@lingui/react';
+import { t } from '@lingui/core/macro';
 
 import { ValidationType } from './types';
 
@@ -12,33 +12,33 @@ export function CharValidation(props: CharValidationProps) {
   const { constraints } = props;
 
   if (constraints.type === 'max') {
+    const { max } = constraints;
     return (
       <span>
-        <Trans
-          id="FieldEditors.Shared.CharValidation.MaxConstraint"
-          values={{ max: constraints.max }}
-          message="Maximum {max} characters"
-        />
+        {t({
+          id: 'FieldEditors.Shared.CharValidation.MaximumConstraint',
+          message: `Maximum ${max} characters`,
+        })}
       </span>
     );
   } else if (constraints.type === 'min') {
+    const { min } = constraints;
     return (
       <span>
-        <Trans
-          id="FieldEditors.Shared.CharValidation.MinConstraint"
-          values={{ min: constraints.min }}
-          message="Requires at least {min} characters"
-        />
+        {t({
+          id: 'FieldEditors.Shared.CharValidation.MinimumConstraint',
+          message: `Requires at least ${min} characters`,
+        })}
       </span>
     );
   } else {
+    const { max, min } = constraints;
     return (
       <span>
-        <Trans
-          id="FieldEditors.Shared.CharValidation.MinMaxConstraint"
-          values={{ max: constraints.max, min: constraints.min }}
-          message="Requires between {min} and {max} characters"
-        />
+        {t({
+          id: 'FieldEditors.Shared.CharValidation.MinMaxConstraint',
+          message: `Requires between ${min} and ${max} characters`,
+        })}
       </span>
     );
   }

--- a/packages/_shared/src/utils/constraints.ts
+++ b/packages/_shared/src/utils/constraints.ts
@@ -29,7 +29,7 @@ export function fromFieldValidations(
     return {
       type: 'min-max',
       min,
-      max: Math.max(max, MAX_LIMITS[fieldType]),
+      max: Math.min(max, MAX_LIMITS[fieldType]),
     };
   } else if (isNumber(min)) {
     return {
@@ -39,7 +39,7 @@ export function fromFieldValidations(
   } else if (isNumber(max)) {
     return {
       type: 'max',
-      max: Math.max(max, MAX_LIMITS[fieldType]),
+      max: Math.min(max, MAX_LIMITS[fieldType]),
     };
   } else {
     return {

--- a/packages/_shared/src/utils/constraints.ts
+++ b/packages/_shared/src/utils/constraints.ts
@@ -29,7 +29,7 @@ export function fromFieldValidations(
     return {
       type: 'min-max',
       min,
-      max,
+      max: Math.max(max, MAX_LIMITS[fieldType]),
     };
   } else if (isNumber(min)) {
     return {
@@ -39,7 +39,7 @@ export function fromFieldValidations(
   } else if (isNumber(max)) {
     return {
       type: 'max',
-      max,
+      max: Math.max(max, MAX_LIMITS[fieldType]),
     };
   } else {
     return {

--- a/packages/_test/src/lingui-macro-stub.ts
+++ b/packages/_test/src/lingui-macro-stub.ts
@@ -1,0 +1,15 @@
+export function t(obj: { id?: string; message: string } | string): string {
+  if (typeof obj === 'object' && obj.message !== undefined) {
+    return obj.message;
+  }
+  return String(obj);
+}
+
+export function plural(
+  count: number,
+  forms: { one?: string; other?: string; [key: string]: string | undefined },
+): string {
+  const form = count === 1 ? 'one' : 'other';
+  const template = String(forms[form] ?? forms.other ?? forms.one ?? '');
+  return template.replace(/#/g, String(count)).replace(/\{count\}/g, String(count));
+}

--- a/packages/single-line/src/SingleLineEditor.test.tsx
+++ b/packages/single-line/src/SingleLineEditor.test.tsx
@@ -152,6 +152,35 @@ describe('SingleLineEditor', () => {
           {
             size: {
               min: 100,
+              max: 200,
+            },
+          },
+        ],
+        id: 'field-id',
+      };
+    });
+
+    const { getByText } = render(
+      <SingleLineEditor
+        field={field}
+        isInitiallyDisabled={false}
+        locales={createFakeLocalesAPI()}
+      />,
+    );
+
+    expect(getByText('0 characters')).toBeInTheDocument();
+    expect(getByText('Requires between 100 and 200 characters')).toBeInTheDocument();
+  });
+
+  it('caps min-max validation message at the technical limit', () => {
+    const [field] = createFakeFieldAPI((field) => {
+      return {
+        ...field,
+        type: 'Symbol',
+        validations: [
+          {
+            size: {
+              min: 100,
               max: 1000,
             },
           },
@@ -169,7 +198,35 @@ describe('SingleLineEditor', () => {
     );
 
     expect(getByText('0 characters')).toBeInTheDocument();
-    expect(getByText('Requires between 100 and 1000 characters')).toBeInTheDocument();
+    expect(getByText('Requires between 100 and 256 characters')).toBeInTheDocument();
+  });
+
+  it('caps max-only validation message at the technical limit', () => {
+    const [field] = createFakeFieldAPI((field) => {
+      return {
+        ...field,
+        type: 'Symbol',
+        validations: [
+          {
+            size: {
+              max: 1000,
+            },
+          },
+        ],
+        id: 'field-id',
+      };
+    });
+
+    const { getByText } = render(
+      <SingleLineEditor
+        field={field}
+        isInitiallyDisabled={false}
+        locales={createFakeLocalesAPI()}
+      />,
+    );
+
+    expect(getByText('0 characters')).toBeInTheDocument();
+    expect(getByText('Maximum 256 characters')).toBeInTheDocument();
   });
 
   it('shows proper min validation message', () => {

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,13 +1,37 @@
-import { i18n } from '@lingui/core';
 import { cleanup } from '@testing-library/react';
-import { afterEach, expect } from 'vitest';
+import { afterEach, expect, vi } from 'vitest';
 import '@testing-library/jest-dom/vitest';
 import * as matchers from 'vitest-axe/matchers';
-
-i18n.activate('en-US');
 
 expect.extend(matchers);
 
 afterEach(() => {
   cleanup();
 });
+
+vi.mock('@lingui/core/macro', () => ({
+  t: vi.fn((obj) => {
+    if (typeof obj === 'object' && obj.message !== undefined) {
+      return typeof obj.message === 'string' ? obj.message : String(obj.message);
+    }
+    return String(obj);
+  }),
+  plural: vi.fn((count, forms) => {
+    const form = count === 1 ? 'one' : 'other';
+    const template = String(forms[form] ?? forms.other ?? forms.one ?? '');
+    return template.replace(/#/g, String(count)).replace(/\{count\}/g, String(count));
+  }),
+}));
+
+vi.mock('@lingui/core', () => ({
+  i18n: {
+    _: vi.fn((obj) => {
+      if (typeof obj === 'object' && obj.message) {
+        return obj.message;
+      }
+      return obj;
+    }),
+    activate: vi.fn(),
+    load: vi.fn(),
+  },
+}));

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,8 +1,10 @@
+import { i18n } from '@lingui/core';
 import { cleanup } from '@testing-library/react';
 import { afterEach, expect } from 'vitest';
-
 import '@testing-library/jest-dom/vitest';
 import * as matchers from 'vitest-axe/matchers';
+
+i18n.activate('en-US');
 
 expect.extend(matchers);
 

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,5 +1,5 @@
 import { cleanup } from '@testing-library/react';
-import { afterEach, vi, expect } from 'vitest';
+import { afterEach, expect } from 'vitest';
 
 import '@testing-library/jest-dom/vitest';
 import * as matchers from 'vitest-axe/matchers';
@@ -9,33 +9,3 @@ expect.extend(matchers);
 afterEach(() => {
   cleanup();
 });
-
-vi.mock('@lingui/core/macro', () => ({
-  t: vi.fn((obj) => {
-    if (typeof obj === 'object' && obj.message) {
-      return obj.message;
-    }
-    return obj;
-  }),
-  plural: vi.fn((count, obj) => {
-    if (typeof obj === 'object') {
-      const form = count === 1 ? 'one' : 'other';
-      const message = obj[form] || obj.other || obj.one || '';
-      return message.replace(/#/g, count);
-    }
-    return obj;
-  }),
-}));
-
-vi.mock('@lingui/core', () => ({
-  i18n: {
-    _: vi.fn((obj) => {
-      if (typeof obj === 'object' && obj.message) {
-        return obj.message;
-      }
-      return obj;
-    }),
-    activate: vi.fn(),
-    load: vi.fn(),
-  },
-}));

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,37 +1,13 @@
+import { i18n } from '@lingui/core';
 import { cleanup } from '@testing-library/react';
-import { afterEach, expect, vi } from 'vitest';
+import { afterEach, expect } from 'vitest';
 import '@testing-library/jest-dom/vitest';
 import * as matchers from 'vitest-axe/matchers';
+
+i18n.activate('en-US');
 
 expect.extend(matchers);
 
 afterEach(() => {
   cleanup();
 });
-
-vi.mock('@lingui/core/macro', () => ({
-  t: vi.fn((obj) => {
-    if (typeof obj === 'object' && obj.message !== undefined) {
-      return typeof obj.message === 'string' ? obj.message : String(obj.message);
-    }
-    return String(obj);
-  }),
-  plural: vi.fn((count, forms) => {
-    const form = count === 1 ? 'one' : 'other';
-    const template = String(forms[form] ?? forms.other ?? forms.one ?? '');
-    return template.replace(/#/g, String(count)).replace(/\{count\}/g, String(count));
-  }),
-}));
-
-vi.mock('@lingui/core', () => ({
-  i18n: {
-    _: vi.fn((obj) => {
-      if (typeof obj === 'object' && obj.message) {
-        return obj.message;
-      }
-      return obj;
-    }),
-    activate: vi.fn(),
-    load: vi.fn(),
-  },
-}));

--- a/vitest.shared.ts
+++ b/vitest.shared.ts
@@ -6,7 +6,7 @@ const rootDir = fileURLToPath(new URL('.', import.meta.url));
 
 export function createVitestConfig(packageName: string) {
   return {
-    plugins: [react({ plugins: [['@lingui/swc-plugin', {}]] })],
+    plugins: [react()],
     test: {
       globals: false,
       environment: 'jsdom' as const,

--- a/vitest.shared.ts
+++ b/vitest.shared.ts
@@ -6,7 +6,7 @@ const rootDir = fileURLToPath(new URL('.', import.meta.url));
 
 export function createVitestConfig(packageName: string) {
   return {
-    plugins: [react()],
+    plugins: [react({ plugins: [['@lingui/swc-plugin', {}]] })],
     test: {
       globals: false,
       environment: 'jsdom' as const,

--- a/vitest.shared.ts
+++ b/vitest.shared.ts
@@ -7,6 +7,11 @@ const rootDir = fileURLToPath(new URL('.', import.meta.url));
 export function createVitestConfig(packageName: string) {
   return {
     plugins: [react()],
+    resolve: {
+      alias: {
+        '@lingui/core/macro': resolve(rootDir, 'packages/_test/src/lingui-macro-stub.ts'),
+      },
+    },
     test: {
       globals: false,
       environment: 'jsdom' as const,


### PR DESCRIPTION
* Caps char validation to the technical limit based on field type, so that users are not confused by custom limits that go beyond them
* Adds a few missing translations to char counters & validation