### PR TITLE
fix: update CODEOWNERS to use group-applied-ai-solutions [AIS-66]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 cypress/        @contentful/team-content-authoring-and-publishing
 packages/        @contentful/team-content-authoring-and-publishing
 
-apps/    @contentful/team-marketplace
+apps/    @contentful/group-applied-ai-solutions


### PR DESCRIPTION
[AIS-66](https://contentful.atlassian.net/browse/AIS-66) / [AIS-60](https://contentful.atlassian.net/browse/AIS-60)

## What's happening here

We're migrating GitHub ownership away from the old Ecosystem-era teams over to the new `group-applied-ai-solutions` group. This PR is the CODEOWNERS piece of that for `field-editors` — it swaps out `@contentful/team-marketplace` wherever they show up and points those paths at `@contentful/group-applied-ai-solutions` instead.

The only line that changes is the rule for `apps/`. Everything else in the file is untouched.

## Before this can merge, someone needs to update repo access

Here's the thing: `group-applied-ai-solutions` doesn't have confirmed Write access to this repo yet (that's tracked separately in [AIS-61](https://contentful.atlassian.net/browse/AIS-61)). If we merge this CODEOWNERS change before that's sorted, GitHub won't be able to resolve the new group as a valid owner, and review routing will just break.

So, before merging:

1. Head over to the repo's access settings: [github.com/contentful/field-editors/settings/access](https://github.com/contentful/field-editors/settings/access)
2. Click **Add teams** and search for `group-applied-ai-solutions`
3. Give it **Write** access — matching the access `@contentful/team-marketplace` already has
4. Before removing `@contentful/team-marketplace`'s access from this repo, confirm their members are a full subset of `group-applied-ai-solutions`'s members (same overlap check we ran for `agents-api` in [#872](https://github.com/contentful/agents-api/pull/872)) — don't assume it's clean without checking, and fall back to the two-phase grant-then-remove approach from AIS-61 if it isn't

## Test plan
- [ ] Confirm `group-applied-ai-solutions` has Write access on this repo before merging
- [ ] Confirm member overlap before removing old team access (or use the two-phase approach if it isn't clean)
- [ ] After merging, make sure GitHub isn't flagging anything as unowned in CODEOWNERS validation
- [ ] Confirm review requests go to `group-applied-ai-solutions` for the affected paths

Generated with [Claude Code](https://claude.com/claude-code)

[AIS-66]: https://contentful.atlassian.net/browse/AIS-66?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AIS-60]: https://contentful.atlassian.net/browse/AIS-60?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AIS-61]: https://contentful.atlassian.net/browse/AIS-61?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ