### PR TITLE
fix(rich-text): prevent heading hotkey from firing inside table cells [ES-533]

### DIFF
--- a/packages/rich-text/src/plugins/Heading/__tests__/createHeadingPlugin.test.tsx
+++ b/packages/rich-text/src/plugins/Heading/__tests__/createHeadingPlugin.test.tsx
@@ -1,8 +1,10 @@
 /* eslint-disable react/no-unknown-property */
 /** @jsx jsx */
-import { describe, it } from 'vitest';
+import { BLOCKS } from '@contentful/rich-text-types';
+import { describe, expect, it, vi } from 'vitest';
 
-import { assertOutput, jsx } from '../../../test-utils';
+import { assertOutput, createTestEditor, jsx } from '../../../test-utils';
+import { createHeadingPlugin } from '../createHeadingPlugin';
 
 describe('normalization', () => {
   it('can contain inline entries & hyperlinks', () => {
@@ -291,5 +293,151 @@ describe('normalization', () => {
 
       assertOutput({ input, expected });
     });
+  });
+});
+
+describe('buildHeadingEventHandler / onKeyDown', () => {
+  const H5_KEYCODE = 53; // '5'
+  const H3_KEYCODE = 51; // '3'
+
+  const fireModAlt = (editor: any, plugin: any, keyCode: number, key: string) => {
+    const event = new KeyboardEvent('keydown', {
+      key,
+      ctrlKey: true,
+      altKey: true,
+      which: keyCode,
+      keyCode,
+      bubbles: true,
+      cancelable: true,
+    });
+
+    plugin.handlers!.onKeyDown!(editor, plugin)(event as any);
+  };
+
+  const getHeadingPlugin = (nodeType: string) => {
+    const heading = createHeadingPlugin();
+    const plugin = heading.plugins!.find((p) => p.type === nodeType)!;
+    return plugin;
+  };
+
+  it('does not toggle a heading when the selection is inside a table cell', () => {
+    const input = (
+      <editor>
+        <htable>
+          <htr>
+            <htd>
+              <hp>
+                <htext />
+                <cursor />
+              </hp>
+            </htd>
+          </htr>
+        </htable>
+      </editor>
+    );
+
+    const trackingHandler = vi.fn();
+    const { editor } = createTestEditor({ input, trackingHandler });
+    const plugin = getHeadingPlugin(BLOCKS.HEADING_5);
+
+    fireModAlt(editor, plugin, H5_KEYCODE, '5');
+
+    expect(
+      editor.children.some((n: any) =>
+        JSON.stringify(n).includes(`"type":"${BLOCKS.HEADING_5}"`),
+      ),
+    ).toBe(false);
+    expect(trackingHandler).not.toHaveBeenCalled();
+  });
+
+  it('does not toggle a heading when the selection is inside a table header cell', () => {
+    const input = (
+      <editor>
+        <htable>
+          <htr>
+            <hth>
+              <hp>
+                <htext />
+                <cursor />
+              </hp>
+            </hth>
+          </htr>
+        </htable>
+      </editor>
+    );
+
+    const trackingHandler = vi.fn();
+    const { editor } = createTestEditor({ input, trackingHandler });
+    const plugin = getHeadingPlugin(BLOCKS.HEADING_5);
+
+    fireModAlt(editor, plugin, H5_KEYCODE, '5');
+
+    expect(
+      editor.children.some((n: any) =>
+        JSON.stringify(n).includes(`"type":"${BLOCKS.HEADING_5}"`),
+      ),
+    ).toBe(false);
+    expect(trackingHandler).not.toHaveBeenCalled();
+  });
+
+  it('still toggles a heading in a plain paragraph outside a table (regression guard)', () => {
+    const input = (
+      <editor>
+        <hp>
+          <htext />
+          <cursor />
+        </hp>
+      </editor>
+    );
+
+    const trackingHandler = vi.fn();
+    const { editor } = createTestEditor({ input, trackingHandler });
+    const plugin = getHeadingPlugin(BLOCKS.HEADING_5);
+
+    fireModAlt(editor, plugin, H5_KEYCODE, '5');
+
+    expect(
+      editor.children.some((n: any) =>
+        JSON.stringify(n).includes(`"type":"${BLOCKS.HEADING_5}"`),
+      ),
+    ).toBe(true);
+    expect(trackingHandler).toHaveBeenCalledWith(
+      'insert',
+      expect.objectContaining({ nodeType: BLOCKS.HEADING_5 }),
+    );
+  });
+
+  it('does not toggle a heading when the selection is in a list item nested inside a table cell', () => {
+    const input = (
+      <editor>
+        <htable>
+          <htr>
+            <htd>
+              <hul>
+                <hli>
+                  <hp>
+                    <htext />
+                    <cursor />
+                  </hp>
+                </hli>
+              </hul>
+            </htd>
+          </htr>
+        </htable>
+      </editor>
+    );
+
+    const trackingHandler = vi.fn();
+    const { editor } = createTestEditor({ input, trackingHandler });
+    const plugin = getHeadingPlugin(BLOCKS.HEADING_3);
+
+    fireModAlt(editor, plugin, H3_KEYCODE, '3');
+
+    expect(
+      editor.children.some((n: any) =>
+        JSON.stringify(n).includes(`"type":"${BLOCKS.HEADING_3}"`),
+      ),
+    ).toBe(false);
+    expect(trackingHandler).not.toHaveBeenCalled();
   });
 });

--- a/packages/rich-text/src/plugins/Heading/createHeadingPlugin.ts
+++ b/packages/rich-text/src/plugins/Heading/createHeadingPlugin.ts
@@ -13,6 +13,14 @@ const buildHeadingEventHandler =
   (editor, { options: { hotkey } }) =>
   (event) => {
     if (editor.selection && hotkey && isHotkey(hotkey, event)) {
+      if (
+        getAboveNode(editor, {
+          match: { type: [BLOCKS.TABLE_CELL, BLOCKS.TABLE_HEADER_CELL] },
+        })
+      ) {
+        return;
+      }
+
       if (type !== BLOCKS.PARAGRAPH) {
         const isActive = isBlockSelected(editor, type);
         editor.tracking.onShortcutAction(isActive ? 'remove' : 'insert', { nodeType: type });


### PR DESCRIPTION
## Summary

Heading toggle shortcuts (`mod+alt+1` … `mod+alt+6`) could fire while the selection was inside a table cell, toggling a heading node type that table cells don't support. The schema normalizer would then immediately revert the change, producing a visible cursor jump with no other effect.

This PR makes `buildHeadingEventHandler` bail out early when the current selection sits inside a `TABLE_CELL` or `TABLE_HEADER_CELL`, so the keystroke falls through as ordinary character input instead of toggling a heading.

Typing `€` (`Ctrl`+`Alt`+`5`) inside a table cell will now correctly insert `€` instead of jumping columns, and `Ctrl`+`Alt`+`5` used anywhere else in the document still converts text to `Heading 5` as expected.

## Scope

- Only the table-cell case is changed.
- Heading toggling in plain paragraphs (toolbar, Command Palette, and hotkey) is unaffected — covered by a regression test.
- No API/schema changes.

## Test plan

- Added unit tests for `buildHeadingEventHandler`/`onKeyDown` covering: table cell, table header cell, a list item nested inside a table cell, and a plain-paragraph regression case.
- `yarn lint`, `yarn tsc`, and `yarn vitest run` all pass for `packages/rich-text` (178/178 tests, no regressions).
