### PR TITLE
fix: revert "fix(markdown): limit indentation to list items"

### DIFF
--- a/cypress/component/markdown/MarkdownEditorSimpleActions.spec.ts
+++ b/cypress/component/markdown/MarkdownEditorSimpleActions.spec.ts
@@ -2,7 +2,6 @@ import {
   renderMarkdownEditor,
   type,
   checkValue,
-  selectAll,
   selectCharsBackwards,
   clickVisibleButtonByName,
   openAdditionalActions,
@@ -336,7 +335,7 @@ describe('Markdown Editor / Simple Actions', () => {
 
       type('first item{enter}second item{enter}third item');
 
-      selectAll();
+      type('{selectall}{selectall}');
       clickUnorderedList();
       checkValue('- first item\n- second item\n- third item');
     });
@@ -385,7 +384,7 @@ describe('Markdown Editor / Simple Actions', () => {
 
       type('first item{enter}second item{enter}third item');
 
-      selectAll();
+      type('{selectall}{selectall}');
       clickOrderedList();
 
       checkValue('1. first item\n2. second item\n3. third item');
@@ -427,27 +426,23 @@ describe('Markdown Editor / Simple Actions', () => {
       clickVisibleButtonByName('Decrease indentation');
     };
 
-    it('disables indentation for a plain paragraph', () => {
-      renderMarkdownEditor();
-
-      unveilAdditionalButtonsRow();
-      type('A plain paragraph');
-
-      selectors.getIndentButton().should('be.disabled');
-      selectors.getDedentButton().should('be.disabled');
-    });
-
-    it('indents and dedents a list item', () => {
+    it('should work properly', () => {
       renderMarkdownEditor({ spyOnSetValue: true });
 
       unveilAdditionalButtonsRow();
-      type('- first item');
-      selectors.getIndentButton().should('not.be.disabled');
-      selectors.getDedentButton().should('not.be.disabled');
+      type('something');
       clickIndentButton();
-      checkValue('  - first item');
+      checkValue('  something');
+
+      type('{enter}');
+      clickIndentButton();
+      type('line two{enter}');
       clickDedentButton();
-      checkValue('- first item');
+      type('line three{enter}');
+      clickDedentButton();
+      type('final line');
+
+      checkValue('  something\n    line two\n  line three\nfinal line');
     });
   });
 });

--- a/cypress/component/markdown/utils.tsx
+++ b/cypress/component/markdown/utils.tsx
@@ -103,11 +103,6 @@ export const clearAll = (): void => {
   getInput().type('{selectall}{backspace}', { force: true });
 };
 
-export const selectAll = (): void => {
-  focusInput();
-  getInput().type('{selectall}{selectall}', { force: true });
-};
-
 //util to select chars backwards from current cursor position
 export const selectCharsBackwards = (skip: number, len: number): void => {
   if (skip > 0) {

--- a/packages/markdown/src/MarkdownEditor.tsx
+++ b/packages/markdown/src/MarkdownEditor.tsx
@@ -17,7 +17,6 @@ import { MarkdownToolbar } from './components/MarkdownToolbar';
 import { openCheatsheetModal } from './dialogs/CheatsheetModalDialog';
 import { createMarkdownActions } from './MarkdownActions';
 import { MarkdownTab, PreviewComponents } from './types';
-import { isMarkdownListItem } from './utils/isMarkdownListItem';
 
 const MarkdownPreview = React.lazy(() => import('./components/MarkdownPreview'));
 
@@ -60,7 +59,6 @@ export function MarkdownEditor(
   const [selectedTab, setSelectedTab] = React.useState<MarkdownTab>('editor');
   const [editor, setEditor] = React.useState<InitializedEditorType | null>(null);
   const [canUploadAssets, setCanUploadAssets] = React.useState<boolean>(false);
-  const [isCurrentLineAListItem, setIsCurrentLineAListItem] = React.useState(false);
 
   React.useEffect(() => {
     if (props.enableTab) {
@@ -101,7 +99,6 @@ export function MarkdownEditor(
   }, [props.value, props.externalReset, editor]);
 
   const isActionDisabled = editor === null || props.isDisabled || selectedTab !== 'editor';
-  const isIndentationDisabled = isActionDisabled || !isCurrentLineAListItem;
 
   const direction = props.sdk.locales.direction[props.sdk.field.locale] ?? 'ltr';
 
@@ -128,7 +125,6 @@ export function MarkdownEditor(
       <MarkdownToolbar
         mode="default"
         disabled={isActionDisabled}
-        indentationDisabled={isIndentationDisabled}
         canUploadAssets={canUploadAssets}
         actions={actions}
       />
@@ -147,10 +143,6 @@ export function MarkdownEditor(
             const trimmedValue = value.replace(/^\s+$/gm, '');
             props.saveValueToSDK(trimmedValue);
             setCurrentValue(value);
-            setIsCurrentLineAListItem(isMarkdownListItem(editor.getCurrentLine()));
-          });
-          editor.events.onCursorActivity(() => {
-            setIsCurrentLineAListItem(isMarkdownListItem(editor.getCurrentLine()));
           });
         }}
       />

--- a/packages/markdown/src/components/MarkdownTextarea/createMarkdownEditor.ts
+++ b/packages/markdown/src/components/MarkdownTextarea/createMarkdownEditor.ts
@@ -11,7 +11,7 @@ export function createMarkdownEditor(
     readOnly: boolean;
     fixedHeight?: number | boolean;
     height?: number | string;
-  },
+  }
 ) {
   const editor = CodeMirrorWrapper.create(host, options);
 
@@ -43,14 +43,10 @@ export function createMarkdownEditor(
       onPaste: function (fn: Function) {
         editor.attachEvent('paste', fn, 0);
       },
-      onCursorActivity: function (fn: Function) {
-        editor.attachEvent('cursorActivity', fn, 0);
-      },
     },
     insert: editor.insertAtCursor,
     focus: editor.focus,
     getContent: editor.getValue,
-    getCurrentLine: editor.getCurrentLine,
     destroy: editor.destroy,
     setContent: editor.setValue,
     getSelectedText: editor.getSelectedText,

--- a/packages/markdown/src/components/MarkdownToolbar.spec.tsx
+++ b/packages/markdown/src/components/MarkdownToolbar.spec.tsx
@@ -13,7 +13,6 @@ configure({
 const createProps = () => ({
   canUploadAssets: true,
   disabled: false,
-  indentationDisabled: false,
   mode: 'default' as const,
   actions: {
     headings: {
@@ -78,16 +77,6 @@ describe('MarkdownToolbar', () => {
       'true',
     );
     expect(screen.getByRole('button', { name: 'Undo' })).toBeInTheDocument();
-  });
-
-  it('disables indentation controls when indentation is unavailable', async () => {
-    const props = { ...createProps(), indentationDisabled: true };
-    render(<MarkdownToolbar {...props} />);
-
-    await userEvent.click(screen.getByRole('button', { name: 'More actions' }));
-
-    expect(screen.getByRole('button', { name: 'Increase indentation' })).toBeDisabled();
-    expect(screen.getByRole('button', { name: 'Decrease indentation' })).toBeDisabled();
   });
 
   it('triggers a toolbar action once per click', async () => {

--- a/packages/markdown/src/components/MarkdownToolbar.tsx
+++ b/packages/markdown/src/components/MarkdownToolbar.tsx
@@ -139,7 +139,6 @@ ToolbarButton.displayName = 'ToolbarButton';
 interface MarkdownToolbarProps {
   canUploadAssets: boolean;
   disabled: boolean;
-  indentationDisabled: boolean;
   actions: MarkdownActions;
   mode: 'default' | 'zen';
 }
@@ -258,7 +257,7 @@ function AdditionalButtons(props: MarkdownToolbarProps) {
         <MinusIcon aria-label="Horizontal rule" className={styles.icon} />
       </ToolbarButton>
       <ToolbarButton
-        isDisabled={props.indentationDisabled}
+        isDisabled={props.disabled}
         testId="markdown-action-button-indent"
         tooltip="Increase indentation"
         tooltipPlace={tooltipPlace}
@@ -267,7 +266,7 @@ function AdditionalButtons(props: MarkdownToolbarProps) {
         <TextIndentIcon aria-label="Increase indentation" className={styles.icon} />
       </ToolbarButton>
       <ToolbarButton
-        isDisabled={props.indentationDisabled}
+        isDisabled={props.disabled}
         testId="markdown-action-button-dedent"
         tooltip="Decrease indentation"
         tooltipPlace={tooltipPlace}

--- a/packages/markdown/src/dialogs/ZenModeModalDialog.tsx
+++ b/packages/markdown/src/dialogs/ZenModeModalDialog.tsx
@@ -16,7 +16,6 @@ import { MarkdownToolbar } from '../components/MarkdownToolbar';
 import { openCheatsheetModal } from '../dialogs/CheatsheetModalDialog';
 import { createMarkdownActions } from '../MarkdownActions';
 import { MarkdownDialogsParams, MarkdownDialogType, PreviewComponents } from '../types';
-import { isMarkdownListItem } from '../utils/isMarkdownListItem';
 
 const MarkdownPreview = React.lazy(() => import('../components/MarkdownPreview'));
 
@@ -102,7 +101,6 @@ export const ZenModeModalDialog = (props: ZenModeDialogProps) => {
   const [currentValue, setCurrentValue] = React.useState<string>(props.initialValue ?? '');
   const [showPreview, setShowPreview] = React.useState<boolean>(true);
   const [editor, setEditor] = React.useState<InitializedEditorType | null>(null);
-  const [isCurrentLineAListItem, setIsCurrentLineAListItem] = React.useState(false);
 
   React.useEffect(() => {
     // eslint-disable-next-line -- TODO: describe this disable  @typescript-eslint/no-explicit-any
@@ -135,13 +133,7 @@ export const ZenModeModalDialog = (props: ZenModeDialogProps) => {
   return (
     <Grid className={styles.root} testId="zen-mode-markdown-editor">
       <Grid.Item className={styles.topSplit}>
-        <MarkdownToolbar
-          mode="zen"
-          disabled={false}
-          indentationDisabled={!isCurrentLineAListItem}
-          canUploadAssets={false}
-          actions={actions}
-        />
+        <MarkdownToolbar mode="zen" disabled={false} canUploadAssets={false} actions={actions} />
       </Grid.Item>
       <Grid.Item
         className={cx(styles.editorSplit, {
@@ -161,10 +153,6 @@ export const ZenModeModalDialog = (props: ZenModeDialogProps) => {
             editor.events.onChange((value: string) => {
               setCurrentValue(value);
               props.saveValueToSDK(value);
-              setIsCurrentLineAListItem(isMarkdownListItem(editor.getCurrentLine()));
-            });
-            editor.events.onCursorActivity(() => {
-              setIsCurrentLineAListItem(isMarkdownListItem(editor.getCurrentLine()));
             });
           }}
         />

--- a/packages/markdown/src/utils/isMarkdownListItem.ts
+++ b/packages/markdown/src/utils/isMarkdownListItem.ts
@@ -1,3 +1,0 @@
-export function isMarkdownListItem(line: string) {
-  return /^\s*(?:[-*+] |\d+[.)] )/.test(line);
-}


### PR DESCRIPTION
Reverts contentful/field-editors#2191. Original behavior was intended 