### PR TITLE
build: add packageManager key to fix vercel yarn version on deployment []

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@contentful/field-editors",
+  "packageManager": "yarn@1.22.22",
   "private": true,
   "version": "1.0.0",
   "description": "React components and apps for building Contentful entry editor",


### PR DESCRIPTION
## Description
Renovate bot updated `package.json` to set min yarn version to `1.22.22` (https://github.com/contentful/field-editors/pull/2220) 4 days ago.

It start breaking the Vercel deployment because apparently vercel sets their yarn engine as `1.22.19`. 
This PR sets `packageManager` key to keep `engines` and `volta` as the renovate bot updated and enable Vercel to use the correct yarn version
