### PR TITLE
fix(date): normalize compact timezone offsets

### DIFF
--- a/packages/date/src/utils/data.spec.ts
+++ b/packages/date/src/utils/data.spec.ts
@@ -309,6 +309,16 @@ describe('date utils', () => {
       expect(result.utcOffset).toBe('+03:00');
     });
 
+    it('normalizes a compact timezone offset for the timezone picker', () => {
+      const result = userInputFromDatetime({
+        value: '2026-12-11T20:00:00.000-0500',
+        uses12hClock: false,
+      });
+      expect(result.time).toBe('20:00');
+      expect(result.ampm).toBe('PM');
+      expect(result.utcOffset).toBe('-05:00');
+    });
+
     it('parses a full ISO datetime string with 12h clock', () => {
       const result = userInputFromDatetime({
         value: '2018-02-02T05:00+03:00',

--- a/packages/date/src/utils/date.ts
+++ b/packages/date/src/utils/date.ts
@@ -11,7 +11,10 @@ function startOfTodayOffset(): string {
 function parseUtcOffset(datetimeString: string): string {
   const match = datetimeString.match(ZONE_RX);
   if (!match) return '+00:00';
-  return match[1] === 'Z' ? '+00:00' : match[1];
+  const utcOffset = match[1];
+  if (utcOffset === 'Z') return '+00:00';
+
+  return utcOffset.replace(/^([+-]\d{2})(\d{2})$/, '$1:$2');
 }
 
 function fieldValueToDate(datetimeString: string | null | undefined): Date | null {


### PR DESCRIPTION
## What changed
Fix the Date editor's timezone selector when an existing value uses a compact UTC offset (for example, `2026-12-11T20:00:00.000-0500`). The editor now converts that offset to the selector's supported format, `-05:00`.

## Why
The date and time were read correctly, but the timezone selector only contains colon-formatted offsets. Because `-0500` did not match any option, the browser displayed the first available option, `UTC-12:00`, which was misleading and could cause a subsequent edit to save the wrong offset.

## Validation
- Added a regression test using the reported timestamp.
- Confirmed it displays `20:00` / `PM` with `UTC-05:00`.
- Ran `yarn --cwd packages/date test:ci --run src/utils/data.spec.ts`.
- Ran `yarn eslint packages/date/src/utils/date.ts packages/date/src/utils/data.spec.ts`.