### PR TITLE
fix(markdown): cap paragraph indentation at 2 spaces to prevent code block rendering [ES-507]

### DIFF
--- a/cypress/component/markdown/MarkdownEditorSimpleActions.spec.ts
+++ b/cypress/component/markdown/MarkdownEditorSimpleActions.spec.ts
@@ -427,14 +427,37 @@ describe('Markdown Editor / Simple Actions', () => {
       clickVisibleButtonByName('Decrease indentation');
     };
 
-    it('disables indentation for a plain paragraph', () => {
+    it('enables indent button for a plain paragraph with no indentation', () => {
       renderMarkdownEditor();
 
       unveilAdditionalButtonsRow();
       type('A plain paragraph');
 
-      selectors.getIndentButton().should('be.disabled');
+      selectors.getIndentButton().should('not.be.disabled');
       selectors.getDedentButton().should('be.disabled');
+    });
+
+    it('disables indent button for a plain paragraph at the 2-space cap', () => {
+      renderMarkdownEditor({ spyOnSetValue: true });
+
+      unveilAdditionalButtonsRow();
+      type('A plain paragraph');
+      clickIndentButton();
+      checkValue('  A plain paragraph');
+
+      selectors.getIndentButton().should('be.disabled');
+      selectors.getDedentButton().should('not.be.disabled');
+    });
+
+    it('indents and dedents a plain paragraph up to the 2-space cap', () => {
+      renderMarkdownEditor({ spyOnSetValue: true });
+
+      unveilAdditionalButtonsRow();
+      type('A plain paragraph');
+      clickIndentButton();
+      checkValue('  A plain paragraph');
+      clickDedentButton();
+      checkValue('A plain paragraph');
     });
 
     it('indents and dedents a list item', () => {
@@ -450,22 +473,20 @@ describe('Markdown Editor / Simple Actions', () => {
       checkValue('- first item');
     });
 
-    it('Tab key indents a plain paragraph when below the 4-space code block threshold', () => {
+    it('Tab key indents a plain paragraph when below the cap', () => {
       renderMarkdownEditor({ spyOnSetValue: true });
 
-      type('A plain paragraph');
       type('{tab}');
 
-      checkValue('  A plain paragraph');
+      checkValue('  ');
     });
 
-    it('Tab key does not indent a plain paragraph that would reach 4 leading spaces', () => {
+    it('Tab key does not indent a plain paragraph beyond the 2-space cap', () => {
       renderMarkdownEditor({ spyOnSetValue: true });
 
-      type('  A plain paragraph');
-      type('{tab}');
+      type('{tab}{tab}');
 
-      checkValue('  A plain paragraph');
+      checkValue('  ');
     });
 
     it('Tab key indents a list item', () => {

--- a/cypress/component/markdown/MarkdownEditorSimpleActions.spec.ts
+++ b/cypress/component/markdown/MarkdownEditorSimpleActions.spec.ts
@@ -449,5 +449,32 @@ describe('Markdown Editor / Simple Actions', () => {
       clickDedentButton();
       checkValue('- first item');
     });
+
+    it('Tab key indents a plain paragraph when below the 4-space code block threshold', () => {
+      renderMarkdownEditor({ spyOnSetValue: true });
+
+      type('A plain paragraph');
+      type('{tab}');
+
+      checkValue('  A plain paragraph');
+    });
+
+    it('Tab key does not indent a plain paragraph that would reach 4 leading spaces', () => {
+      renderMarkdownEditor({ spyOnSetValue: true });
+
+      type('  A plain paragraph');
+      type('{tab}');
+
+      checkValue('  A plain paragraph');
+    });
+
+    it('Tab key indents a list item', () => {
+      renderMarkdownEditor({ spyOnSetValue: true });
+
+      type('- first item');
+      type('{tab}');
+
+      checkValue('  - first item');
+    });
   });
 });

--- a/packages/markdown/src/MarkdownEditor.tsx
+++ b/packages/markdown/src/MarkdownEditor.tsx
@@ -147,8 +147,7 @@ export function MarkdownEditor(
           setEditor(editor);
           const syncIndentState = () => {
             const line = editor.getCurrentLine();
-            const unit = editor.getIndentation().length;
-            setCanIndentLine(canIndent(line, unit));
+            setCanIndentLine(canIndent(line));
             setCanDedentLine(canDedent(line));
           };
           editor.events.onChange((value: string) => {

--- a/packages/markdown/src/MarkdownEditor.tsx
+++ b/packages/markdown/src/MarkdownEditor.tsx
@@ -17,7 +17,7 @@ import { MarkdownToolbar } from './components/MarkdownToolbar';
 import { openCheatsheetModal } from './dialogs/CheatsheetModalDialog';
 import { createMarkdownActions } from './MarkdownActions';
 import { MarkdownTab, PreviewComponents } from './types';
-import { isMarkdownListItem } from './utils/isMarkdownListItem';
+import { canIndent, canDedent } from './utils/indentation';
 
 const MarkdownPreview = React.lazy(() => import('./components/MarkdownPreview'));
 
@@ -60,7 +60,8 @@ export function MarkdownEditor(
   const [selectedTab, setSelectedTab] = React.useState<MarkdownTab>('editor');
   const [editor, setEditor] = React.useState<InitializedEditorType | null>(null);
   const [canUploadAssets, setCanUploadAssets] = React.useState<boolean>(false);
-  const [isCurrentLineAListItem, setIsCurrentLineAListItem] = React.useState(false);
+  const [canIndentLine, setCanIndentLine] = React.useState(false);
+  const [canDedentLine, setCanDedentLine] = React.useState(false);
 
   React.useEffect(() => {
     if (props.enableTab) {
@@ -101,7 +102,8 @@ export function MarkdownEditor(
   }, [props.value, props.externalReset, editor]);
 
   const isActionDisabled = editor === null || props.isDisabled || selectedTab !== 'editor';
-  const isIndentationDisabled = isActionDisabled || !isCurrentLineAListItem;
+  const indentDisabled = isActionDisabled || !canIndentLine;
+  const dedentDisabled = isActionDisabled || !canDedentLine;
 
   const direction = props.sdk.locales.direction[props.sdk.field.locale] ?? 'ltr';
 
@@ -128,7 +130,8 @@ export function MarkdownEditor(
       <MarkdownToolbar
         mode="default"
         disabled={isActionDisabled}
-        indentationDisabled={isIndentationDisabled}
+        indentDisabled={indentDisabled}
+        dedentDisabled={dedentDisabled}
         canUploadAssets={canUploadAssets}
         actions={actions}
       />
@@ -142,16 +145,20 @@ export function MarkdownEditor(
           editor.setContent(props.value ?? '');
           editor.setReadOnly(!!props.isDisabled);
           setEditor(editor);
+          const syncIndentState = () => {
+            const line = editor.getCurrentLine();
+            const unit = editor.getIndentation().length;
+            setCanIndentLine(canIndent(line, unit));
+            setCanDedentLine(canDedent(line));
+          };
           editor.events.onChange((value: string) => {
             // Trim empty lines
             const trimmedValue = value.replace(/^\s+$/gm, '');
             props.saveValueToSDK(trimmedValue);
             setCurrentValue(value);
-            setIsCurrentLineAListItem(isMarkdownListItem(editor.getCurrentLine()));
+            syncIndentState();
           });
-          editor.events.onCursorActivity(() => {
-            setIsCurrentLineAListItem(isMarkdownListItem(editor.getCurrentLine()));
-          });
+          editor.events.onCursorActivity(syncIndentState);
         }}
       />
       {selectedTab === 'preview' && (

--- a/packages/markdown/src/components/MarkdownTextarea/CodeMirrorWrapper.ts
+++ b/packages/markdown/src/components/MarkdownTextarea/CodeMirrorWrapper.ts
@@ -28,7 +28,7 @@ export function create(
     readOnly: boolean;
     fixedHeight?: number | boolean;
     height?: number | string;
-  }
+  },
 ) {
   const { direction, fixedHeight, height, readOnly } = options || {};
 
@@ -73,7 +73,12 @@ export function create(
 
   cm.setOption('extraKeys', {
     Tab: function () {
-      replaceSelectedText(getIndentation());
+      const line = cm.getLine(cm.getCursor().line);
+      const leadingSpaces = (line.match(/^ */) ?? [''])[0].length;
+      const indentUnit = cm.getOption('indentUnit') ?? 2;
+      if (leadingSpaces + indentUnit <= 3) {
+        replaceSelectedText(getIndentation());
+      }
     },
     Enter: 'newlineAndIndentContinueMarkdownList',
     Esc: () => {
@@ -181,8 +186,8 @@ export function create(
           // @ts-ignore
           acc[ctrlKey + '-' + key] = value;
         },
-        {}
-      )
+        {},
+      ),
     );
   }
 

--- a/packages/markdown/src/components/MarkdownTextarea/CodeMirrorWrapper.ts
+++ b/packages/markdown/src/components/MarkdownTextarea/CodeMirrorWrapper.ts
@@ -6,6 +6,7 @@ import throttle from 'lodash/throttle';
 import transform from 'lodash/transform';
 
 import { EditorDirection } from '../../types';
+import { canIndent, getLeadingSpaces } from '../../utils/indentation';
 import * as userAgent from '../../utils/userAgent';
 
 function stripUnit(value: number | string): number {
@@ -73,10 +74,12 @@ export function create(
 
   cm.setOption('extraKeys', {
     Tab: function () {
-      const line = cm.getLine(cm.getCursor().line);
-      const leadingSpaces = (line.match(/^ */) ?? [''])[0].length;
+      const cursor = cm.getCursor();
+      const line = cm.getLine(cursor.line);
       const indentUnit = cm.getOption('indentUnit') ?? 2;
-      if (leadingSpaces + indentUnit <= 3) {
+      // Only tab presses within the leading whitespace zone can grow indentation.
+      // Past the indentation zone, insert freely (can't create a code block).
+      if (cursor.ch > getLeadingSpaces(line) || canIndent(line, indentUnit)) {
         replaceSelectedText(getIndentation());
       }
     },

--- a/packages/markdown/src/components/MarkdownTextarea/MarkdownCommands.ts
+++ b/packages/markdown/src/components/MarkdownTextarea/MarkdownCommands.ts
@@ -7,6 +7,7 @@ import times from 'lodash/times';
 // eslint-disable-next-line -- TODO: describe this disable  you-dont-need-lodash-underscore/repeat
 import repeat from 'lodash/repeat';
 
+import { canIndent, canDedent, getLeadingSpaces } from '../../utils/indentation';
 import * as CodeMirrorWrapper from './CodeMirrorWrapper';
 
 type EditorInstanceType = ReturnType<typeof CodeMirrorWrapper.create>;
@@ -40,7 +41,7 @@ function wrapSelection(editor: EditorInstanceType, marker: string, emptyText: st
         const markerLength = marker.length;
         const textWithoutMarker = selectedText.slice(
           markerLength,
-          selectedText.length - markerLength
+          selectedText.length - markerLength,
         );
         editor.replaceSelectedText(textWithoutMarker);
       } else {
@@ -107,7 +108,11 @@ export function create(editor: EditorInstanceType) {
    * Indent the current line.
    */
   function indent() {
-    editor.insertAtLineBeginning(editor.getIndentation());
+    const line = editor.getCurrentLine();
+    const indentUnit = editor.getIndentation().length;
+    if (canIndent(line, indentUnit)) {
+      editor.insertAtLineBeginning(editor.getIndentation());
+    }
   }
 
   /**
@@ -115,9 +120,10 @@ export function create(editor: EditorInstanceType) {
    * Dedent the current line.
    */
   function dedent() {
-    const indentation = editor.getIndentation();
-    if (editor.lineStartsWith(indentation)) {
-      editor.removeFromLineBeginning(indentation.length);
+    const line = editor.getCurrentLine();
+    if (canDedent(line)) {
+      const remove = Math.min(editor.getIndentation().length, getLeadingSpaces(line));
+      editor.removeFromLineBeginning(remove);
     }
   }
 
@@ -159,7 +165,7 @@ export function create(editor: EditorInstanceType) {
 function modifySelection(
   editor: EditorInstanceType,
   toggleFn: (editor: EditorInstanceType, listNumber?: number) => void,
-  isList?: boolean
+  isList?: boolean,
 ) {
   return () => {
     editor.usePrimarySelection();
@@ -198,7 +204,7 @@ function forLineIn(
     anchor: CodeMirror.Position;
     head: CodeMirror.Position;
   },
-  cb: Function
+  cb: Function,
 ) {
   // anchor/head depend on selection direction, so min & max have to be used
   const lines = [selection.anchor.line, selection.head.line];

--- a/packages/markdown/src/components/MarkdownToolbar.spec.tsx
+++ b/packages/markdown/src/components/MarkdownToolbar.spec.tsx
@@ -13,7 +13,8 @@ configure({
 const createProps = () => ({
   canUploadAssets: true,
   disabled: false,
-  indentationDisabled: false,
+  indentDisabled: false,
+  dedentDisabled: false,
   mode: 'default' as const,
   actions: {
     headings: {
@@ -80,13 +81,23 @@ describe('MarkdownToolbar', () => {
     expect(screen.getByRole('button', { name: 'Undo' })).toBeInTheDocument();
   });
 
-  it('disables indentation controls when indentation is unavailable', async () => {
-    const props = { ...createProps(), indentationDisabled: true };
+  it('disables indent button when indent is unavailable', async () => {
+    const props = { ...createProps(), indentDisabled: true };
     render(<MarkdownToolbar {...props} />);
 
     await userEvent.click(screen.getByRole('button', { name: 'More actions' }));
 
     expect(screen.getByRole('button', { name: 'Increase indentation' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Decrease indentation' })).not.toBeDisabled();
+  });
+
+  it('disables dedent button when dedent is unavailable', async () => {
+    const props = { ...createProps(), dedentDisabled: true };
+    render(<MarkdownToolbar {...props} />);
+
+    await userEvent.click(screen.getByRole('button', { name: 'More actions' }));
+
+    expect(screen.getByRole('button', { name: 'Increase indentation' })).not.toBeDisabled();
     expect(screen.getByRole('button', { name: 'Decrease indentation' })).toBeDisabled();
   });
 

--- a/packages/markdown/src/components/MarkdownToolbar.tsx
+++ b/packages/markdown/src/components/MarkdownToolbar.tsx
@@ -139,7 +139,8 @@ ToolbarButton.displayName = 'ToolbarButton';
 interface MarkdownToolbarProps {
   canUploadAssets: boolean;
   disabled: boolean;
-  indentationDisabled: boolean;
+  indentDisabled: boolean;
+  dedentDisabled: boolean;
   actions: MarkdownActions;
   mode: 'default' | 'zen';
 }
@@ -258,7 +259,7 @@ function AdditionalButtons(props: MarkdownToolbarProps) {
         <MinusIcon aria-label="Horizontal rule" className={styles.icon} />
       </ToolbarButton>
       <ToolbarButton
-        isDisabled={props.indentationDisabled}
+        isDisabled={props.indentDisabled}
         testId="markdown-action-button-indent"
         tooltip="Increase indentation"
         tooltipPlace={tooltipPlace}
@@ -267,7 +268,7 @@ function AdditionalButtons(props: MarkdownToolbarProps) {
         <TextIndentIcon aria-label="Increase indentation" className={styles.icon} />
       </ToolbarButton>
       <ToolbarButton
-        isDisabled={props.indentationDisabled}
+        isDisabled={props.dedentDisabled}
         testId="markdown-action-button-dedent"
         tooltip="Decrease indentation"
         tooltipPlace={tooltipPlace}

--- a/packages/markdown/src/dialogs/ZenModeModalDialog.tsx
+++ b/packages/markdown/src/dialogs/ZenModeModalDialog.tsx
@@ -16,7 +16,7 @@ import { MarkdownToolbar } from '../components/MarkdownToolbar';
 import { openCheatsheetModal } from '../dialogs/CheatsheetModalDialog';
 import { createMarkdownActions } from '../MarkdownActions';
 import { MarkdownDialogsParams, MarkdownDialogType, PreviewComponents } from '../types';
-import { isMarkdownListItem } from '../utils/isMarkdownListItem';
+import { canIndent, canDedent } from '../utils/indentation';
 
 const MarkdownPreview = React.lazy(() => import('../components/MarkdownPreview'));
 
@@ -102,7 +102,8 @@ export const ZenModeModalDialog = (props: ZenModeDialogProps) => {
   const [currentValue, setCurrentValue] = React.useState<string>(props.initialValue ?? '');
   const [showPreview, setShowPreview] = React.useState<boolean>(true);
   const [editor, setEditor] = React.useState<InitializedEditorType | null>(null);
-  const [isCurrentLineAListItem, setIsCurrentLineAListItem] = React.useState(false);
+  const [canIndentLine, setCanIndentLine] = React.useState(false);
+  const [canDedentLine, setCanDedentLine] = React.useState(false);
 
   React.useEffect(() => {
     // eslint-disable-next-line -- TODO: describe this disable  @typescript-eslint/no-explicit-any
@@ -138,7 +139,8 @@ export const ZenModeModalDialog = (props: ZenModeDialogProps) => {
         <MarkdownToolbar
           mode="zen"
           disabled={false}
-          indentationDisabled={!isCurrentLineAListItem}
+          indentDisabled={!canIndentLine}
+          dedentDisabled={!canDedentLine}
           canUploadAssets={false}
           actions={actions}
         />
@@ -158,14 +160,18 @@ export const ZenModeModalDialog = (props: ZenModeDialogProps) => {
             editor.setReadOnly(false);
             setEditor(editor);
             editor.focus();
+            const syncIndentState = () => {
+              const line = editor.getCurrentLine();
+              const unit = editor.getIndentation().length;
+              setCanIndentLine(canIndent(line, unit));
+              setCanDedentLine(canDedent(line));
+            };
             editor.events.onChange((value: string) => {
               setCurrentValue(value);
               props.saveValueToSDK(value);
-              setIsCurrentLineAListItem(isMarkdownListItem(editor.getCurrentLine()));
+              syncIndentState();
             });
-            editor.events.onCursorActivity(() => {
-              setIsCurrentLineAListItem(isMarkdownListItem(editor.getCurrentLine()));
-            });
+            editor.events.onCursorActivity(syncIndentState);
           }}
         />
       </Grid.Item>

--- a/packages/markdown/src/dialogs/ZenModeModalDialog.tsx
+++ b/packages/markdown/src/dialogs/ZenModeModalDialog.tsx
@@ -162,8 +162,7 @@ export const ZenModeModalDialog = (props: ZenModeDialogProps) => {
             editor.focus();
             const syncIndentState = () => {
               const line = editor.getCurrentLine();
-              const unit = editor.getIndentation().length;
-              setCanIndentLine(canIndent(line, unit));
+              setCanIndentLine(canIndent(line));
               setCanDedentLine(canDedent(line));
             };
             editor.events.onChange((value: string) => {

--- a/packages/markdown/src/utils/indentation.ts
+++ b/packages/markdown/src/utils/indentation.ts
@@ -1,0 +1,18 @@
+import { isMarkdownListItem } from './isMarkdownListItem';
+
+// remark (the preview renderer) treats 4+ leading spaces as a code block (<pre>).
+// 2 leading spaces is the maximum safe indent for a non-list paragraph.
+export const MAX_PARAGRAPH_LEADING_SPACES = 2;
+
+export function getLeadingSpaces(line: string): number {
+  return line.match(/^ */)?.[0].length ?? 0;
+}
+
+export function canIndent(line: string, indentUnit: number): boolean {
+  if (isMarkdownListItem(line)) return true;
+  return getLeadingSpaces(line) + indentUnit <= MAX_PARAGRAPH_LEADING_SPACES;
+}
+
+export function canDedent(line: string): boolean {
+  return getLeadingSpaces(line) > 0;
+}

--- a/packages/markdown/src/utils/indentation.ts
+++ b/packages/markdown/src/utils/indentation.ts
@@ -8,7 +8,7 @@ export function getLeadingSpaces(line: string): number {
   return line.match(/^ */)?.[0].length ?? 0;
 }
 
-export function canIndent(line: string, indentUnit: number): boolean {
+export function canIndent(line: string, indentUnit = 2): boolean {
   if (isMarkdownListItem(line)) return true;
   return getLeadingSpaces(line) + indentUnit <= MAX_PARAGRAPH_LEADING_SPACES;
 }


### PR DESCRIPTION
## Summary

Fixes a regression introduced in 2.3.2 where the indent/dedent toolbar buttons were disabled entirely for non-list lines. This removed a feature customers actively use (ES-507: Prada reported that indenting plain paragraphs via the toolbar caused the preview to render as a `<pre>` code block).

The root cause: `remark` (the preview renderer) treats 4+ leading spaces as a code block. The 2.3.2 fix blocked indentation on plain paragraphs altogether rather than preventing the threshold from being crossed.

Ticket: https://contentful.atlassian.net/browse/ES-507

## What changed

**New `packages/markdown/src/utils/indentation.ts`** — single source of truth for all indentation decisions:
- `canIndent(line, indentUnit)` — true for list items always; true for plain paragraphs only if adding `indentUnit` spaces would stay at or below 2 leading spaces
- `canDedent(line)` — true whenever the line has any leading spaces
- `MAX_PARAGRAPH_LEADING_SPACES = 2` — named constant with a comment explaining the remark 4-space threshold

**Three call sites, one decision function:**
- `MarkdownCommands.ts` — `indent`/`dedent` now clamp themselves via the util; correctness no longer depends on the toolbar button being disabled upstream
- `CodeMirrorWrapper.ts` — Tab key uses `cursor.ch > leadingSpaces` (correct discriminator: is the cursor in the indentation zone or the text body?) combined with `canIndent`
- `MarkdownEditor.tsx` / `ZenModeModalDialog.tsx` — React state split into separate `canIndentLine`/`canDedentLine` flags, both purely advisory for button affordance

**`MarkdownToolbar.tsx`** — `indentationDisabled` replaced with separate `indentDisabled` and `dedentDisabled` props, allowing the two buttons to reflect their independent states.

Also fixes a latent dedent bug: the previous implementation used `lineStartsWith(indentation)` which could not dedent a line with fewer leading spaces than `indentUnit` (e.g. a 1-space-indented line with `indentUnit = 2`). The new `Math.min(unit, leadingSpaces)` always removes cleanly.

## Why 2 spaces and not 3

The all-or-nothing approach: each indent press always inserts a full `indentUnit` (2 spaces), or is blocked entirely. A partial last step (0 → 2 → 3) would insert different amounts for the same action, which is confusing. Capping at 2 means the sequence is always `0 → 2 → blocked` — consistent and predictable.

## Why 4 spaces triggers the bug

Verified directly against the renderer in use:

```
unified().use(remarkParse).use(remarkGfm).parse('   text').children[0].type  // → 'paragraph'
unified().use(remarkParse).use(remarkGfm).parse('    text').children[0].type // → 'code'
```

Not an assumption from the CommonMark spec — confirmed against the actual parse tree.

## Test plan

- [ ] Plain paragraph with no indentation: indent button enabled, dedent button disabled
- [ ] After one indent press (2 spaces): indent button disabled, dedent button enabled
- [ ] Dedent returns to 0 spaces: indent button re-enabled, dedent button disabled
- [ ] List item: indent and dedent both work freely (no cap)
- [ ] Tab key on empty line: inserts 2 spaces
- [ ] Tab key on a 2-space-indented line: no change (blocked)
- [ ] Tab key mid-line (cursor past indentation zone): inserts spaces freely
- [ ] Preview tab: indented plain paragraph renders as paragraph, not `<pre>`
- [ ] Cypress component tests: `npm run cy:run -- --spec "cypress/component/markdown/MarkdownEditorSimpleActions.spec.ts"`
