### PR TITLE
fix: make canary prerelease versions unique

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,7 +117,19 @@ jobs:
           echo "//npm.pkg.github.com/:_authToken=${GITHUB_PACKAGES_WRITE_TOKEN}" > ~/.npmrc
           echo "@contentful:registry=https://npm.pkg.github.com" >> ~/.npmrc
       - run: yarn build
-      - run: yarn lerna publish --no-private --canary --preid canary --dist-tag canary --conventional-commits --yes
+      - run:
+          name: Publish canary packages
+          command: |
+            CANARY_SHORT_SHA="${CIRCLE_SHA1:0:8}"
+            # npm ignores Lerna's +sha build metadata when identifying versions.
+            yarn lerna publish \
+              --no-private \
+              --canary \
+              --preid "canary.sha-${CANARY_SHORT_SHA}" \
+              --dist-tag canary \
+              --conventional-commits \
+              --force-publish \
+              --yes
 
 workflows:
   version: 2
@@ -134,7 +146,7 @@ workflows:
           context: vault
           filters:
             branches:
-              ignore: master
+              only: canary
           requires:
             - lint
             - unit-tests

--- a/README.md
+++ b/README.md
@@ -85,18 +85,18 @@ Canary releases allow you to test changes before they are merged to the main bra
 2. Once the PR is merged to `canary`, CircleCI will automatically:
    - Build all packages
    - Run tests
-   - Create a canary version (e.g., `1.2.3-canary.123.abc1234`)
-   - Publish to npm with the `canary` tag
+   - Create a canary version (e.g., `1.2.3-canary.sha-abc12345.123`)
+   - Publish all packages to npm with the `canary` tag
 3. You can install the canary version in your project:
    ```bash
-   yarn add @contentful/field-editor-reference@canaryversion
+   yarn add @contentful/field-editor-reference@canary
    ```
 
 ### Notes
 
 - Canary releases are temporary and intended for testing only
 - Each merge to the `canary` branch will create a new canary version
-- Canary versions follow the format: `{version}-canary.{prNumber}.{shortSha}`
+- Canary versions follow the format: `{version}-canary.sha-{shortSha}.{commitCount}`
 
 ## Links & related repositories
 


### PR DESCRIPTION
## What changed
- run prerelease publishing only after merges to `canary`
- include the short SHA in the prerelease identity so npm cannot collapse different builds
- force-publish the coordinated package set so this pipeline-only fix produces a fresh TOL-3560 canary
- correct the canary documentation and install command

## Validation
- CircleCI YAML parses successfully
- Lerna accepts the publish options
- generated version is valid SemVer and unique by SHA
- Prettier and `git diff --check` pass