### PR TITLE
fix: avoid disclosing raw error details via console.error [TOL-4240]

### DIFF
--- a/tools/extract-new-translation-keys/extract-new-translation-keys.mjs
+++ b/tools/extract-new-translation-keys/extract-new-translation-keys.mjs
@@ -100,8 +100,8 @@ async function runCommand(command, message) {
     const result = await command();
     console.log(' DONE');
     return result;
-  } catch (error) {
-    console.error(`\nError: ${error}`);
+  } catch {
+    console.error(`\nError: ${message} failed.`);
     process.exit(1);
   }
 }
@@ -223,8 +223,8 @@ async function createTranslationEntry(client, key, messageEntry) {
         environmentId: ENVIRONMENT_ID,
         entryId: messageEntry.sys.id,
       });
-    } catch (err) {
-      console.error(err);
+    } catch (cleanupErr) {
+      console.error(`Failed to clean up entries for key ${key} (${cleanupErr.name}).`);
     }
 
     if (
@@ -234,7 +234,7 @@ async function createTranslationEntry(client, key, messageEntry) {
       console.error(`Entry for key ${key} already exists.`);
       return;
     }
-    console.error(err);
+    console.error(`Failed to create entry for key ${key} (${err.name}).`);
   }
 }
 


### PR DESCRIPTION
## Summary
- `console.error` calls in this script printed error details (raw `Error` objects, or `err.message`) which for CMA SDK errors is a JSON blob of the request URL, method, payload, and response details — a stack-trace/error-disclosure risk flagged by Wiz.
- Fixed all three catch blocks to log only a static description of what failed, with no error content at all:
  - `runCommand`'s catch now logs `` `${message} failed.` `` (the step description already passed in by each call site) instead of any part of the caught error.
  - The two catch blocks in `createTranslationEntry` (CMA SDK errors from `client.entry.create/delete/publish`) log `err.name`/`cleanupErr.name` only — a short error code, not the message (which the SDK builds as a JSON blob including request/response internals).
- Addresses Wiz SAST finding [ACT-3797](https://contentful.atlassian.net/browse/ACT-3797) (Disclosure of Error Details and Stack Traces, High severity).
- Jira: [TOL-4240](https://contentful.atlassian.net/browse/TOL-4240)

## Context
This is a standalone, manually-run dev CLI script (`npm run upload-translation-keys`), not executed in CI and not part of the published packages. No Sentry/monitoring equivalent exists in this repo.

## Test plan
- [x] `node --check` passes on the modified file
- [x] `eslint` passes with no errors
- [ ] Manual run of `npm run upload-translation-keys <token>` to confirm error paths still print a useful message (not required for this diff, but recommended before merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ACT-3797]: https://contentful.atlassian.net/browse/ACT-3797?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TOL-4240]: https://contentful.atlassian.net/browse/TOL-4240?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ